### PR TITLE
feat: parse `channel` key and consolidate `NamelessMatchSpec`

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1011,6 +1011,7 @@ mod tests {
             "~\\windows_channel::package",
             "./relative/channel::package",
             "python[channel=https://conda.anaconda.org/python/conda,version=3.9]",
+            "channel/win-64::foobar[channel=conda-forge, subdir=linux-64]",
         ];
 
         let evaluated: IndexMap<_, _> = specs

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -132,3 +132,9 @@ rust ~=1.2.3:
   channel:
     base_url: "https://conda.anaconda.org/python/conda/"
     name: python/conda
+"channel/win-64::foobar[channel=conda-forge, subdir=linux-64]":
+  name: foobar
+  channel:
+    base_url: "https://conda.anaconda.org/conda-forge/"
+    name: conda-forge
+  subdir: linux-64

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -98,6 +98,19 @@ python=*:
     base_url: "https://conda.anaconda.org/conda-forge/"
     name: conda-forge
   subdir: linux-64
+"python ==3.9[channel=conda-forge]":
+  name: python
+  version: "==3.9"
+  channel:
+    base_url: "https://conda.anaconda.org/conda-forge/"
+    name: conda-forge
+"python ==3.9[channel=conda-forge/linux-64]":
+  name: python
+  version: "==3.9"
+  channel:
+    base_url: "https://conda.anaconda.org/conda-forge/"
+    name: conda-forge
+  subdir: linux-64
 rust ~=1.2.3:
   name: rust
   version: ~=1.2.3
@@ -113,3 +126,9 @@ rust ~=1.2.3:
   channel:
     base_url: "file://<CRATE>/relative/channel/"
     name: "./relative/channel"
+"python[channel=https://conda.anaconda.org/python/conda,version=3.9]":
+  name: python
+  version: "==3.9"
+  channel:
+    base_url: "https://conda.anaconda.org/python/conda/"
+    name: python/conda

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -90,6 +90,19 @@ python=*:
     base_url: "https://conda.anaconda.org/conda-forge/"
     name: conda-forge
   subdir: linux-64
+"python ==3.9[channel=conda-forge]":
+  name: python
+  version: "==3.9"
+  channel:
+    base_url: "https://conda.anaconda.org/conda-forge/"
+    name: conda-forge
+"python ==3.9[channel=conda-forge/linux-64]":
+  name: python
+  version: "==3.9"
+  channel:
+    base_url: "https://conda.anaconda.org/conda-forge/"
+    name: conda-forge
+  subdir: linux-64
 rust ~=1.2.3:
   name: rust
   version: ~=1.2.3
@@ -105,3 +118,9 @@ rust ~=1.2.3:
   channel:
     base_url: "file://<CRATE>/relative/channel/"
     name: "./relative/channel"
+"python[channel=https://conda.anaconda.org/python/conda,version=3.9]":
+  name: python
+  version: "==3.9"
+  channel:
+    base_url: "https://conda.anaconda.org/python/conda/"
+    name: python/conda

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -124,3 +124,9 @@ rust ~=1.2.3:
   channel:
     base_url: "https://conda.anaconda.org/python/conda/"
     name: python/conda
+"channel/win-64::foobar[channel=conda-forge, subdir=linux-64]":
+  name: foobar
+  channel:
+    base_url: "https://conda.anaconda.org/conda-forge/"
+    name: conda-forge
+  subdir: linux-64


### PR DESCRIPTION
Fixes https://github.com/conda-incubator/rattler/issues/793

Continuation of https://github.com/conda-incubator/rattler/pull/792 that adds support for `1.2.3[channel=...]` and consolidates logic of parsing matchspec and namelessmatchspec some more.