### PR TITLE
refactor: change links from conda-incubator to conda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-* `ProgressBar` trait and progress bar for package writing by @wolfv ([#525](https://github.com/conda-incubator/rattler/pull/525))
+* `ProgressBar` trait and progress bar for package writing by @wolfv ([#525](https://github.com/conda/rattler/pull/525))
 
 #### Changed
 
-* improved logging in package validation to include package path by @orhun ([#521](https://github.com/conda-incubator/rattler/pull/521))
-* use resolvo 0.4.0 with better error messages by @baszalmstra ([#523](https://github.com/conda-incubator/rattler/pull/523))
+* improved logging in package validation to include package path by @orhun ([#521](https://github.com/conda/rattler/pull/521))
+* use resolvo 0.4.0 with better error messages by @baszalmstra ([#523](https://github.com/conda/rattler/pull/523))
 
 #### Fixed
 
-* allow multiple clobbers per package by @wolfv ([#526](https://github.com/conda-incubator/rattler/pull/526))
-* remove drop-bomb, move empty folder removal to `post_process` by @wolfv ([#519](https://github.com/conda-incubator/rattler/pull/519))
-* keep in mind python: noarch packages in clobber calculations by @wolfv ([#511](https://github.com/conda-incubator/rattler/pull/511))
+* allow multiple clobbers per package by @wolfv ([#526](https://github.com/conda/rattler/pull/526))
+* remove drop-bomb, move empty folder removal to `post_process` by @wolfv ([#519](https://github.com/conda/rattler/pull/519))
+* keep in mind python: noarch packages in clobber calculations by @wolfv ([#511](https://github.com/conda/rattler/pull/511))
 
 # [0.17.0] - 2024-02-01
 
@@ -60,33 +60,33 @@ Note that all old formats (including the original conda-lock format) can still b
 
 #### Added
 
-* Add `get_windows_launcher` function by @wolfv ([#477](https://github.com/conda-incubator/rattler/pull/477))
-* Expose `get_windows_launcher` function by @wolfv ([#477](https://github.com/conda-incubator/rattler/pull/477))
-* Consistent clobbering & removal of `__pycache__` by @wolfv ([#437](https://github.com/conda-incubator/rattler/pull/437))
-* Add `name()` to `Channel` by @ruben-arts ([#495](https://github.com/conda-incubator/rattler/pull/495))
-* Add timeout parameter to the solver by @wolfv ([#499](https://github.com/conda-incubator/rattler/pull/499))
-* Add a very simple basic test to validate that we can at least parse netrc properly by @mariusvniekerk ([#503](https://github.com/conda-incubator/rattler/pull/503))
+* Add `get_windows_launcher` function by @wolfv ([#477](https://github.com/conda/rattler/pull/477))
+* Expose `get_windows_launcher` function by @wolfv ([#477](https://github.com/conda/rattler/pull/477))
+* Consistent clobbering & removal of `__pycache__` by @wolfv ([#437](https://github.com/conda/rattler/pull/437))
+* Add `name()` to `Channel` by @ruben-arts ([#495](https://github.com/conda/rattler/pull/495))
+* Add timeout parameter to the solver by @wolfv ([#499](https://github.com/conda/rattler/pull/499))
+* Add a very simple basic test to validate that we can at least parse netrc properly by @mariusvniekerk ([#503](https://github.com/conda/rattler/pull/503))
 
 #### Changed
 
-* Allow the full range of compression levels for zstd by @wolfv ([#479](https://github.com/conda-incubator/rattler/pull/479))
-* Make compression conversion functions `pub` by @wolfv ([#480](https://github.com/conda-incubator/rattler/pull/480))
-* Lock-file v4 by @baszalmstra ([#484](https://github.com/conda-incubator/rattler/pull/484))
-* Convert authenticated client to reqwest middleware by @vlad-ivanov-name ([#488](https://github.com/conda-incubator/rattler/pull/488))
-* Upgrade to latest resolvo main by @tdejager ([#497](https://github.com/conda-incubator/rattler/pull/497))
-* Bump: resolvo 0.3.0 by @baszalmstra ([#500](https://github.com/conda-incubator/rattler/pull/500))
+* Allow the full range of compression levels for zstd by @wolfv ([#479](https://github.com/conda/rattler/pull/479))
+* Make compression conversion functions `pub` by @wolfv ([#480](https://github.com/conda/rattler/pull/480))
+* Lock-file v4 by @baszalmstra ([#484](https://github.com/conda/rattler/pull/484))
+* Convert authenticated client to reqwest middleware by @vlad-ivanov-name ([#488](https://github.com/conda/rattler/pull/488))
+* Upgrade to latest resolvo main by @tdejager ([#497](https://github.com/conda/rattler/pull/497))
+* Bump: resolvo 0.3.0 by @baszalmstra ([#500](https://github.com/conda/rattler/pull/500))
 
 #### Fixed
 
-* Copy over file permissions after reflink by @orhun ([#485](https://github.com/conda-incubator/rattler/pull/485))
-* Fix clippy and deprecation warnings by @wolfv ([#490](https://github.com/conda-incubator/rattler/pull/490))
-* Do not unwrap as much in clobberregistry by @wolfv ([#489](https://github.com/conda-incubator/rattler/pull/489))
-* Fix warning for deref on a double reference by @wolfv ([#493](https://github.com/conda-incubator/rattler/pull/493))
-* Fix self-clobbering when updating a package by @wolfv ([#494](https://github.com/conda-incubator/rattler/pull/494))
-* Fix netrc parsing into BasicAuth by @wolfv ([#506](https://github.com/conda-incubator/rattler/pull/506))
+* Copy over file permissions after reflink by @orhun ([#485](https://github.com/conda/rattler/pull/485))
+* Fix clippy and deprecation warnings by @wolfv ([#490](https://github.com/conda/rattler/pull/490))
+* Do not unwrap as much in clobberregistry by @wolfv ([#489](https://github.com/conda/rattler/pull/489))
+* Fix warning for deref on a double reference by @wolfv ([#493](https://github.com/conda/rattler/pull/493))
+* Fix self-clobbering when updating a package by @wolfv ([#494](https://github.com/conda/rattler/pull/494))
+* Fix netrc parsing into BasicAuth by @wolfv ([#506](https://github.com/conda/rattler/pull/506))
 
 ### New Contributors
-* @vlad-ivanov-name made their first contribution in https://github.com/conda-incubator/rattler/pull/482
+* @vlad-ivanov-name made their first contribution in https://github.com/conda/rattler/pull/482
 
 # [0.16.2] - 2024-01-11
 
@@ -94,7 +94,7 @@ Note that all old formats (including the original conda-lock format) can still b
 
 #### Fixed
 
-* Reduce tracing level for reflink by @baszalmstra ([#475](https://github.com/conda-incubator/rattler/pull/475))
+* Reduce tracing level for reflink by @baszalmstra ([#475](https://github.com/conda/rattler/pull/475))
 
 # [0.16.1] - 2024-01-09
 
@@ -102,18 +102,18 @@ Note that all old formats (including the original conda-lock format) can still b
 
 #### Added
 
-* Add `read_package_file` function by @wolfv ([#472](https://github.com/conda-incubator/rattler/pull/472))
-* implement `Clone` for `AboutJson` by @0xbe7a ([#467](https://github.com/conda-incubator/rattler/pull/467))
-* Allow using `str` in `HashMap`s with a `PackageName` key by @baszalmstra ([#468](https://github.com/conda-incubator/rattler/pull/468))
+* Add `read_package_file` function by @wolfv ([#472](https://github.com/conda/rattler/pull/472))
+* implement `Clone` for `AboutJson` by @0xbe7a ([#467](https://github.com/conda/rattler/pull/467))
+* Allow using `str` in `HashMap`s with a `PackageName` key by @baszalmstra ([#468](https://github.com/conda/rattler/pull/468))
 
 #### Changed
 
-* Reflink files to destination if supported (instead of hardlinking) by @baszalmstra ([#463](https://github.com/conda-incubator/rattler/pull/463))
+* Reflink files to destination if supported (instead of hardlinking) by @baszalmstra ([#463](https://github.com/conda/rattler/pull/463))
 
 #### Fixed
 
-* Automatic clippy fixes by @wolfv ([#470](https://github.com/conda-incubator/rattler/pull/470))
-* Fix getting credentials from keyring error by @0xbe7a ([#474](https://github.com/conda-incubator/rattler/pull/474))
+* Automatic clippy fixes by @wolfv ([#470](https://github.com/conda/rattler/pull/470))
+* Fix getting credentials from keyring error by @0xbe7a ([#474](https://github.com/conda/rattler/pull/474))
 
 
 # [0.15.0] - 2024-01-05
@@ -122,24 +122,24 @@ Note that all old formats (including the original conda-lock format) can still b
 
 #### Added
 
-* Add ParseMatchSpecError and ParseMatchSpecError tests by @Johnwillliam ([#434](https://github.com/conda-incubator/rattler/pull/434))
-* Add option to force usage of fallback_auth_store by @0xbe7a ([#435](https://github.com/conda-incubator/rattler/pull/435))
-* New crate (rattler-index) with index functionality including python bindings by @BenjaminLowry ([#436](https://github.com/conda-incubator/rattler/pull/436))
-* Add support for netrc files by @mariusvniekerk ([#395](https://github.com/conda-incubator/rattler/pull/395))
+* Add ParseMatchSpecError and ParseMatchSpecError tests by @Johnwillliam ([#434](https://github.com/conda/rattler/pull/434))
+* Add option to force usage of fallback_auth_store by @0xbe7a ([#435](https://github.com/conda/rattler/pull/435))
+* New crate (rattler-index) with index functionality including python bindings by @BenjaminLowry ([#436](https://github.com/conda/rattler/pull/436))
+* Add support for netrc files by @mariusvniekerk ([#395](https://github.com/conda/rattler/pull/395))
 
 #### Changed
 
-* Renamed `behaviour` to `behavior` ([#428](https://github.com/conda-incubator/rattler/pull/428))
-* Enabled more clippy lints by @baszalmstra ([#462](https://github.com/conda-incubator/rattler/pull/462))
-* Refactor `Version.bump()` to accept bumping `major/minor/patch/last` by @hadim ([#452](https://github.com/conda-incubator/rattler/pull/452))
+* Renamed `behaviour` to `behavior` ([#428](https://github.com/conda/rattler/pull/428))
+* Enabled more clippy lints by @baszalmstra ([#462](https://github.com/conda/rattler/pull/462))
+* Refactor `Version.bump()` to accept bumping `major/minor/patch/last` by @hadim ([#452](https://github.com/conda/rattler/pull/452))
 
 #### Fixed
 
-* Default value for `conda_packages` in repodata.json by @BenjaminLowry ([#441](https://github.com/conda-incubator/rattler/pull/441))
-* Wildcard expansion for stored credentials of domains by @0xbe7a ([#442](https://github.com/conda-incubator/rattler/pull/442))
-* Use serde default for proper serialization by @ruben-arts ([#443](https://github.com/conda-incubator/rattler/pull/443))
-* Better detection of hardlinks and fallback to copy by @baszalmstra ([#461](https://github.com/conda-incubator/rattler/pull/461))
-* Re-download the repodata cache if is out of sync/corrupt by @orhun ([#466](https://github.com/conda-incubator/rattler/pull/466))
+* Default value for `conda_packages` in repodata.json by @BenjaminLowry ([#441](https://github.com/conda/rattler/pull/441))
+* Wildcard expansion for stored credentials of domains by @0xbe7a ([#442](https://github.com/conda/rattler/pull/442))
+* Use serde default for proper serialization by @ruben-arts ([#443](https://github.com/conda/rattler/pull/443))
+* Better detection of hardlinks and fallback to copy by @baszalmstra ([#461](https://github.com/conda/rattler/pull/461))
+* Re-download the repodata cache if is out of sync/corrupt by @orhun ([#466](https://github.com/conda/rattler/pull/466))
 
 # [0.14.0] - 2023-12-05
 
@@ -147,19 +147,19 @@ Note that all old formats (including the original conda-lock format) can still b
 
 #### Added
 
-* Options to disable `bz2` and `zstd` in `fetch_repo_data` ([#420](https://github.com/conda-incubator/rattler/pull/420))
-* Support for powerpc64 and s390x ([#425](https://github.com/conda-incubator/rattler/pull/425))
+* Options to disable `bz2` and `zstd` in `fetch_repo_data` ([#420](https://github.com/conda/rattler/pull/420))
+* Support for powerpc64 and s390x ([#425](https://github.com/conda/rattler/pull/425))
 
 #### Changed
 
-* Renamed `behaviour` to `behavior` ([#428](https://github.com/conda-incubator/rattler/pull/428))
+* Renamed `behaviour` to `behavior` ([#428](https://github.com/conda/rattler/pull/428))
 
 #### Fixed
 
-* Recursive look for parent process name ([#424](https://github.com/conda-incubator/rattler/pull/424))
-* Improve repodata fetch errors ([#426](https://github.com/conda-incubator/rattler/pull/426))
-* Use filelock for authentication fallback storage  ([#427](https://github.com/conda-incubator/rattler/pull/427))
-* Improved lockfile version mismatch error ([#423](https://github.com/conda-incubator/rattler/pull/423))
+* Recursive look for parent process name ([#424](https://github.com/conda/rattler/pull/424))
+* Improve repodata fetch errors ([#426](https://github.com/conda/rattler/pull/426))
+* Use filelock for authentication fallback storage  ([#427](https://github.com/conda/rattler/pull/427))
+* Improved lockfile version mismatch error ([#423](https://github.com/conda/rattler/pull/423))
 
 ## [0.13.0] - 2023-11-27
 
@@ -167,16 +167,16 @@ Note that all old formats (including the original conda-lock format) can still b
 
 #### Added
 
-* Experimental support for purls in PackageRecord and derived datastructures ([#414](https://github.com/conda-incubator/rattler/pull/414))
+* Experimental support for purls in PackageRecord and derived datastructures ([#414](https://github.com/conda/rattler/pull/414))
 
 #### Changed
 
-* Rename `pip` to `pypi` in lockfile ([#415](https://github.com/conda-incubator/rattler/pull/415))
+* Rename `pip` to `pypi` in lockfile ([#415](https://github.com/conda/rattler/pull/415))
 
 #### Fixed
 
-* Allow compilation for android ([#418](https://github.com/conda-incubator/rattler/pull/418))
-* Normalize relative-paths with writing to file ([#416](https://github.com/conda-incubator/rattler/pull/416))
+* Allow compilation for android ([#418](https://github.com/conda/rattler/pull/418))
+* Normalize relative-paths with writing to file ([#416](https://github.com/conda/rattler/pull/416))
 
 ## [0.12.3] - 2023-11-23
 
@@ -184,9 +184,9 @@ Note that all old formats (including the original conda-lock format) can still b
 
 #### Fixed
 
-* Expose missing `StringMatcherParseError` ([#410](https://github.com/conda-incubator/rattler/pull/410))
-* Fix JLAP issue by setting the nominal hash when first downloading repodata ([#411](https://github.com/conda-incubator/rattler/pull/411))
-* Support channel names with slashes ([#413](https://github.com/conda-incubator/rattler/pull/413))
+* Expose missing `StringMatcherParseError` ([#410](https://github.com/conda/rattler/pull/410))
+* Fix JLAP issue by setting the nominal hash when first downloading repodata ([#411](https://github.com/conda/rattler/pull/411))
+* Support channel names with slashes ([#413](https://github.com/conda/rattler/pull/413))
 
 ## [0.12.2] - 2023-11-17
 
@@ -194,7 +194,7 @@ Note that all old formats (including the original conda-lock format) can still b
 
 #### Fixed
 
-* fix: make redaction work by using `From` explicitly ([#408](https://github.com/conda-incubator/rattler/pull/408))
+* fix: make redaction work by using `From` explicitly ([#408](https://github.com/conda/rattler/pull/408))
 
 ## [0.12.1] - 2023-11-17
 
@@ -202,7 +202,7 @@ Note that all old formats (including the original conda-lock format) can still b
 
 #### Fixed
 
-* fix: redact tokens from urls in errors ([#407](https://github.com/conda-incubator/rattler/pull/407))
+* fix: redact tokens from urls in errors ([#407](https://github.com/conda/rattler/pull/407))
 
 ## [0.12.0] - 2023-11-14
 
@@ -214,21 +214,21 @@ Adds support for strict priority channel ordering, channel-specific selectors,
 
 #### Added
 
-* Add strict channel priority option ([#385](https://github.com/conda-incubator/rattler/pull/385))
-* Add lock-file forward compatibility error ([#389](https://github.com/conda-incubator/rattler/pull/389))
-* Add channel priority and channel-specific selectors to solver info ([#394](https://github.com/conda-incubator/rattler/pull/394))
+* Add strict channel priority option ([#385](https://github.com/conda/rattler/pull/385))
+* Add lock-file forward compatibility error ([#389](https://github.com/conda/rattler/pull/389))
+* Add channel priority and channel-specific selectors to solver info ([#394](https://github.com/conda/rattler/pull/394))
 
 #### Changed
 
-* Channel in the `MatchSpec` struct changed to `Channel` type  ([#401](https://github.com/conda-incubator/rattler/pull/401))
+* Channel in the `MatchSpec` struct changed to `Channel` type  ([#401](https://github.com/conda/rattler/pull/401))
 
 #### Fixed
 
-* Expose previous python version information in transaction ([#384](https://github.com/conda-incubator/rattler/pull/384))
-* Avoid use of \ in doctest strings, for ide integration ([#387](https://github.com/conda-incubator/rattler/pull/387))
-* Issue with JLAP using the wrong hash ([#390](https://github.com/conda-incubator/rattler/pull/390))
-* Use the correct channel in the reason for exclude ([#397](https://github.com/conda-incubator/rattler/pull/397))
-* Environment activation for windows ([#398](https://github.com/conda-incubator/rattler/pull/398))
+* Expose previous python version information in transaction ([#384](https://github.com/conda/rattler/pull/384))
+* Avoid use of \ in doctest strings, for ide integration ([#387](https://github.com/conda/rattler/pull/387))
+* Issue with JLAP using the wrong hash ([#390](https://github.com/conda/rattler/pull/390))
+* Use the correct channel in the reason for exclude ([#397](https://github.com/conda/rattler/pull/397))
+* Environment activation for windows ([#398](https://github.com/conda/rattler/pull/398))
 
 ## [0.11.0] - 2023-10-17
 
@@ -240,19 +240,19 @@ Lock file support has been moved into its own crate (rattler_lock) and support f
 
 #### Changed
 
-* change authentication fallback warnings to debug by @ruben-arts in https://github.com/conda-incubator/rattler/pull/365
-* repodata cache now uses `.info.json` instead of `.state.json` by @dholth in https://github.com/conda-incubator/rattler/pull/377
-* lock file now lives in its own crate with pip support by @baszalmstra in https://github.com/conda-incubator/rattler/pull/378
+* change authentication fallback warnings to debug by @ruben-arts in https://github.com/conda/rattler/pull/365
+* repodata cache now uses `.info.json` instead of `.state.json` by @dholth in https://github.com/conda/rattler/pull/377
+* lock file now lives in its own crate with pip support by @baszalmstra in https://github.com/conda/rattler/pull/378
 
 #### Fixed
-* Nushell fixes by @wolfv in https://github.com/conda-incubator/rattler/pull/360
-* Construct placeholder string at runtime to work around invalid conda prefix replacement by @baszalmstra in https://github.com/conda-incubator/rattler/pull/371
-* xonsh extension by @ruben-arts in https://github.com/conda-incubator/rattler/pull/375
+* Nushell fixes by @wolfv in https://github.com/conda/rattler/pull/360
+* Construct placeholder string at runtime to work around invalid conda prefix replacement by @baszalmstra in https://github.com/conda/rattler/pull/371
+* xonsh extension by @ruben-arts in https://github.com/conda/rattler/pull/375
 
 ## New Contributors
-* @dholth made their first contribution in https://github.com/conda-incubator/rattler/pull/377
+* @dholth made their first contribution in https://github.com/conda/rattler/pull/377
 
-**Full Changelog**: https://github.com/conda-incubator/rattler/compare/v0.10.0...v0.11.0
+**Full Changelog**: https://github.com/conda/rattler/compare/v0.10.0...v0.11.0
 
 ## [0.10.0] - 2023-10-02
 
@@ -266,27 +266,27 @@ Still no official release of the bindings though, but getting closer every day.
 
 #### Added
 
-* add initial nushell support by @wolfv in [#271](https://github.com/conda-incubator/rattler/pull/271)
+* add initial nushell support by @wolfv in [#271](https://github.com/conda/rattler/pull/271)
 
 #### Changed
 
-* the solver has been extracted in its own package: resolvo by @baszalmstra in [#349](https://github.com/conda-incubator/rattler/pull/349) & [#350](https://github.com/conda-incubator/rattler/pull/350)
+* the solver has been extracted in its own package: resolvo by @baszalmstra in [#349](https://github.com/conda/rattler/pull/349) & [#350](https://github.com/conda/rattler/pull/350)
 
 #### Fixed
 
-* Change solver implementation doc comment by @nichmor in [#352](https://github.com/conda-incubator/rattler/pull/352)
+* Change solver implementation doc comment by @nichmor in [#352](https://github.com/conda/rattler/pull/352)
 
 ### 🐍 Python
 
-* add more py-rattler types by @Wackyator in [#348](https://github.com/conda-incubator/rattler/pull/348)
-* add fetch repo data to py-rattler by @Wackyator in [#334](https://github.com/conda-incubator/rattler/pull/334)
-* use SparseRepoData in fetch_repo_data by @Wackyator in [#359](https://github.com/conda-incubator/rattler/pull/359)
-* add solver by @Wackyator in [#361](https://github.com/conda-incubator/rattler/pull/361)
+* add more py-rattler types by @Wackyator in [#348](https://github.com/conda/rattler/pull/348)
+* add fetch repo data to py-rattler by @Wackyator in [#334](https://github.com/conda/rattler/pull/334)
+* use SparseRepoData in fetch_repo_data by @Wackyator in [#359](https://github.com/conda/rattler/pull/359)
+* add solver by @Wackyator in [#361](https://github.com/conda/rattler/pull/361)
 
 ### 🤗 New Contributors
-* @nichmor made their first contribution in [#352](https://github.com/conda-incubator/rattler/pull/352)
+* @nichmor made their first contribution in [#352](https://github.com/conda/rattler/pull/352)
 
-**Full Changelog**: https://github.com/conda-incubator/rattler/compare/v0.9.0...v0.10.0
+**Full Changelog**: https://github.com/conda/rattler/compare/v0.9.0...v0.10.0
 
 
 ## [0.9.0] - 2023-09-22
@@ -298,58 +298,58 @@ This is a pretty substantial release which includes many refactors to the solver
 ### 📃 Details
 
 #### Added
-* [pixi](https://github.com/prefix-dev/pixi) project to make contributing easier by @YeungOnion in [#283](https://github.com/conda-incubator/rattler/pull/283), [#342](https://github.com/conda-incubator/rattler/pull/342)
-* make rattler-package-streaming compile with wasm by @wolfv in [#287](https://github.com/conda-incubator/rattler/pull/287)
-* implement base_url cep by @baszalmstra in [#322](https://github.com/conda-incubator/rattler/pull/322)
-* use emscripten-wasm32 and wasi-wasm32 by @wolfv in [#333](https://github.com/conda-incubator/rattler/pull/333)
-* add build_spec module by @YeungOnion in [#340](https://github.com/conda-incubator/rattler/pull/340), [#346](https://github.com/conda-incubator/rattler/pull/346)
+* [pixi](https://github.com/prefix-dev/pixi) project to make contributing easier by @YeungOnion in [#283](https://github.com/conda/rattler/pull/283), [#342](https://github.com/conda/rattler/pull/342)
+* make rattler-package-streaming compile with wasm by @wolfv in [#287](https://github.com/conda/rattler/pull/287)
+* implement base_url cep by @baszalmstra in [#322](https://github.com/conda/rattler/pull/322)
+* use emscripten-wasm32 and wasi-wasm32 by @wolfv in [#333](https://github.com/conda/rattler/pull/333)
+* add build_spec module by @YeungOnion in [#340](https://github.com/conda/rattler/pull/340), [#346](https://github.com/conda/rattler/pull/346)
 
 #### Changed
 
-* use normalized package names where applicable by @baszalmstra in [#285](https://github.com/conda-incubator/rattler/pull/285)
-* new `StrictVersion` type for VersionSpec ranges. by @tdejager in [#296](https://github.com/conda-incubator/rattler/pull/296)
-* refactored ratter_libsolv_rs to be conda agnostic by @tdejager & @baszalmstra in [#316](https://github.com/conda-incubator/rattler/pull/316), [#309](https://github.com/conda-incubator/rattler/pull/309), [#317](https://github.com/conda-incubator/rattler/pull/317), [#320](https://github.com/conda-incubator/rattler/pull/320), [#319](https://github.com/conda-incubator/rattler/pull/319), [#323](https://github.com/conda-incubator/rattler/pull/323), [#324](https://github.com/conda-incubator/rattler/pull/324), [#328](https://github.com/conda-incubator/rattler/pull/328), [#325](https://github.com/conda-incubator/rattler/pull/325), [#326](https://github.com/conda-incubator/rattler/pull/326), [#335](https://github.com/conda-incubator/rattler/pull/335), [#336](https://github.com/conda-incubator/rattler/pull/336), [#338](https://github.com/conda-incubator/rattler/pull/338), [#343](https://github.com/conda-incubator/rattler/pull/343), [#337](https://github.com/conda-incubator/rattler/pull/337)
-* feat: allow disabling jlap by @baszalmstra in [#327](https://github.com/conda-incubator/rattler/pull/327)
-* test: added job to check for lfs links by @tdejager in [#331](https://github.com/conda-incubator/rattler/pull/331)
-* hide implementation detail, version_spec::Constraint by @YeungOnion in [#341](https://github.com/conda-incubator/rattler/pull/341)
+* use normalized package names where applicable by @baszalmstra in [#285](https://github.com/conda/rattler/pull/285)
+* new `StrictVersion` type for VersionSpec ranges. by @tdejager in [#296](https://github.com/conda/rattler/pull/296)
+* refactored ratter_libsolv_rs to be conda agnostic by @tdejager & @baszalmstra in [#316](https://github.com/conda/rattler/pull/316), [#309](https://github.com/conda/rattler/pull/309), [#317](https://github.com/conda/rattler/pull/317), [#320](https://github.com/conda/rattler/pull/320), [#319](https://github.com/conda/rattler/pull/319), [#323](https://github.com/conda/rattler/pull/323), [#324](https://github.com/conda/rattler/pull/324), [#328](https://github.com/conda/rattler/pull/328), [#325](https://github.com/conda/rattler/pull/325), [#326](https://github.com/conda/rattler/pull/326), [#335](https://github.com/conda/rattler/pull/335), [#336](https://github.com/conda/rattler/pull/336), [#338](https://github.com/conda/rattler/pull/338), [#343](https://github.com/conda/rattler/pull/343), [#337](https://github.com/conda/rattler/pull/337)
+* feat: allow disabling jlap by @baszalmstra in [#327](https://github.com/conda/rattler/pull/327)
+* test: added job to check for lfs links by @tdejager in [#331](https://github.com/conda/rattler/pull/331)
+* hide implementation detail, version_spec::Constraint by @YeungOnion in [#341](https://github.com/conda/rattler/pull/341)
 
 #### Fixed
 
-* typo in solver error message by @baszalmstra in [#284](https://github.com/conda-incubator/rattler/pull/284)
-* expose ParseMatchSpecError in rattler_conda_types by @Wackyator in [#286](https://github.com/conda-incubator/rattler/pull/286)
-* use nvidia-smi on musl targets to detect Cuda by @baszalmstra in [#290](https://github.com/conda-incubator/rattler/pull/290)
-* typo in snap file by @wolfv in [#291](https://github.com/conda-incubator/rattler/pull/291)
-* Version::is_dev returning false for dev version (fix #289) by @Wackyator in [#293](https://github.com/conda-incubator/rattler/pull/293)
-* workaround for `PIP_REQUIRE_VIRTUALENV` env variable by @tusharsadhwani in [#294](https://github.com/conda-incubator/rattler/pull/294)
-* ensure consistent sorting of locked packages by @baszalmstra in [#295](https://github.com/conda-incubator/rattler/pull/295)
-* updates to `NamelessMatchSpec` to allow deserializing by @travishathaway in [#299](https://github.com/conda-incubator/rattler/pull/299)
-* update all dependencies and fix chrono deprecation by @wolfv in [#302](https://github.com/conda-incubator/rattler/pull/302)
-* shell improvements for powershell env-var escaping and xonsh detection by @wolfv in [#307](https://github.com/conda-incubator/rattler/pull/307)
-* also export strict version by @wolfv in [#312](https://github.com/conda-incubator/rattler/pull/312)
-* make FetchRepoDataOptions clonable by @Wackyator in [#321](https://github.com/conda-incubator/rattler/pull/321)
-* bump json-patch 1.1.0 to fix stack overflow by @baszalmstra in [#332](https://github.com/conda-incubator/rattler/pull/332)
-* emscripten is a unix variant by @wolfv in [#339](https://github.com/conda-incubator/rattler/pull/339)
-* authentication fallback storage location by @ruben-arts in [#347](https://github.com/conda-incubator/rattler/pull/347)
+* typo in solver error message by @baszalmstra in [#284](https://github.com/conda/rattler/pull/284)
+* expose ParseMatchSpecError in rattler_conda_types by @Wackyator in [#286](https://github.com/conda/rattler/pull/286)
+* use nvidia-smi on musl targets to detect Cuda by @baszalmstra in [#290](https://github.com/conda/rattler/pull/290)
+* typo in snap file by @wolfv in [#291](https://github.com/conda/rattler/pull/291)
+* Version::is_dev returning false for dev version (fix #289) by @Wackyator in [#293](https://github.com/conda/rattler/pull/293)
+* workaround for `PIP_REQUIRE_VIRTUALENV` env variable by @tusharsadhwani in [#294](https://github.com/conda/rattler/pull/294)
+* ensure consistent sorting of locked packages by @baszalmstra in [#295](https://github.com/conda/rattler/pull/295)
+* updates to `NamelessMatchSpec` to allow deserializing by @travishathaway in [#299](https://github.com/conda/rattler/pull/299)
+* update all dependencies and fix chrono deprecation by @wolfv in [#302](https://github.com/conda/rattler/pull/302)
+* shell improvements for powershell env-var escaping and xonsh detection by @wolfv in [#307](https://github.com/conda/rattler/pull/307)
+* also export strict version by @wolfv in [#312](https://github.com/conda/rattler/pull/312)
+* make FetchRepoDataOptions clonable by @Wackyator in [#321](https://github.com/conda/rattler/pull/321)
+* bump json-patch 1.1.0 to fix stack overflow by @baszalmstra in [#332](https://github.com/conda/rattler/pull/332)
+* emscripten is a unix variant by @wolfv in [#339](https://github.com/conda/rattler/pull/339)
+* authentication fallback storage location by @ruben-arts in [#347](https://github.com/conda/rattler/pull/347)
 
 ### 🐍 Python
 
 Although this release doesn't include a formal release of the python bindings yet, a lot of work has been done to work towards a first version. 
 
-* initial version of rattler python bindings by @baszalmstra in [#279](https://github.com/conda-incubator/rattler/pull/279)
-* bind `Version`, `MatchSpec`, `NamelessMatchSpec` by @Wackyator in [#292](https://github.com/conda-incubator/rattler/pull/292)
-* add more tests, hash and repr changes by @baszalmstra in [#300](https://github.com/conda-incubator/rattler/pull/300)
-* add license by @Wackyator in [#301](https://github.com/conda-incubator/rattler/pull/301)
-* bind channel types to py-rattler by @wolfv in [#313](https://github.com/conda-incubator/rattler/pull/313)
-* bind everything necessary for shell activation by @wolfv in [#298](https://github.com/conda-incubator/rattler/pull/298)
-* add mypy checks by @baszalmstra in [#314](https://github.com/conda-incubator/rattler/pull/314)
-* bind `AuthenticatedClient` by @Wackyator in [#315](https://github.com/conda-incubator/rattler/pull/315)
-* add `py.typed` file by @baszalmstra in [#318](https://github.com/conda-incubator/rattler/pull/318)
-* bind `VersionWithSource` by @Wackyator in [#304](https://github.com/conda-incubator/rattler/pull/304)
+* initial version of rattler python bindings by @baszalmstra in [#279](https://github.com/conda/rattler/pull/279)
+* bind `Version`, `MatchSpec`, `NamelessMatchSpec` by @Wackyator in [#292](https://github.com/conda/rattler/pull/292)
+* add more tests, hash and repr changes by @baszalmstra in [#300](https://github.com/conda/rattler/pull/300)
+* add license by @Wackyator in [#301](https://github.com/conda/rattler/pull/301)
+* bind channel types to py-rattler by @wolfv in [#313](https://github.com/conda/rattler/pull/313)
+* bind everything necessary for shell activation by @wolfv in [#298](https://github.com/conda/rattler/pull/298)
+* add mypy checks by @baszalmstra in [#314](https://github.com/conda/rattler/pull/314)
+* bind `AuthenticatedClient` by @Wackyator in [#315](https://github.com/conda/rattler/pull/315)
+* add `py.typed` file by @baszalmstra in [#318](https://github.com/conda/rattler/pull/318)
+* bind `VersionWithSource` by @Wackyator in [#304](https://github.com/conda/rattler/pull/304)
 
 ### 🤗 New Contributors
-* @Wackyator made their first contribution in [#286](https://github.com/conda-incubator/rattler/pull/286)
-* @YeungOnion made their first contribution in [#283](https://github.com/conda-incubator/rattler/pull/283)
-* @tusharsadhwani made their first contribution in [#294](https://github.com/conda-incubator/rattler/pull/294)
+* @Wackyator made their first contribution in [#286](https://github.com/conda/rattler/pull/286)
+* @YeungOnion made their first contribution in [#283](https://github.com/conda/rattler/pull/283)
+* @tusharsadhwani made their first contribution in [#294](https://github.com/conda/rattler/pull/294)
 
 To all contributors, thank you for your amazing work on Rattler. This project wouldn't exist without you! 🙏
 
@@ -363,11 +363,11 @@ This release contains bug fixes.
 
 #### Added
 
-- retry behavior when downloading package archives by @baszalmstra in ([#281](https://github.com/conda-incubator/rattler/pull/281))
+- retry behavior when downloading package archives by @baszalmstra in ([#281](https://github.com/conda/rattler/pull/281))
 
 #### Fixed
 
-- parsing of local versions in `Constraint`s by @baszalmstra in ([#280](https://github.com/conda-incubator/rattler/pull/280))
+- parsing of local versions in `Constraint`s by @baszalmstra in ([#280](https://github.com/conda/rattler/pull/280))
 
 ## [0.7.0] - 2023-08-11
 
@@ -379,27 +379,27 @@ This release mostly contains bug fixes.
 
 #### Added
 
-- Rattler is now also build for Linux aarch64 in CI by @pavelzw in ([#272](https://github.com/conda-incubator/rattler/pull/272))
-- `FromStr` for `ShellEnum` by @ruben-arts in ([#258](https://github.com/conda-incubator/rattler/pull/258))
+- Rattler is now also build for Linux aarch64 in CI by @pavelzw in ([#272](https://github.com/conda/rattler/pull/272))
+- `FromStr` for `ShellEnum` by @ruben-arts in ([#258](https://github.com/conda/rattler/pull/258))
 
 #### Changed
 
-- Run activation scripts and capture their output by @baszalmstra in ([#239](https://github.com/conda-incubator/rattler/pull/239))
-- If memory mapping fails during installation the entire file is read instead by @baszalmstra in ([#273](https://github.com/conda-incubator/rattler/pull/273))
-- Constraints parsing to improve performance and error messages by @baszalmstra in ([#254](https://github.com/conda-incubator/rattler/pull/254))
-- Added explicit error in case repodata does not exist on the server by @ruben-arts in ([#256](https://github.com/conda-incubator/rattler/pull/256))
-- Code signing on apple platform now uses `codesign` binary instead of `apple-codesign` crate by @wolfv in ([#259](https://github.com/conda-incubator/rattler/pull/259))
+- Run activation scripts and capture their output by @baszalmstra in ([#239](https://github.com/conda/rattler/pull/239))
+- If memory mapping fails during installation the entire file is read instead by @baszalmstra in ([#273](https://github.com/conda/rattler/pull/273))
+- Constraints parsing to improve performance and error messages by @baszalmstra in ([#254](https://github.com/conda/rattler/pull/254))
+- Added explicit error in case repodata does not exist on the server by @ruben-arts in ([#256](https://github.com/conda/rattler/pull/256))
+- Code signing on apple platform now uses `codesign` binary instead of `apple-codesign` crate by @wolfv in ([#259](https://github.com/conda/rattler/pull/259))
 
 #### Fixed
 
-- `Shell::run_command` ends with a newline by @baszalmstra in ([#262](https://github.com/conda-incubator/rattler/pull/262))
-- Formatting of environment variable in fish by @ruben-arts in ([#264](https://github.com/conda-incubator/rattler/pull/264))
-- Suppress stderr and stdout from codesigning by @wolfv in ([#265](https://github.com/conda-incubator/rattler/pull/265))
-- All crates have at least basic documentation by @wolfv in ([#268](https://github.com/conda-incubator/rattler/pull/268))
-- Use `default_cache_dir` in the rattler binary by @wolfv in ([#269](https://github.com/conda-incubator/rattler/pull/269))
-- Corrupted tar files generated by rattler-package-streaming by @johnhany97 in ([#276](https://github.com/conda-incubator/rattler/pull/276))
-- Superfluous quotes in the `content-hash` of conda lock files by @baszalmstra in ([#277](https://github.com/conda-incubator/rattler/pull/277))
-- `subdir` and `arch` fields when converting `RepoDataRecord` to a `LockedDependency` in conda-lock format by @wolfv in ([#255](https://github.com/conda-incubator/rattler/pull/255))
+- `Shell::run_command` ends with a newline by @baszalmstra in ([#262](https://github.com/conda/rattler/pull/262))
+- Formatting of environment variable in fish by @ruben-arts in ([#264](https://github.com/conda/rattler/pull/264))
+- Suppress stderr and stdout from codesigning by @wolfv in ([#265](https://github.com/conda/rattler/pull/265))
+- All crates have at least basic documentation by @wolfv in ([#268](https://github.com/conda/rattler/pull/268))
+- Use `default_cache_dir` in the rattler binary by @wolfv in ([#269](https://github.com/conda/rattler/pull/269))
+- Corrupted tar files generated by rattler-package-streaming by @johnhany97 in ([#276](https://github.com/conda/rattler/pull/276))
+- Superfluous quotes in the `content-hash` of conda lock files by @baszalmstra in ([#277](https://github.com/conda/rattler/pull/277))
+- `subdir` and `arch` fields when converting `RepoDataRecord` to a `LockedDependency` in conda-lock format by @wolfv in ([#255](https://github.com/conda/rattler/pull/255))
 
 ## [0.6.0] - 2023-07-07
 
@@ -450,24 +450,24 @@ Caching the result of an activation script can be useful if you need to invoke m
 
 #### Added
 
-- Run activation scripts and capture their output by @baszalmstra in ([#239](https://github.com/conda-incubator/rattler/pull/239))
-- Support for sha256 and md5 field in matchspec by @0xbe7a in ([#241](https://github.com/conda-incubator/rattler/pull/241))
-- A rust port of libsolv as an additional solver backend by @aochagavia, @baszalmstra in ([#243](https://github.com/conda-incubator/rattler/pull/243) & [#253](https://github.com/conda-incubator/rattler/pull/253)) 
-- Test cases and benchmarks for solver implementations by @baszalmstra in ([#250](https://github.com/conda-incubator/rattler/pull/249) & [#250](https://github.com/conda-incubator/rattler/pull/249))
-- The ability to add a dependency from `python` on `pip` while loading repodata @wolfv in ([#238](https://github.com/conda-incubator/rattler/pull/238))
+- Run activation scripts and capture their output by @baszalmstra in ([#239](https://github.com/conda/rattler/pull/239))
+- Support for sha256 and md5 field in matchspec by @0xbe7a in ([#241](https://github.com/conda/rattler/pull/241))
+- A rust port of libsolv as an additional solver backend by @aochagavia, @baszalmstra in ([#243](https://github.com/conda/rattler/pull/243) & [#253](https://github.com/conda/rattler/pull/253)) 
+- Test cases and benchmarks for solver implementations by @baszalmstra in ([#250](https://github.com/conda/rattler/pull/249) & [#250](https://github.com/conda/rattler/pull/249))
+- The ability to add a dependency from `python` on `pip` while loading repodata @wolfv in ([#238](https://github.com/conda/rattler/pull/238))
 
 #### Changed
 
-- Completely refactored version parsing by @baszalmstra in ([#240](https://github.com/conda-incubator/rattler/pull/240))
-- Refactored solver interface to allow generic use of solver implementations by @baszalmstra in ([#245](https://github.com/conda-incubator/rattler/pull/245))
-- Also check if credentials stored under wildcard host by @wolfv in ([#252](https://github.com/conda-incubator/rattler/pull/252))
+- Completely refactored version parsing by @baszalmstra in ([#240](https://github.com/conda/rattler/pull/240))
+- Refactored solver interface to allow generic use of solver implementations by @baszalmstra in ([#245](https://github.com/conda/rattler/pull/245))
+- Also check if credentials stored under wildcard host by @wolfv in ([#252](https://github.com/conda/rattler/pull/252))
 
 #### Fixed
 
-- Compilation issues by @wolfv in ([#244](https://github.com/conda-incubator/rattler/pull/244))
-- Add missing `From<VersionWithSource>` for `Version` by @baszalmstra in ([#246](https://github.com/conda-incubator/rattler/pull/246))
-- Optimized libsolv port by removing redundant MatchSpec parsing by @baszalmstra in ([#246](https://github.com/conda-incubator/rattler/pull/246))
-- Optimized libsolv port by caching matching Solvables by @baszalmstra in ([#251](https://github.com/conda-incubator/rattler/pull/251))
+- Compilation issues by @wolfv in ([#244](https://github.com/conda/rattler/pull/244))
+- Add missing `From<VersionWithSource>` for `Version` by @baszalmstra in ([#246](https://github.com/conda/rattler/pull/246))
+- Optimized libsolv port by removing redundant MatchSpec parsing by @baszalmstra in ([#246](https://github.com/conda/rattler/pull/246))
+- Optimized libsolv port by caching matching Solvables by @baszalmstra in ([#251](https://github.com/conda/rattler/pull/251))
 
 ## [0.5.0] - 2023-06-30
 
@@ -479,13 +479,13 @@ A bug fix release
 
 #### Added
 
-- More control over how the PATH is altered during activation ([#232](https://github.com/conda-incubator/rattler/pull/232))
+- More control over how the PATH is altered during activation ([#232](https://github.com/conda/rattler/pull/232))
 
 #### Fixed
 
-- Reconstructing of RepoData from conda lock files for local channels ([#231](https://github.com/conda-incubator/rattler/pull/231))
-- Powershell on Linux ([#234](https://github.com/conda-incubator/rattler/pull/234))
-- Proper parsing of `>2.10*` as `>=2.10` ([#237](https://github.com/conda-incubator/rattler/pull/237))
+- Reconstructing of RepoData from conda lock files for local channels ([#231](https://github.com/conda/rattler/pull/231))
+- Powershell on Linux ([#234](https://github.com/conda/rattler/pull/234))
+- Proper parsing of `>2.10*` as `>=2.10` ([#237](https://github.com/conda/rattler/pull/237))
 
 ## [0.4.0] - 2023-06-23
 
@@ -493,7 +493,7 @@ A bug fix release
 
 A new algorithm was introduced to sort `PackageRecord`s in a topological order based on their dependencies.
 Sorting in this way provides a deterministic way of sorting packages in the order in which they should be installed to avoid clobbering.
-The original algorithm was extracted from [rattler-server](https://github.com/conda-incubator/rattler-server).
+The original algorithm was extracted from [rattler-server](https://github.com/conda/rattler-server).
 
 Experimental extensions to the conda lock file format have also been introduced to make it possible to completely reproduce the original `RepoDataRecord`s from a lock file.
 
@@ -503,21 +503,21 @@ Fixes were made to the `MatchSpec` and `Version` implementation to catch some co
 
 #### Added
 
-- `PackageRecord::sort_topologically` to perform a topological sort of `PackageRecord`s ([#218](https://github.com/conda-incubator/rattler/pull/218))
-- Experimental fields to be able to reconstruct `RepoDataRecord` from conda lock files. ([#221](https://github.com/conda-incubator/rattler/pull/221))
-- Methods to manipulate `Version`s ([#229](https://github.com/conda-incubator/rattler/pull/229))
+- `PackageRecord::sort_topologically` to perform a topological sort of `PackageRecord`s ([#218](https://github.com/conda/rattler/pull/218))
+- Experimental fields to be able to reconstruct `RepoDataRecord` from conda lock files. ([#221](https://github.com/conda/rattler/pull/221))
+- Methods to manipulate `Version`s ([#229](https://github.com/conda/rattler/pull/229))
 
 #### Changed
 
-- Refactored shell detection code using `$SHELL` or parent process name ([#219](https://github.com/conda-incubator/rattler/pull/219))
-- The error message that is thrown when parsing a `Platform` now includes possible options ([#222](https://github.com/conda-incubator/rattler/pull/222))
-- Completely refactored `Version` implementation to reduce memory footprint and increase readability ([#227](https://github.com/conda-incubator/rattler/pull/227))
+- Refactored shell detection code using `$SHELL` or parent process name ([#219](https://github.com/conda/rattler/pull/219))
+- The error message that is thrown when parsing a `Platform` now includes possible options ([#222](https://github.com/conda/rattler/pull/222))
+- Completely refactored `Version` implementation to reduce memory footprint and increase readability ([#227](https://github.com/conda/rattler/pull/227))
 
 #### Fixed
 
-- Issue with parsing matchspecs that contain epochs ([#220](https://github.com/conda-incubator/rattler/pull/220))
-- Zsh activation scripts invoke .sh scripts ([#223](https://github.com/conda-incubator/rattler/pull/223))
-- Detect the proper powershell parent process ([#224](https://github.com/conda-incubator/rattler/pull/224))
+- Issue with parsing matchspecs that contain epochs ([#220](https://github.com/conda/rattler/pull/220))
+- Zsh activation scripts invoke .sh scripts ([#223](https://github.com/conda/rattler/pull/223))
+- Detect the proper powershell parent process ([#224](https://github.com/conda/rattler/pull/224))
 
 ## [0.3.0] - 2023-06-15
 
@@ -548,55 +548,55 @@ A new crate has been added to facilitate authentication when downloading repodat
 
 #### Added
 
-- Support for detecting more platforms ([#135](https://github.com/conda-incubator/rattler/pull/135))
-- `RepoData` is now clonable ([#138](https://github.com/conda-incubator/rattler/pull/138))
-- `RunExportsJson` is now clonable ([#169](https://github.com/conda-incubator/rattler/pull/169))
-- `file://` urls are now supported for package extraction functions ([#157](https://github.com/conda-incubator/rattler/pull/157))
-- `file://` urls are now supported for repodata fetching ([#158](https://github.com/conda-incubator/rattler/pull/158))
-- Getting started with rattler using micromamba ([#163](https://github.com/conda-incubator/rattler/pull/163))
-- Add `Platform::arch` function to return the architecture of a given platform ([#166](https://github.com/conda-incubator/rattler/pull/166))
-- Extracted Python style JSON formatting into [a separate crate](https://github.com/prefix-dev/serde-json-python-formatter) ([#163](https://github.com/conda-incubator/rattler/pull/180))
-- Added feature to use `rustls` with `rattler_package_streaming` and `rattler_repodata_gateway` ([#179](https://github.com/conda-incubator/rattler/pull/179) & [#181](https://github.com/conda-incubator/rattler/pull/181))
-- Expose `version_spec` module ([#183](https://github.com/conda-incubator/rattler/pull/183))
-- `NamelessMatchSpec` a variant of `MatchSpec` that does not include a package name [#185](https://github.com/conda-incubator/rattler/pull/185))
-- `ShellEnum` - a dynamic shell type for dynamic discovery [#187](https://github.com/conda-incubator/rattler/pull/187))
-- Exposed the `python_entry_point_template` function ([#190](https://github.com/conda-incubator/rattler/pull/190))
-- Enable deserializing virtual packages ([#198](https://github.com/conda-incubator/rattler/pull/198))
-- Refactored CI to add macOS arm64 ([#201](https://github.com/conda-incubator/rattler/pull/201))
-- Support for JLAP when downloading repodata ([#197](https://github.com/conda-incubator/rattler/pull/197) & [#214](https://github.com/conda-incubator/rattler/pull/214))
-- `Clone`, `Debug`, `PartialEq`, `Eq` implementations for conda lock types ([#213](https://github.com/conda-incubator/rattler/pull/213))
-- `rattler_networking` to enable accessing `repodata.json` and packages that require authentication ([#191](https://github.com/conda-incubator/rattler/pull/191))
+- Support for detecting more platforms ([#135](https://github.com/conda/rattler/pull/135))
+- `RepoData` is now clonable ([#138](https://github.com/conda/rattler/pull/138))
+- `RunExportsJson` is now clonable ([#169](https://github.com/conda/rattler/pull/169))
+- `file://` urls are now supported for package extraction functions ([#157](https://github.com/conda/rattler/pull/157))
+- `file://` urls are now supported for repodata fetching ([#158](https://github.com/conda/rattler/pull/158))
+- Getting started with rattler using micromamba ([#163](https://github.com/conda/rattler/pull/163))
+- Add `Platform::arch` function to return the architecture of a given platform ([#166](https://github.com/conda/rattler/pull/166))
+- Extracted Python style JSON formatting into [a separate crate](https://github.com/prefix-dev/serde-json-python-formatter) ([#163](https://github.com/conda/rattler/pull/180))
+- Added feature to use `rustls` with `rattler_package_streaming` and `rattler_repodata_gateway` ([#179](https://github.com/conda/rattler/pull/179) & [#181](https://github.com/conda/rattler/pull/181))
+- Expose `version_spec` module ([#183](https://github.com/conda/rattler/pull/183))
+- `NamelessMatchSpec` a variant of `MatchSpec` that does not include a package name [#185](https://github.com/conda/rattler/pull/185))
+- `ShellEnum` - a dynamic shell type for dynamic discovery [#187](https://github.com/conda/rattler/pull/187))
+- Exposed the `python_entry_point_template` function ([#190](https://github.com/conda/rattler/pull/190))
+- Enable deserializing virtual packages ([#198](https://github.com/conda/rattler/pull/198))
+- Refactored CI to add macOS arm64 ([#201](https://github.com/conda/rattler/pull/201))
+- Support for JLAP when downloading repodata ([#197](https://github.com/conda/rattler/pull/197) & [#214](https://github.com/conda/rattler/pull/214))
+- `Clone`, `Debug`, `PartialEq`, `Eq` implementations for conda lock types ([#213](https://github.com/conda/rattler/pull/213))
+- `rattler_networking` to enable accessing `repodata.json` and packages that require authentication ([#191](https://github.com/conda/rattler/pull/191))
 
 #### Changed
 
-- `FileMode` is now included with `prefix_placeholder` is set ([#136](https://github.com/conda-incubator/rattler/pull/135))
-- `rattler_digest` now re-exports commonly used hash types and typed hashes are now used in more placed (instead of strings) [[#137](https://github.com/conda-incubator/rattler/pull/137) & [#153](https://github.com/conda-incubator/rattler/pull/153)]
-- Use `Platform` in to detect running operating system ([#144](https://github.com/conda-incubator/rattler/pull/144))
-- `paths.json` is now serialized in a deterministic fashion ([#147](https://github.com/conda-incubator/rattler/pull/147))
-- Determine the `subdir` for the `platform` and `arch` fields when creating a `PackageRecord` from an `index.json` ([#145](https://github.com/conda-incubator/rattler/pull/145) & [#152](https://github.com/conda-incubator/rattler/pull/152))
-- `Activator::activation` now returns the new `PATH` in addition to the script ([#151](https://github.com/conda-incubator/rattler/pull/151))
-- Use properly typed `chrono::DateTime<chrono::Utc>` for timestamps instead of `u64` ([#157](https://github.com/conda-incubator/rattler/pull/157))
-- Made `ParseError` public and reuse `ArchiveType` ([#167](https://github.com/conda-incubator/rattler/pull/167))
-- Allow setting timestamps when creating package archive ([#171](https://github.com/conda-incubator/rattler/pull/171))
-- `about.json` and `index.json` are now serialized in a deterministic fashion ([#180](https://github.com/conda-incubator/rattler/pull/180))
-- SHA256 and MD5 hashes are computed on the fly when extracting packages ([#176](https://github.com/conda-incubator/rattler/pull/176)
-- Change blake2 hash to use blake2b instead of blake2s ([#192](https://github.com/conda-incubator/rattler/pull/192)
-- LibSolv error messages are now passed through ([#202](https://github.com/conda-incubator/rattler/pull/202) & [#210](https://github.com/conda-incubator/rattler/pull/210))
-- `VersionTree` parsing now uses `nom` instead of a complex regex ([#206](https://github.com/conda-incubator/rattler/pull/206)
-- `libc` version detection now uses `lld --version` to properly detect the libc version on the host ([#209](https://github.com/conda-incubator/rattler/pull/209)
-- Improved version parse error messages ([#211](https://github.com/conda-incubator/rattler/pull/211)
-- Parsing of some complex MatchSpecs ([#217](https://github.com/conda-incubator/rattler/pull/217)
+- `FileMode` is now included with `prefix_placeholder` is set ([#136](https://github.com/conda/rattler/pull/135))
+- `rattler_digest` now re-exports commonly used hash types and typed hashes are now used in more placed (instead of strings) [[#137](https://github.com/conda/rattler/pull/137) & [#153](https://github.com/conda/rattler/pull/153)]
+- Use `Platform` in to detect running operating system ([#144](https://github.com/conda/rattler/pull/144))
+- `paths.json` is now serialized in a deterministic fashion ([#147](https://github.com/conda/rattler/pull/147))
+- Determine the `subdir` for the `platform` and `arch` fields when creating a `PackageRecord` from an `index.json` ([#145](https://github.com/conda/rattler/pull/145) & [#152](https://github.com/conda/rattler/pull/152))
+- `Activator::activation` now returns the new `PATH` in addition to the script ([#151](https://github.com/conda/rattler/pull/151))
+- Use properly typed `chrono::DateTime<chrono::Utc>` for timestamps instead of `u64` ([#157](https://github.com/conda/rattler/pull/157))
+- Made `ParseError` public and reuse `ArchiveType` ([#167](https://github.com/conda/rattler/pull/167))
+- Allow setting timestamps when creating package archive ([#171](https://github.com/conda/rattler/pull/171))
+- `about.json` and `index.json` are now serialized in a deterministic fashion ([#180](https://github.com/conda/rattler/pull/180))
+- SHA256 and MD5 hashes are computed on the fly when extracting packages ([#176](https://github.com/conda/rattler/pull/176)
+- Change blake2 hash to use blake2b instead of blake2s ([#192](https://github.com/conda/rattler/pull/192)
+- LibSolv error messages are now passed through ([#202](https://github.com/conda/rattler/pull/202) & [#210](https://github.com/conda/rattler/pull/210))
+- `VersionTree` parsing now uses `nom` instead of a complex regex ([#206](https://github.com/conda/rattler/pull/206)
+- `libc` version detection now uses `lld --version` to properly detect the libc version on the host ([#209](https://github.com/conda/rattler/pull/209)
+- Improved version parse error messages ([#211](https://github.com/conda/rattler/pull/211)
+- Parsing of some complex MatchSpecs ([#217](https://github.com/conda/rattler/pull/217)
 
 #### Fixed
 
-- MatchSpec bracket list parsing can now handle quoted values ([#157](https://github.com/conda-incubator/rattler/pull/156))
-- Typos and documentation ([#164](https://github.com/conda-incubator/rattler/pull/164) & [#188](https://github.com/conda-incubator/rattler/pull/188))
-- Allow downloading of repodata.json to fail in some cases (only noarch is a required subdir) ([#174](https://github.com/conda-incubator/rattler/pull/174))
-- Missing feature when using the sparse index ([#182](https://github.com/conda-incubator/rattler/pull/182))
-- Several small issues or missing functionality ([#184](https://github.com/conda-incubator/rattler/pull/184))
-- Loosened strictness of comparing packages in `Transaction`s ([#186](https://github.com/conda-incubator/rattler/pull/186)
-- Missing `noarch: generic` parsing in `links.json` ([#189](https://github.com/conda-incubator/rattler/pull/189)
-- Ignore trailing .0 in version comparison ([#196](https://github.com/conda-incubator/rattler/pull/196)
+- MatchSpec bracket list parsing can now handle quoted values ([#157](https://github.com/conda/rattler/pull/156))
+- Typos and documentation ([#164](https://github.com/conda/rattler/pull/164) & [#188](https://github.com/conda/rattler/pull/188))
+- Allow downloading of repodata.json to fail in some cases (only noarch is a required subdir) ([#174](https://github.com/conda/rattler/pull/174))
+- Missing feature when using the sparse index ([#182](https://github.com/conda/rattler/pull/182))
+- Several small issues or missing functionality ([#184](https://github.com/conda/rattler/pull/184))
+- Loosened strictness of comparing packages in `Transaction`s ([#186](https://github.com/conda/rattler/pull/186)
+- Missing `noarch: generic` parsing in `links.json` ([#189](https://github.com/conda/rattler/pull/189)
+- Ignore trailing .0 in version comparison ([#196](https://github.com/conda/rattler/pull/196)
 
 ## [0.2.0] - 2023-03-24
 
@@ -617,5 +617,5 @@ A new crate has been added to facilitate authentication when downloading repodat
 
 First release
 
-[unreleased]: https://github.com/conda-incubator/rattler/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/conda-incubator/rattler/releases/tag/v0.1.0
+[unreleased]: https://github.com/conda/rattler/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/conda/rattler/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing 😍
 
 We would love to have you contribute!
-For a good list of things you could help us with, take a look at our [*good first issues*](https://github.com/conda-incubator/rattler/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
-If you want to go deeper though, any [open issue](https://github.com/conda-incubator/rattler/issues) is up for grabs.
+For a good list of things you could help us with, take a look at our [*good first issues*](https://github.com/conda/rattler/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+If you want to go deeper though, any [open issue](https://github.com/conda/rattler/issues) is up for grabs.
 Just let us know what you start on something.
 
 For questions, requests or a casual chat, we are very active on our discord server. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ opt-level = 3
 
 [workspace.package]
 categories = ["development-tools"]
-homepage = "https://github.com/conda-incubator/rattler"
-repository = "https://github.com/conda-incubator/rattler"
+homepage = "https://github.com/conda/rattler"
+repository = "https://github.com/conda/rattler"
 license = "BSD-3-Clause"
 edition = "2021"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/conda-incubator/rattler/">
+<a href="https://github.com/conda/rattler/">
     <picture>
       <source srcset="https://github.com/user-attachments/assets/6f3f05bc-6363-4974-9517-fe5c0fcffd1a" type="image/jpeg">
       <source srcset="https://github.com/user-attachments/assets/dc30403d-6392-460a-b923-986c2164ef79" type="image/webp">
@@ -17,8 +17,8 @@
 [![python docs main][py-docs-main-badge]][py-docs-main]
 
 [license-badge]: https://img.shields.io/badge/license-BSD--3--Clause-blue?style=flat-square
-[build-badge]: https://img.shields.io/github/actions/workflow/status/conda-incubator/rattler/rust-compile.yml?style=flat-square&branch=main
-[build]: https://github.com/conda-incubator/rattler/actions
+[build-badge]: https://img.shields.io/github/actions/workflow/status/conda/rattler/rust-compile.yml?style=flat-square&branch=main
+[build]: https://github.com/conda/rattler/actions
 [chat-badge]: https://img.shields.io/discord/1082332781146800168.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2&style=flat-square
 [chat-url]: https://discord.gg/kKV8ZxyzY4
 [docs-main-badge]: https://img.shields.io/badge/rust_docs-main-yellow.svg?style=flat-square
@@ -42,7 +42,7 @@ Rattler is actively used by [pixi](https://github.com/prefix-dev/pixi), [rattler
 This repository also contains a binary (use `cargo run` to try) that shows some of the capabilities of the library.
 This is an example of installing an environment containing `cowpy` and all its dependencies _from scratch_ (including Python!):
 
-![Installing an environment](https://github.com/conda-incubator/rattler/assets/4995967/c7946f6e-28a9-41ef-8836-ef4b4c94d273)
+![Installing an environment](https://github.com/conda/rattler/assets/4995967/c7946f6e-28a9-41ef-8836-ef4b4c94d273)
 
 ## Give it a try!
 
@@ -53,7 +53,7 @@ Before you begin, make sure you have the following prerequisites:
 Follow these steps to clone, compile, and run the rattler project:
 ```shell
 # Clone the rattler repository along with its submodules:
-git clone --recursive https://github.com/conda-incubator/rattler.git
+git clone --recursive https://github.com/conda/rattler.git
 cd rattler
 
 # Compile and execute rattler to create a JupyterLab instance:

--- a/crates/file_url/CHANGELOG.md
+++ b/crates/file_url/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3](https://github.com/conda-incubator/rattler/compare/file_url-v0.1.2...file_url-v0.1.3) - 2024-07-15
+## [0.1.3](https://github.com/conda/rattler/compare/file_url-v0.1.2...file_url-v0.1.3) - 2024-07-15
 
 ### Other
 - update Cargo.toml dependencies
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - parse url and path as matchspec ([#704](https://github.com/baszalmstra/rattler/pull/704))
 
-## [0.1.1](https://github.com/conda-incubator/rattler/compare/file_url-v0.1.0...file_url-v0.1.1) - 2024-05-14
+## [0.1.1](https://github.com/conda/rattler/compare/file_url-v0.1.0...file_url-v0.1.1) - 2024-05-14
 
 ### Added
-- exclude repodata records based on timestamp ([#654](https://github.com/conda-incubator/rattler/pull/654))
+- exclude repodata records based on timestamp ([#654](https://github.com/conda/rattler/pull/654))

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -16,34 +16,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - mark some crates 1.0 ([#789](https://github.com/baszalmstra/rattler/pull/789))
 
-## [0.27.2](https://github.com/conda-incubator/rattler/compare/rattler-v0.27.1...rattler-v0.27.2) - 2024-07-23
+## [0.27.2](https://github.com/conda/rattler/compare/rattler-v0.27.1...rattler-v0.27.2) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.27.1](https://github.com/conda-incubator/rattler/compare/rattler-v0.27.0...rattler-v0.27.1) - 2024-07-23
+## [0.27.1](https://github.com/conda/rattler/compare/rattler-v0.27.0...rattler-v0.27.1) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.27.0](https://github.com/conda-incubator/rattler/compare/rattler-v0.26.5...rattler-v0.27.0) - 2024-07-15
+## [0.27.0](https://github.com/conda/rattler/compare/rattler-v0.26.5...rattler-v0.27.0) - 2024-07-15
 
 ### Fixed
-- unclobber issue when packages are named differently ([#776](https://github.com/conda-incubator/rattler/pull/776))
+- unclobber issue when packages are named differently ([#776](https://github.com/conda/rattler/pull/776))
 
 ### Other
-- bump dependencies and remove unused ones ([#771](https://github.com/conda-incubator/rattler/pull/771))
+- bump dependencies and remove unused ones ([#771](https://github.com/conda/rattler/pull/771))
 
-## [0.26.5](https://github.com/conda-incubator/rattler/compare/rattler-v0.26.4...rattler-v0.26.5) - 2024-07-08
+## [0.26.5](https://github.com/conda/rattler/compare/rattler-v0.26.4...rattler-v0.26.5) - 2024-07-08
 
 ### Added
-- add direct url repodata building ([#725](https://github.com/conda-incubator/rattler/pull/725))
+- add direct url repodata building ([#725](https://github.com/conda/rattler/pull/725))
 
 ### Fixed
-- errors should not contain trailing punctuation ([#763](https://github.com/conda-incubator/rattler/pull/763))
-- run clippy on all targets ([#762](https://github.com/conda-incubator/rattler/pull/762))
+- errors should not contain trailing punctuation ([#763](https://github.com/conda/rattler/pull/763))
+- run clippy on all targets ([#762](https://github.com/conda/rattler/pull/762))
 
-## [0.26.4](https://github.com/conda-incubator/rattler/compare/rattler-v0.26.3...rattler-v0.26.4) - 2024-06-06
+## [0.26.4](https://github.com/conda/rattler/compare/rattler-v0.26.3...rattler-v0.26.4) - 2024-06-06
 
 ### Other
 - updated the following local packages: rattler_shell
@@ -54,75 +54,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove lfs ([#512](https://github.com/baszalmstra/rattler/pull/512))
 - move the cache tooling into its own crate for reuse downstream ([#721](https://github.com/baszalmstra/rattler/pull/721))
 
-## [0.26.2](https://github.com/conda-incubator/rattler/compare/rattler-v0.26.1...rattler-v0.26.2) - 2024-06-03
+## [0.26.2](https://github.com/conda/rattler/compare/rattler-v0.26.1...rattler-v0.26.2) - 2024-06-03
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_package_streaming
 
-## [0.26.1](https://github.com/conda-incubator/rattler/compare/rattler-v0.26.0...rattler-v0.26.1) - 2024-05-28
+## [0.26.1](https://github.com/conda/rattler/compare/rattler-v0.26.0...rattler-v0.26.1) - 2024-05-28
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.26.0](https://github.com/conda-incubator/rattler/compare/rattler-v0.25.0...rattler-v0.26.0) - 2024-05-27
+## [0.26.0](https://github.com/conda/rattler/compare/rattler-v0.25.0...rattler-v0.26.0) - 2024-05-27
 
 ### Fixed
-- improve progress bar duration display ([#680](https://github.com/conda-incubator/rattler/pull/680))
+- improve progress bar duration display ([#680](https://github.com/conda/rattler/pull/680))
 
 ### Other
-- introducing the installer ([#664](https://github.com/conda-incubator/rattler/pull/664))
-- create directories up front ([#533](https://github.com/conda-incubator/rattler/pull/533))
+- introducing the installer ([#664](https://github.com/conda/rattler/pull/664))
+- create directories up front ([#533](https://github.com/conda/rattler/pull/533))
 
-## [0.25.0](https://github.com/conda-incubator/rattler/compare/rattler-v0.24.1...rattler-v0.25.0) - 2024-05-14
+## [0.25.0](https://github.com/conda/rattler/compare/rattler-v0.24.1...rattler-v0.25.0) - 2024-05-14
 
 ### Added
-- exclude repodata records based on timestamp ([#654](https://github.com/conda-incubator/rattler/pull/654))
+- exclude repodata records based on timestamp ([#654](https://github.com/conda/rattler/pull/654))
 
 ### Other
-- use semaphore for install driver ([#653](https://github.com/conda-incubator/rattler/pull/653))
+- use semaphore for install driver ([#653](https://github.com/conda/rattler/pull/653))
 
-## [0.24.1](https://github.com/conda-incubator/rattler/compare/rattler-v0.24.0...rattler-v0.24.1) - 2024-05-13
+## [0.24.1](https://github.com/conda/rattler/compare/rattler-v0.24.0...rattler-v0.24.1) - 2024-05-13
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_digest, rattler_package_streaming, rattler_networking
 
-## [0.24.0](https://github.com/conda-incubator/rattler/compare/rattler-v0.23.2...rattler-v0.24.0) - 2024-05-06
+## [0.24.0](https://github.com/conda/rattler/compare/rattler-v0.23.2...rattler-v0.24.0) - 2024-05-06
 
 ### Fixed
-- use the output of `readlink` as hash for softlinks ([#643](https://github.com/conda-incubator/rattler/pull/643))
-- sha computation of symlinks was failing sometimes ([#641](https://github.com/conda-incubator/rattler/pull/641))
+- use the output of `readlink` as hash for softlinks ([#643](https://github.com/conda/rattler/pull/643))
+- sha computation of symlinks was failing sometimes ([#641](https://github.com/conda/rattler/pull/641))
 
-## [0.23.2](https://github.com/conda-incubator/rattler/compare/rattler-v0.23.1...rattler-v0.23.2) - 2024-04-30
+## [0.23.2](https://github.com/conda/rattler/compare/rattler-v0.23.1...rattler-v0.23.2) - 2024-04-30
 
 ### Other
 - updated the following local packages: rattler_networking
 
-## [0.23.1](https://github.com/conda-incubator/rattler/compare/rattler-v0.23.0...rattler-v0.23.1) - 2024-04-25
+## [0.23.1](https://github.com/conda/rattler/compare/rattler-v0.23.0...rattler-v0.23.1) - 2024-04-25
 
 ### Other
 - updated the following local packages: rattler_networking
 
-## [0.23.0](https://github.com/conda-incubator/rattler/compare/rattler-v0.22.0...rattler-v0.23.0) - 2024-04-25
+## [0.23.0](https://github.com/conda/rattler/compare/rattler-v0.22.0...rattler-v0.23.0) - 2024-04-25
 
 ### Added
-- Expose paths_data as PathEntry in py-rattler ([#620](https://github.com/conda-incubator/rattler/pull/620))
-- add support for extracting prefix placeholder data to PathsEntry ([#614](https://github.com/conda-incubator/rattler/pull/614))
+- Expose paths_data as PathEntry in py-rattler ([#620](https://github.com/conda/rattler/pull/620))
+- add support for extracting prefix placeholder data to PathsEntry ([#614](https://github.com/conda/rattler/pull/614))
 
 ### Fixed
-- compare `UrlOrPath` ([#618](https://github.com/conda-incubator/rattler/pull/618))
+- compare `UrlOrPath` ([#618](https://github.com/conda/rattler/pull/618))
 
-## [0.22.0](https://github.com/conda-incubator/rattler/compare/rattler-v0.21.0...rattler-v0.22.0) - 2024-04-19
+## [0.22.0](https://github.com/conda/rattler/compare/rattler-v0.21.0...rattler-v0.22.0) - 2024-04-19
 
 ### Added
-- make root dir configurable in channel config ([#602](https://github.com/conda-incubator/rattler/pull/602))
+- make root dir configurable in channel config ([#602](https://github.com/conda/rattler/pull/602))
 
 ### Fixed
-- unicode activation issues on windows ([#604](https://github.com/conda-incubator/rattler/pull/604))
-- no shebang on windows to make spaces in prefix work ([#611](https://github.com/conda-incubator/rattler/pull/611))
-- use correct platform to decide the windows launcher ([#608](https://github.com/conda-incubator/rattler/pull/608))
+- unicode activation issues on windows ([#604](https://github.com/conda/rattler/pull/604))
+- no shebang on windows to make spaces in prefix work ([#611](https://github.com/conda/rattler/pull/611))
+- use correct platform to decide the windows launcher ([#608](https://github.com/conda/rattler/pull/608))
 
 ### Other
-- update dependencies incl. reqwest ([#606](https://github.com/conda-incubator/rattler/pull/606))
+- update dependencies incl. reqwest ([#606](https://github.com/conda/rattler/pull/606))
 
 ## [0.21.0](https://github.com/baszalmstra/rattler/compare/rattler-v0.20.1...rattler-v0.21.0) - 2024-04-05
 
@@ -130,55 +130,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - replace long shebangs with `/usr/bin/env` ([#594](https://github.com/baszalmstra/rattler/pull/594))
 - run post-link scripts ([#574](https://github.com/baszalmstra/rattler/pull/574))
 
-## [0.20.1](https://github.com/conda-incubator/rattler/compare/rattler-v0.20.0...rattler-v0.20.1) - 2024-04-02
+## [0.20.1](https://github.com/conda/rattler/compare/rattler-v0.20.0...rattler-v0.20.1) - 2024-04-02
 
 ### Fixed
-- copy windows dll without replacements ([#590](https://github.com/conda-incubator/rattler/pull/590))
+- copy windows dll without replacements ([#590](https://github.com/conda/rattler/pull/590))
 
-## [0.20.0](https://github.com/conda-incubator/rattler/compare/rattler-v0.19.6...rattler-v0.20.0) - 2024-04-02
+## [0.20.0](https://github.com/conda/rattler/compare/rattler-v0.19.6...rattler-v0.20.0) - 2024-04-02
 
 ### Fixed
-- do not do cstring replacement on windows ([#589](https://github.com/conda-incubator/rattler/pull/589))
+- do not do cstring replacement on windows ([#589](https://github.com/conda/rattler/pull/589))
 
-## [0.19.6](https://github.com/conda-incubator/rattler/compare/rattler-v0.19.5...rattler-v0.19.6) - 2024-03-30
+## [0.19.6](https://github.com/conda/rattler/compare/rattler-v0.19.5...rattler-v0.19.6) - 2024-03-30
 
 ### Other
-- remove unused dependencies ([#585](https://github.com/conda-incubator/rattler/pull/585))
+- remove unused dependencies ([#585](https://github.com/conda/rattler/pull/585))
 
-## [0.19.5](https://github.com/conda-incubator/rattler/compare/rattler-v0.19.4...rattler-v0.19.5) - 2024-03-21
-
-### Fixed
-- typo ([#576](https://github.com/conda-incubator/rattler/pull/576))
-
-## [0.19.4](https://github.com/conda-incubator/rattler/compare/rattler-v0.19.3...rattler-v0.19.4) - 2024-03-19
+## [0.19.5](https://github.com/conda/rattler/compare/rattler-v0.19.4...rattler-v0.19.5) - 2024-03-21
 
 ### Fixed
-- multi-prefix replacement in binary files ([#570](https://github.com/conda-incubator/rattler/pull/570))
+- typo ([#576](https://github.com/conda/rattler/pull/576))
 
-## [0.19.3](https://github.com/conda-incubator/rattler/compare/rattler-v0.19.2...rattler-v0.19.3) - 2024-03-14
+## [0.19.4](https://github.com/conda/rattler/compare/rattler-v0.19.3...rattler-v0.19.4) - 2024-03-19
+
+### Fixed
+- multi-prefix replacement in binary files ([#570](https://github.com/conda/rattler/pull/570))
+
+## [0.19.3](https://github.com/conda/rattler/compare/rattler-v0.19.2...rattler-v0.19.3) - 2024-03-14
 
 ### Added
-- add mirror handling and OCI mirror type ([#553](https://github.com/conda-incubator/rattler/pull/553))
+- add mirror handling and OCI mirror type ([#553](https://github.com/conda/rattler/pull/553))
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler-v0.19.1...rattler-v0.19.2) - 2024-03-08
+## [0.19.2](https://github.com/conda/rattler/compare/rattler-v0.19.1...rattler-v0.19.2) - 2024-03-08
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler-v0.19.0...rattler-v0.19.1) - 2024-03-06
+## [0.19.1](https://github.com/conda/rattler/compare/rattler-v0.19.0...rattler-v0.19.1) - 2024-03-06
 
 ### Added
-- generalised CLI authentication ([#537](https://github.com/conda-incubator/rattler/pull/537))
+- generalised CLI authentication ([#537](https://github.com/conda/rattler/pull/537))
 
 ### Fixed
-- removal of multiple packages that clobber each other ([#556](https://github.com/conda-incubator/rattler/pull/556))
-- dont use workspace dependencies for local crates ([#546](https://github.com/conda-incubator/rattler/pull/546))
+- removal of multiple packages that clobber each other ([#556](https://github.com/conda/rattler/pull/556))
+- dont use workspace dependencies for local crates ([#546](https://github.com/conda/rattler/pull/546))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler-v0.18.0...rattler-v0.19.0) - 2024-02-26
 

--- a/crates/rattler/src/lib.rs
+++ b/crates/rattler/src/lib.rs
@@ -1,4 +1,4 @@
-//! [![Rattler banner](https://github.com/user-attachments/assets/bfd64756-061d-49f5-af4e-388743bdb855)](https://github.com/conda-incubator/rattler)
+//! [![Rattler banner](https://github.com/user-attachments/assets/bfd64756-061d-49f5-af4e-388743bdb855)](https://github.com/conda/rattler)
 //!
 //! Rattler is a library and executable to work with [Conda](http://conda.io)
 //! environments. Conda is a cross-platform open-source package management

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -16,28 +16,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - mark some crates 1.0 ([#789](https://github.com/baszalmstra/rattler/pull/789))
 
-## [0.1.4](https://github.com/conda-incubator/rattler/compare/rattler_cache-v0.1.3...rattler_cache-v0.1.4) - 2024-07-23
+## [0.1.4](https://github.com/conda/rattler/compare/rattler_cache-v0.1.3...rattler_cache-v0.1.4) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.1.3](https://github.com/conda-incubator/rattler/compare/rattler_cache-v0.1.2...rattler_cache-v0.1.3) - 2024-07-23
+## [0.1.3](https://github.com/conda/rattler/compare/rattler_cache-v0.1.2...rattler_cache-v0.1.3) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.1.2](https://github.com/conda-incubator/rattler/compare/rattler_cache-v0.1.1...rattler_cache-v0.1.2) - 2024-07-15
+## [0.1.2](https://github.com/conda/rattler/compare/rattler_cache-v0.1.1...rattler_cache-v0.1.2) - 2024-07-15
 
 ### Other
-- bump dependencies and remove unused ones ([#771](https://github.com/conda-incubator/rattler/pull/771))
+- bump dependencies and remove unused ones ([#771](https://github.com/conda/rattler/pull/771))
 
-## [0.1.1](https://github.com/conda-incubator/rattler/compare/rattler_cache-v0.1.0...rattler_cache-v0.1.1) - 2024-07-08
+## [0.1.1](https://github.com/conda/rattler/compare/rattler_cache-v0.1.0...rattler_cache-v0.1.1) - 2024-07-08
 
 ### Added
-- add direct url repodata building ([#725](https://github.com/conda-incubator/rattler/pull/725))
+- add direct url repodata building ([#725](https://github.com/conda/rattler/pull/725))
 
 ### Fixed
-- run clippy on all targets ([#762](https://github.com/conda-incubator/rattler/pull/762))
+- run clippy on all targets ([#762](https://github.com/conda/rattler/pull/762))
 
 ## [0.1.0](https://github.com/baszalmstra/rattler/releases/tag/rattler_cache-v0.1.0) - 2024-06-04
 

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -23,38 +23,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - mark some crates 1.0 ([#789](https://github.com/baszalmstra/rattler/pull/789))
 
-## [0.26.3](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.26.2...rattler_conda_types-v0.26.3) - 2024-07-23
+## [0.26.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.26.2...rattler_conda_types-v0.26.3) - 2024-07-23
 
 ### Fixed
-- channel `base_url` requires trailing slash ([#787](https://github.com/conda-incubator/rattler/pull/787))
+- channel `base_url` requires trailing slash ([#787](https://github.com/conda/rattler/pull/787))
 
-## [0.26.2](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.26.1...rattler_conda_types-v0.26.2) - 2024-07-23
+## [0.26.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.26.1...rattler_conda_types-v0.26.2) - 2024-07-23
 
 ### Added
-- `environment.yaml` type ([#786](https://github.com/conda-incubator/rattler/pull/786))
-- Add to_path() method to ExplicitEnvironmentSpec ([#781](https://github.com/conda-incubator/rattler/pull/781))
-- expose `HasPrefixEntry` for public use ([#784](https://github.com/conda-incubator/rattler/pull/784))
+- `environment.yaml` type ([#786](https://github.com/conda/rattler/pull/786))
+- Add to_path() method to ExplicitEnvironmentSpec ([#781](https://github.com/conda/rattler/pull/781))
+- expose `HasPrefixEntry` for public use ([#784](https://github.com/conda/rattler/pull/784))
 
-## [0.26.1](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.26.0...rattler_conda_types-v0.26.1) - 2024-07-15
+## [0.26.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.26.0...rattler_conda_types-v0.26.1) - 2024-07-15
 
 ### Other
-- PrefixRecord deserialization using simd ([#777](https://github.com/conda-incubator/rattler/pull/777))
+- PrefixRecord deserialization using simd ([#777](https://github.com/conda/rattler/pull/777))
 
-## [0.26.0](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.25.2...rattler_conda_types-v0.26.0) - 2024-07-08
+## [0.26.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.25.2...rattler_conda_types-v0.26.0) - 2024-07-08
 
 ### Added
-- add support for zos-z ([#753](https://github.com/conda-incubator/rattler/pull/753))
-- return pybytes for sha256 and md5 everywhere and use md5 hash for legacy bz2 md5 ([#752](https://github.com/conda-incubator/rattler/pull/752))
-- add direct url repodata building ([#725](https://github.com/conda-incubator/rattler/pull/725))
-- add shards_base_url and write shards atomically ([#747](https://github.com/conda-incubator/rattler/pull/747))
+- add support for zos-z ([#753](https://github.com/conda/rattler/pull/753))
+- return pybytes for sha256 and md5 everywhere and use md5 hash for legacy bz2 md5 ([#752](https://github.com/conda/rattler/pull/752))
+- add direct url repodata building ([#725](https://github.com/conda/rattler/pull/725))
+- add shards_base_url and write shards atomically ([#747](https://github.com/conda/rattler/pull/747))
 
 ### Fixed
-- allow version following package in strict mode ([#770](https://github.com/conda-incubator/rattler/pull/770))
-- Fix doctests and start testing them again ([#767](https://github.com/conda-incubator/rattler/pull/767))
-- skip over implicit `0` components when copying ([#760](https://github.com/conda-incubator/rattler/pull/760))
-- allow empty json repodata ([#745](https://github.com/conda-incubator/rattler/pull/745))
-- lenient and strict parsing of equality signs ([#738](https://github.com/conda-incubator/rattler/pull/738))
-- This fixes parsing of `ray[default,data] >=2.9.0,<3.0.0` ([#732](https://github.com/conda-incubator/rattler/pull/732))
+- allow version following package in strict mode ([#770](https://github.com/conda/rattler/pull/770))
+- Fix doctests and start testing them again ([#767](https://github.com/conda/rattler/pull/767))
+- skip over implicit `0` components when copying ([#760](https://github.com/conda/rattler/pull/760))
+- allow empty json repodata ([#745](https://github.com/conda/rattler/pull/745))
+- lenient and strict parsing of equality signs ([#738](https://github.com/conda/rattler/pull/738))
+- This fixes parsing of `ray[default,data] >=2.9.0,<3.0.0` ([#732](https://github.com/conda/rattler/pull/732))
 
 ## [0.25.2](https://github.com/baszalmstra/rattler/compare/rattler_conda_types-v0.25.1...rattler_conda_types-v0.25.2) - 2024-06-04
 
@@ -68,106 +68,106 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove lfs ([#512](https://github.com/baszalmstra/rattler/pull/512))
 - move the cache tooling into its own crate for reuse downstream ([#721](https://github.com/baszalmstra/rattler/pull/721))
 
-## [0.25.1](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.25.0...rattler_conda_types-v0.25.1) - 2024-06-03
+## [0.25.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.25.0...rattler_conda_types-v0.25.1) - 2024-06-03
 
 ### Added
-- add a `with_alpha` function that adds `0a0` to the version ([#696](https://github.com/conda-incubator/rattler/pull/696))
+- add a `with_alpha` function that adds `0a0` to the version ([#696](https://github.com/conda/rattler/pull/696))
 
-## [0.25.0](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.24.0...rattler_conda_types-v0.25.0) - 2024-05-28
+## [0.25.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.24.0...rattler_conda_types-v0.25.0) - 2024-05-28
 
 ### Added
-- when bumping, extend versions with `0` to match the bump request ([#695](https://github.com/conda-incubator/rattler/pull/695))
-- extend tests and handle characters better when bumping versions ([#694](https://github.com/conda-incubator/rattler/pull/694))
-- add a function to extend version with `0s` ([#689](https://github.com/conda-incubator/rattler/pull/689))
-- add run exports to package data ([#671](https://github.com/conda-incubator/rattler/pull/671))
+- when bumping, extend versions with `0` to match the bump request ([#695](https://github.com/conda/rattler/pull/695))
+- extend tests and handle characters better when bumping versions ([#694](https://github.com/conda/rattler/pull/694))
+- add a function to extend version with `0s` ([#689](https://github.com/conda/rattler/pull/689))
+- add run exports to package data ([#671](https://github.com/conda/rattler/pull/671))
 
 ### Fixed
-- lenient parsing of 2023.*.* ([#688](https://github.com/conda-incubator/rattler/pull/688))
-- VersionSpec starts with, with trailing zeros ([#686](https://github.com/conda-incubator/rattler/pull/686))
+- lenient parsing of 2023.*.* ([#688](https://github.com/conda/rattler/pull/688))
+- VersionSpec starts with, with trailing zeros ([#686](https://github.com/conda/rattler/pull/686))
 
 ### Other
-- move bump implementation to bump.rs and simplify tests ([#692](https://github.com/conda-incubator/rattler/pull/692))
+- move bump implementation to bump.rs and simplify tests ([#692](https://github.com/conda/rattler/pull/692))
 
-## [0.24.0](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.23.1...rattler_conda_types-v0.24.0) - 2024-05-27
+## [0.24.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.23.1...rattler_conda_types-v0.24.0) - 2024-05-27
 
 ### Added
-- removed Ord and more ([#673](https://github.com/conda-incubator/rattler/pull/673))
-- always store purls as a key in lock file ([#669](https://github.com/conda-incubator/rattler/pull/669))
-- add solve strategies ([#660](https://github.com/conda-incubator/rattler/pull/660))
+- removed Ord and more ([#673](https://github.com/conda/rattler/pull/673))
+- always store purls as a key in lock file ([#669](https://github.com/conda/rattler/pull/669))
+- add solve strategies ([#660](https://github.com/conda/rattler/pull/660))
 
 ### Fixed
-- make topological sorting support fully cyclic dependencies ([#678](https://github.com/conda-incubator/rattler/pull/678))
+- make topological sorting support fully cyclic dependencies ([#678](https://github.com/conda/rattler/pull/678))
 
-## [0.23.1](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.23.0...rattler_conda_types-v0.23.1) - 2024-05-14
-
-### Added
-- exclude repodata records based on timestamp ([#654](https://github.com/conda-incubator/rattler/pull/654))
-
-## [0.23.0](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.22.1...rattler_conda_types-v0.23.0) - 2024-05-13
+## [0.23.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.23.0...rattler_conda_types-v0.23.1) - 2024-05-14
 
 ### Added
-- high level repodata access ([#560](https://github.com/conda-incubator/rattler/pull/560))
+- exclude repodata records based on timestamp ([#654](https://github.com/conda/rattler/pull/654))
+
+## [0.23.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.22.1...rattler_conda_types-v0.23.0) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/conda/rattler/pull/560))
 
 ### Other
 - update README.md
 
-## [0.22.1](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.22.0...rattler_conda_types-v0.22.1) - 2024-05-06
+## [0.22.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.22.0...rattler_conda_types-v0.22.1) - 2024-05-06
 
 ### Added
-- expose `*Record.noarch` in Python bindings ([#635](https://github.com/conda-incubator/rattler/pull/635))
+- expose `*Record.noarch` in Python bindings ([#635](https://github.com/conda/rattler/pull/635))
 
-## [0.22.0](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.21.0...rattler_conda_types-v0.22.0) - 2024-04-25
-
-### Added
-- add support for extracting prefix placeholder data to PathsEntry ([#614](https://github.com/conda-incubator/rattler/pull/614))
-
-## [0.21.0](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.20.5...rattler_conda_types-v0.21.0) - 2024-04-19
+## [0.22.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.21.0...rattler_conda_types-v0.22.0) - 2024-04-25
 
 ### Added
-- make root dir configurable in channel config ([#602](https://github.com/conda-incubator/rattler/pull/602))
+- add support for extracting prefix placeholder data to PathsEntry ([#614](https://github.com/conda/rattler/pull/614))
+
+## [0.21.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.20.5...rattler_conda_types-v0.21.0) - 2024-04-19
+
+### Added
+- make root dir configurable in channel config ([#602](https://github.com/conda/rattler/pull/602))
 
 ### Fixed
-- better value for `link` field ([#610](https://github.com/conda-incubator/rattler/pull/610))
+- better value for `link` field ([#610](https://github.com/conda/rattler/pull/610))
 
 ### Other
-- update dependencies incl. reqwest ([#606](https://github.com/conda-incubator/rattler/pull/606))
+- update dependencies incl. reqwest ([#606](https://github.com/conda/rattler/pull/606))
 
 ## [0.20.5](https://github.com/baszalmstra/rattler/compare/rattler_conda_types-v0.20.4...rattler_conda_types-v0.20.5) - 2024-04-05
 
 ### Fixed
 - run post-link scripts ([#574](https://github.com/baszalmstra/rattler/pull/574))
 
-## [0.20.4](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.20.3...rattler_conda_types-v0.20.4) - 2024-03-30
+## [0.20.4](https://github.com/conda/rattler/compare/rattler_conda_types-v0.20.3...rattler_conda_types-v0.20.4) - 2024-03-30
 
 ### Fixed
-- matchspec empty namespace and channel cannonical name ([#582](https://github.com/conda-incubator/rattler/pull/582))
+- matchspec empty namespace and channel cannonical name ([#582](https://github.com/conda/rattler/pull/582))
 
-## [0.20.3](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.20.2...rattler_conda_types-v0.20.3) - 2024-03-21
+## [0.20.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.20.2...rattler_conda_types-v0.20.3) - 2024-03-21
 
 ### Fixed
-- allow not starts with in strict mode ([#577](https://github.com/conda-incubator/rattler/pull/577))
+- allow not starts with in strict mode ([#577](https://github.com/conda/rattler/pull/577))
 
-## [0.20.2](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.20.1...rattler_conda_types-v0.20.2) - 2024-03-14
+## [0.20.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.20.1...rattler_conda_types-v0.20.2) - 2024-03-14
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.20.1](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.20.0...rattler_conda_types-v0.20.1) - 2024-03-08
+## [0.20.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.20.0...rattler_conda_types-v0.20.1) - 2024-03-08
 
 ### Fixed
-- chrono deprecation warnings ([#558](https://github.com/conda-incubator/rattler/pull/558))
+- chrono deprecation warnings ([#558](https://github.com/conda/rattler/pull/558))
 
-## [0.20.0](https://github.com/conda-incubator/rattler/compare/rattler_conda_types-v0.19.0...rattler_conda_types-v0.20.0) - 2024-03-06
+## [0.20.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.19.0...rattler_conda_types-v0.20.0) - 2024-03-06
 
 ### Added
-- [**breaking**] optional strict parsing of matchspec and versionspec ([#552](https://github.com/conda-incubator/rattler/pull/552))
+- [**breaking**] optional strict parsing of matchspec and versionspec ([#552](https://github.com/conda/rattler/pull/552))
 
 ### Fixed
-- patch unsupported glob operators ([#551](https://github.com/conda-incubator/rattler/pull/551))
-- dont use workspace dependencies for local crates ([#546](https://github.com/conda-incubator/rattler/pull/546))
+- patch unsupported glob operators ([#551](https://github.com/conda/rattler/pull/551))
+- dont use workspace dependencies for local crates ([#546](https://github.com/conda/rattler/pull/546))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_conda_types-v0.18.0...rattler_conda_types-v0.19.0) - 2024-02-26
 

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,32 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.19.5](https://github.com/conda-incubator/rattler/compare/rattler_digest-v0.19.4...rattler_digest-v0.19.5) - 2024-07-15
+## [0.19.5](https://github.com/conda/rattler/compare/rattler_digest-v0.19.4...rattler_digest-v0.19.5) - 2024-07-15
 
 ### Other
-- bump dependencies and remove unused ones ([#771](https://github.com/conda-incubator/rattler/pull/771))
+- bump dependencies and remove unused ones ([#771](https://github.com/conda/rattler/pull/771))
 
-## [0.19.4](https://github.com/conda-incubator/rattler/compare/rattler_digest-v0.19.3...rattler_digest-v0.19.4) - 2024-05-13
+## [0.19.4](https://github.com/conda/rattler/compare/rattler_digest-v0.19.3...rattler_digest-v0.19.4) - 2024-05-13
 
 ### Added
-- high level repodata access ([#560](https://github.com/conda-incubator/rattler/pull/560))
+- high level repodata access ([#560](https://github.com/conda/rattler/pull/560))
 
 ### Other
 - update README.md
 
-## [0.19.3](https://github.com/conda-incubator/rattler/compare/rattler_digest-v0.19.2...rattler_digest-v0.19.3) - 2024-04-19
+## [0.19.3](https://github.com/conda/rattler/compare/rattler_digest-v0.19.2...rattler_digest-v0.19.3) - 2024-04-19
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler_digest-v0.19.1...rattler_digest-v0.19.2) - 2024-03-14
+## [0.19.2](https://github.com/conda/rattler/compare/rattler_digest-v0.19.1...rattler_digest-v0.19.2) - 2024-03-14
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler_digest-v0.19.0...rattler_digest-v0.19.1) - 2024-03-06
+## [0.19.1](https://github.com/conda/rattler/compare/rattler_digest-v0.19.0...rattler_digest-v0.19.1) - 2024-03-06
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_digest-v0.18.0...rattler_digest-v0.19.0) - 2024-02-26

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -16,77 +16,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - mark some crates 1.0 ([#789](https://github.com/baszalmstra/rattler/pull/789))
 
-## [0.19.21](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.20...rattler_index-v0.19.21) - 2024-07-23
+## [0.19.21](https://github.com/conda/rattler/compare/rattler_index-v0.19.20...rattler_index-v0.19.21) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.20](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.19...rattler_index-v0.19.20) - 2024-07-23
+## [0.19.20](https://github.com/conda/rattler/compare/rattler_index-v0.19.19...rattler_index-v0.19.20) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.19](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.18...rattler_index-v0.19.19) - 2024-07-15
+## [0.19.19](https://github.com/conda/rattler/compare/rattler_index-v0.19.18...rattler_index-v0.19.19) - 2024-07-15
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_digest, rattler_package_streaming
 
-## [0.19.18](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.17...rattler_index-v0.19.18) - 2024-07-08
+## [0.19.18](https://github.com/conda/rattler/compare/rattler_index-v0.19.17...rattler_index-v0.19.18) - 2024-07-08
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_package_streaming
 
-## [0.19.17](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.16...rattler_index-v0.19.17) - 2024-06-06
+## [0.19.17](https://github.com/conda/rattler/compare/rattler_index-v0.19.16...rattler_index-v0.19.17) - 2024-06-06
 
 ### Other
-- make package_record_from_* functions public ([#726](https://github.com/conda-incubator/rattler/pull/726))
+- make package_record_from_* functions public ([#726](https://github.com/conda/rattler/pull/726))
 
 ## [0.19.16](https://github.com/baszalmstra/rattler/compare/rattler_index-v0.19.15...rattler_index-v0.19.16) - 2024-06-04
 
 ### Other
 - remove lfs ([#512](https://github.com/baszalmstra/rattler/pull/512))
 
-## [0.19.15](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.14...rattler_index-v0.19.15) - 2024-06-03
+## [0.19.15](https://github.com/conda/rattler/compare/rattler_index-v0.19.14...rattler_index-v0.19.15) - 2024-06-03
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_package_streaming
 
-## [0.19.14](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.13...rattler_index-v0.19.14) - 2024-05-28
+## [0.19.14](https://github.com/conda/rattler/compare/rattler_index-v0.19.13...rattler_index-v0.19.14) - 2024-05-28
 
 ### Added
-- add run exports to package data ([#671](https://github.com/conda-incubator/rattler/pull/671))
+- add run exports to package data ([#671](https://github.com/conda/rattler/pull/671))
 
-## [0.19.13](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.12...rattler_index-v0.19.13) - 2024-05-27
+## [0.19.13](https://github.com/conda/rattler/compare/rattler_index-v0.19.12...rattler_index-v0.19.13) - 2024-05-27
 
 ### Added
-- always store purls as a key in lock file ([#669](https://github.com/conda-incubator/rattler/pull/669))
+- always store purls as a key in lock file ([#669](https://github.com/conda/rattler/pull/669))
 
-## [0.19.12](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.11...rattler_index-v0.19.12) - 2024-05-14
+## [0.19.12](https://github.com/conda/rattler/compare/rattler_index-v0.19.11...rattler_index-v0.19.12) - 2024-05-14
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_package_streaming
 
-## [0.19.11](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.10...rattler_index-v0.19.11) - 2024-05-13
+## [0.19.11](https://github.com/conda/rattler/compare/rattler_index-v0.19.10...rattler_index-v0.19.11) - 2024-05-13
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_digest, rattler_package_streaming
 
-## [0.19.10](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.9...rattler_index-v0.19.10) - 2024-05-06
+## [0.19.10](https://github.com/conda/rattler/compare/rattler_index-v0.19.9...rattler_index-v0.19.10) - 2024-05-06
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.9](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.8...rattler_index-v0.19.9) - 2024-04-30
+## [0.19.9](https://github.com/conda/rattler/compare/rattler_index-v0.19.8...rattler_index-v0.19.9) - 2024-04-30
 
 ### Other
-- release ([#625](https://github.com/conda-incubator/rattler/pull/625))
+- release ([#625](https://github.com/conda/rattler/pull/625))
 
-## [0.19.8](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.7...rattler_index-v0.19.8) - 2024-04-25
+## [0.19.8](https://github.com/conda/rattler/compare/rattler_index-v0.19.7...rattler_index-v0.19.8) - 2024-04-25
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.7](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.6...rattler_index-v0.19.7) - 2024-04-19
+## [0.19.7](https://github.com/conda/rattler/compare/rattler_index-v0.19.6...rattler_index-v0.19.7) - 2024-04-19
 
 ### Other
 - update Cargo.toml dependencies
@@ -96,33 +96,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.5](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.4...rattler_index-v0.19.5) - 2024-03-30
+## [0.19.5](https://github.com/conda/rattler/compare/rattler_index-v0.19.4...rattler_index-v0.19.5) - 2024-03-30
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.4](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.3...rattler_index-v0.19.4) - 2024-03-21
+## [0.19.4](https://github.com/conda/rattler/compare/rattler_index-v0.19.3...rattler_index-v0.19.4) - 2024-03-21
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.3](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.2...rattler_index-v0.19.3) - 2024-03-14
+## [0.19.3](https://github.com/conda/rattler/compare/rattler_index-v0.19.2...rattler_index-v0.19.3) - 2024-03-14
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.1...rattler_index-v0.19.2) - 2024-03-08
+## [0.19.2](https://github.com/conda/rattler/compare/rattler_index-v0.19.1...rattler_index-v0.19.2) - 2024-03-08
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_package_streaming
 
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler_index-v0.19.0...rattler_index-v0.19.1) - 2024-03-06
+## [0.19.1](https://github.com/conda/rattler/compare/rattler_index-v0.19.0...rattler_index-v0.19.1) - 2024-03-06
 
 ### Fixed
-- dont use workspace dependencies for local crates ([#546](https://github.com/conda-incubator/rattler/pull/546))
+- dont use workspace dependencies for local crates ([#546](https://github.com/conda/rattler/pull/546))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_index-v0.18.0...rattler_index-v0.19.0) - 2024-02-26
 

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,29 +6,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.19.5](https://github.com/conda-incubator/rattler/compare/rattler_libsolv_c-v0.19.4...rattler_libsolv_c-v0.19.5) - 2024-07-15
+## [0.19.5](https://github.com/conda/rattler/compare/rattler_libsolv_c-v0.19.4...rattler_libsolv_c-v0.19.5) - 2024-07-15
 
 ### Other
-- bump dependencies and remove unused ones ([#771](https://github.com/conda-incubator/rattler/pull/771))
+- bump dependencies and remove unused ones ([#771](https://github.com/conda/rattler/pull/771))
 
-## [0.19.4](https://github.com/conda-incubator/rattler/compare/rattler_libsolv_c-v0.19.3...rattler_libsolv_c-v0.19.4) - 2024-07-08
+## [0.19.4](https://github.com/conda/rattler/compare/rattler_libsolv_c-v0.19.3...rattler_libsolv_c-v0.19.4) - 2024-07-08
 
 ### Other
 - update README.md
 
-## [0.19.3](https://github.com/conda-incubator/rattler/compare/rattler_libsolv_c-v0.19.2...rattler_libsolv_c-v0.19.3) - 2024-04-19
+## [0.19.3](https://github.com/conda/rattler/compare/rattler_libsolv_c-v0.19.2...rattler_libsolv_c-v0.19.3) - 2024-04-19
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler_libsolv_c-v0.19.1...rattler_libsolv_c-v0.19.2) - 2024-03-14
+## [0.19.2](https://github.com/conda/rattler/compare/rattler_libsolv_c-v0.19.1...rattler_libsolv_c-v0.19.2) - 2024-03-14
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler_libsolv_c-v0.19.0...rattler_libsolv_c-v0.19.1) - 2024-03-06
+## [0.19.1](https://github.com/conda/rattler/compare/rattler_libsolv_c-v0.19.0...rattler_libsolv_c-v0.19.1) - 2024-03-06
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_libsolv_c-v0.18.0...rattler_libsolv_c-v0.19.0) - 2024-02-26

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -16,133 +16,133 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - mark some crates 1.0 ([#789](https://github.com/baszalmstra/rattler/pull/789))
 
-## [0.22.16](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.15...rattler_lock-v0.22.16) - 2024-07-23
+## [0.22.16](https://github.com/conda/rattler/compare/rattler_lock-v0.22.15...rattler_lock-v0.22.16) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.22.15](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.14...rattler_lock-v0.22.15) - 2024-07-23
+## [0.22.15](https://github.com/conda/rattler/compare/rattler_lock-v0.22.14...rattler_lock-v0.22.15) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.22.14](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.13...rattler_lock-v0.22.14) - 2024-07-15
+## [0.22.14](https://github.com/conda/rattler/compare/rattler_lock-v0.22.13...rattler_lock-v0.22.14) - 2024-07-15
 
 ### Other
-- bump dependencies and remove unused ones ([#771](https://github.com/conda-incubator/rattler/pull/771))
+- bump dependencies and remove unused ones ([#771](https://github.com/conda/rattler/pull/771))
 
-## [0.22.13](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.12...rattler_lock-v0.22.13) - 2024-07-08
+## [0.22.13](https://github.com/conda/rattler/compare/rattler_lock-v0.22.12...rattler_lock-v0.22.13) - 2024-07-08
 
 ### Added
-- Only save md5 in lock file if no sha256 is present ([#764](https://github.com/conda-incubator/rattler/pull/764))
-- return pybytes for sha256 and md5 everywhere and use md5 hash for legacy bz2 md5 ([#752](https://github.com/conda-incubator/rattler/pull/752))
-- add direct url repodata building ([#725](https://github.com/conda-incubator/rattler/pull/725))
+- Only save md5 in lock file if no sha256 is present ([#764](https://github.com/conda/rattler/pull/764))
+- return pybytes for sha256 and md5 everywhere and use md5 hash for legacy bz2 md5 ([#752](https://github.com/conda/rattler/pull/752))
+- add direct url repodata building ([#725](https://github.com/conda/rattler/pull/725))
 
 ### Fixed
-- lock file stability issues with PyPI types ([#761](https://github.com/conda-incubator/rattler/pull/761))
-- errors should not contain trailing punctuation ([#763](https://github.com/conda-incubator/rattler/pull/763))
+- lock file stability issues with PyPI types ([#761](https://github.com/conda/rattler/pull/761))
+- errors should not contain trailing punctuation ([#763](https://github.com/conda/rattler/pull/763))
 
 ### Other
-- revert only save md5 in lock file if no sha256 is present ([#766](https://github.com/conda-incubator/rattler/pull/766))
+- revert only save md5 in lock file if no sha256 is present ([#766](https://github.com/conda/rattler/pull/766))
 
-## [0.22.12](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.11...rattler_lock-v0.22.12) - 2024-06-06
+## [0.22.12](https://github.com/conda/rattler/compare/rattler_lock-v0.22.11...rattler_lock-v0.22.12) - 2024-06-06
 
 ### Added
-- serialize packages from lock file individually ([#728](https://github.com/conda-incubator/rattler/pull/728))
+- serialize packages from lock file individually ([#728](https://github.com/conda/rattler/pull/728))
 
 ## [0.22.11](https://github.com/baszalmstra/rattler/compare/rattler_lock-v0.22.10...rattler_lock-v0.22.11) - 2024-06-04
 
 ### Other
 - updated the following local packages: file_url, rattler_conda_types
 
-## [0.22.10](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.9...rattler_lock-v0.22.10) - 2024-06-03
+## [0.22.10](https://github.com/conda/rattler/compare/rattler_lock-v0.22.9...rattler_lock-v0.22.10) - 2024-06-03
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.22.9](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.8...rattler_lock-v0.22.9) - 2024-05-28
+## [0.22.9](https://github.com/conda/rattler/compare/rattler_lock-v0.22.8...rattler_lock-v0.22.9) - 2024-05-28
 
 ### Added
-- add run exports to package data ([#671](https://github.com/conda-incubator/rattler/pull/671))
+- add run exports to package data ([#671](https://github.com/conda/rattler/pull/671))
 
 ### Other
-- bump ([#683](https://github.com/conda-incubator/rattler/pull/683))
+- bump ([#683](https://github.com/conda/rattler/pull/683))
 
-## [0.22.8](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.7...rattler_lock-v0.22.8) - 2024-05-27
+## [0.22.8](https://github.com/conda/rattler/compare/rattler_lock-v0.22.7...rattler_lock-v0.22.8) - 2024-05-27
 
 ### Added
-- removed Ord and more ([#673](https://github.com/conda-incubator/rattler/pull/673))
-- always store purls as a key in lock file ([#669](https://github.com/conda-incubator/rattler/pull/669))
+- removed Ord and more ([#673](https://github.com/conda/rattler/pull/673))
+- always store purls as a key in lock file ([#669](https://github.com/conda/rattler/pull/669))
 
-## [0.22.7](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.6...rattler_lock-v0.22.7) - 2024-05-14
+## [0.22.7](https://github.com/conda/rattler/compare/rattler_lock-v0.22.6...rattler_lock-v0.22.7) - 2024-05-14
 
 ### Other
-- bump pep crates ([#661](https://github.com/conda-incubator/rattler/pull/661))
+- bump pep crates ([#661](https://github.com/conda/rattler/pull/661))
 
-## [0.22.6](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.5...rattler_lock-v0.22.6) - 2024-05-13
+## [0.22.6](https://github.com/conda/rattler/compare/rattler_lock-v0.22.5...rattler_lock-v0.22.6) - 2024-05-13
 
 ### Added
-- high level repodata access ([#560](https://github.com/conda-incubator/rattler/pull/560))
+- high level repodata access ([#560](https://github.com/conda/rattler/pull/560))
 
 ### Other
 - update README.md
 
-## [0.22.5](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.4...rattler_lock-v0.22.5) - 2024-05-06
+## [0.22.5](https://github.com/conda/rattler/compare/rattler_lock-v0.22.4...rattler_lock-v0.22.5) - 2024-05-06
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.22.4](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.3...rattler_lock-v0.22.4) - 2024-04-30
+## [0.22.4](https://github.com/conda/rattler/compare/rattler_lock-v0.22.3...rattler_lock-v0.22.4) - 2024-04-30
 
 ### Added
-- adds pypi indexes to the lock-file ([#626](https://github.com/conda-incubator/rattler/pull/626))
+- adds pypi indexes to the lock-file ([#626](https://github.com/conda/rattler/pull/626))
 
-## [0.22.3](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.2...rattler_lock-v0.22.3) - 2024-04-25
+## [0.22.3](https://github.com/conda/rattler/compare/rattler_lock-v0.22.2...rattler_lock-v0.22.3) - 2024-04-25
 
 ### Fixed
-- compare `UrlOrPath` ([#618](https://github.com/conda-incubator/rattler/pull/618))
-- parse absolute paths on Windows correctly in lockfiles ([#616](https://github.com/conda-incubator/rattler/pull/616))
+- compare `UrlOrPath` ([#618](https://github.com/conda/rattler/pull/618))
+- parse absolute paths on Windows correctly in lockfiles ([#616](https://github.com/conda/rattler/pull/616))
 
-## [0.22.2](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.22.1...rattler_lock-v0.22.2) - 2024-04-19
+## [0.22.2](https://github.com/conda/rattler/compare/rattler_lock-v0.22.1...rattler_lock-v0.22.2) - 2024-04-19
 
 ### Other
-- update dependencies incl. reqwest ([#606](https://github.com/conda-incubator/rattler/pull/606))
+- update dependencies incl. reqwest ([#606](https://github.com/conda/rattler/pull/606))
 
 ## [0.22.1](https://github.com/baszalmstra/rattler/compare/rattler_lock-v0.22.0...rattler_lock-v0.22.1) - 2024-04-05
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.22.0](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.21.0...rattler_lock-v0.22.0) - 2024-03-30
+## [0.22.0](https://github.com/conda/rattler/compare/rattler_lock-v0.21.0...rattler_lock-v0.22.0) - 2024-03-30
 
 ### Added
-- editable pypi packages ([#581](https://github.com/conda-incubator/rattler/pull/581))
+- editable pypi packages ([#581](https://github.com/conda/rattler/pull/581))
 
-## [0.21.0](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.20.2...rattler_lock-v0.21.0) - 2024-03-21
+## [0.21.0](https://github.com/conda/rattler/compare/rattler_lock-v0.20.2...rattler_lock-v0.21.0) - 2024-03-21
 
 ### Added
-- allow passing pypi paths ([#572](https://github.com/conda-incubator/rattler/pull/572))
+- allow passing pypi paths ([#572](https://github.com/conda/rattler/pull/572))
 
-## [0.20.2](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.20.1...rattler_lock-v0.20.2) - 2024-03-14
+## [0.20.2](https://github.com/conda/rattler/compare/rattler_lock-v0.20.1...rattler_lock-v0.20.2) - 2024-03-14
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.20.1](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.20.0...rattler_lock-v0.20.1) - 2024-03-08
+## [0.20.1](https://github.com/conda/rattler/compare/rattler_lock-v0.20.0...rattler_lock-v0.20.1) - 2024-03-08
 
 ### Fixed
-- chrono deprecation warnings ([#558](https://github.com/conda-incubator/rattler/pull/558))
+- chrono deprecation warnings ([#558](https://github.com/conda/rattler/pull/558))
 
-## [0.20.0](https://github.com/conda-incubator/rattler/compare/rattler_lock-v0.19.0...rattler_lock-v0.20.0) - 2024-03-06
+## [0.20.0](https://github.com/conda/rattler/compare/rattler_lock-v0.19.0...rattler_lock-v0.20.0) - 2024-03-06
 
 ### Added
-- sort extras by name and urls by filename ([#540](https://github.com/conda-incubator/rattler/pull/540))
+- sort extras by name and urls by filename ([#540](https://github.com/conda/rattler/pull/540))
 
 ### Fixed
-- dont use workspace dependencies for local crates ([#546](https://github.com/conda-incubator/rattler/pull/546))
+- dont use workspace dependencies for local crates ([#546](https://github.com/conda/rattler/pull/546))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
-- bump pep508_rs and pep440_rs ([#549](https://github.com/conda-incubator/rattler/pull/549))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
+- bump pep508_rs and pep440_rs ([#549](https://github.com/conda/rattler/pull/549))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_lock-v0.18.0...rattler_lock-v0.19.0) - 2024-02-26

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -671,7 +671,7 @@ mod test {
     }
 
     /// Absolute paths on Windows are not properly parsed.
-    /// See: <https://github.com/conda-incubator/rattler/issues/615>
+    /// See: <https://github.com/conda/rattler/issues/615>
     #[test]
     fn test_issue_615() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,24 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.19.4](https://github.com/conda-incubator/rattler/compare/rattler_macros-v0.19.3...rattler_macros-v0.19.4) - 2024-07-08
+## [0.19.4](https://github.com/conda/rattler/compare/rattler_macros-v0.19.3...rattler_macros-v0.19.4) - 2024-07-08
 
 ### Other
 - update README.md
 
-## [0.19.3](https://github.com/conda-incubator/rattler/compare/rattler_macros-v0.19.2...rattler_macros-v0.19.3) - 2024-04-19
+## [0.19.3](https://github.com/conda/rattler/compare/rattler_macros-v0.19.2...rattler_macros-v0.19.3) - 2024-04-19
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler_macros-v0.19.1...rattler_macros-v0.19.2) - 2024-03-14
+## [0.19.2](https://github.com/conda/rattler/compare/rattler_macros-v0.19.1...rattler_macros-v0.19.2) - 2024-03-14
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler_macros-v0.19.0...rattler_macros-v0.19.1) - 2024-03-06
+## [0.19.1](https://github.com/conda/rattler/compare/rattler_macros-v0.19.0...rattler_macros-v0.19.1) - 2024-03-06
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_macros-v0.18.0...rattler_macros-v0.19.0) - 2024-02-26

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -11,57 +11,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - redact secrets in the `canonical_name` functions ([#801](https://github.com/baszalmstra/rattler/pull/801))
 
-## [0.20.10](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.20.9...rattler_networking-v0.20.10) - 2024-07-15
+## [0.20.10](https://github.com/conda/rattler/compare/rattler_networking-v0.20.9...rattler_networking-v0.20.10) - 2024-07-15
 
 ### Other
-- bump dependencies and remove unused ones ([#771](https://github.com/conda-incubator/rattler/pull/771))
+- bump dependencies and remove unused ones ([#771](https://github.com/conda/rattler/pull/771))
 
-## [0.20.9](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.20.8...rattler_networking-v0.20.9) - 2024-07-08
+## [0.20.9](https://github.com/conda/rattler/compare/rattler_networking-v0.20.8...rattler_networking-v0.20.9) - 2024-07-08
 
 ### Fixed
-- errors should not contain trailing punctuation ([#763](https://github.com/conda-incubator/rattler/pull/763))
+- errors should not contain trailing punctuation ([#763](https://github.com/conda/rattler/pull/763))
 
-## [0.20.8](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.20.7...rattler_networking-v0.20.8) - 2024-05-27
+## [0.20.8](https://github.com/conda/rattler/compare/rattler_networking-v0.20.7...rattler_networking-v0.20.8) - 2024-05-27
 
 ### Other
-- introducing the installer ([#664](https://github.com/conda-incubator/rattler/pull/664))
+- introducing the installer ([#664](https://github.com/conda/rattler/pull/664))
 
-## [0.20.7](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.20.6...rattler_networking-v0.20.7) - 2024-05-14
-
-### Added
-- exclude repodata records based on timestamp ([#654](https://github.com/conda-incubator/rattler/pull/654))
-
-## [0.20.6](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.20.5...rattler_networking-v0.20.6) - 2024-05-13
+## [0.20.7](https://github.com/conda/rattler/compare/rattler_networking-v0.20.6...rattler_networking-v0.20.7) - 2024-05-14
 
 ### Added
-- high level repodata access ([#560](https://github.com/conda-incubator/rattler/pull/560))
-- add AuthenticationStorage::from_file() ([#645](https://github.com/conda-incubator/rattler/pull/645))
+- exclude repodata records based on timestamp ([#654](https://github.com/conda/rattler/pull/654))
+
+## [0.20.6](https://github.com/conda/rattler/compare/rattler_networking-v0.20.5...rattler_networking-v0.20.6) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/conda/rattler/pull/560))
+- add AuthenticationStorage::from_file() ([#645](https://github.com/conda/rattler/pull/645))
 
 ### Other
 - update README.md
 
-## [0.20.5](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.20.4...rattler_networking-v0.20.5) - 2024-05-06
+## [0.20.5](https://github.com/conda/rattler/compare/rattler_networking-v0.20.4...rattler_networking-v0.20.5) - 2024-05-06
 
 ### Added
-- respect `RATTLER_AUTH_FILE` when using AuthenticationStorage::default() ([#636](https://github.com/conda-incubator/rattler/pull/636))
+- respect `RATTLER_AUTH_FILE` when using AuthenticationStorage::default() ([#636](https://github.com/conda/rattler/pull/636))
 
-## [0.20.4](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.20.3...rattler_networking-v0.20.4) - 2024-04-30
+## [0.20.4](https://github.com/conda/rattler/compare/rattler_networking-v0.20.3...rattler_networking-v0.20.4) - 2024-04-30
 
 ### Other
-- bump py-rattler 0.5.0 ([#629](https://github.com/conda-incubator/rattler/pull/629))
+- bump py-rattler 0.5.0 ([#629](https://github.com/conda/rattler/pull/629))
 
-## [0.20.3](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.20.2...rattler_networking-v0.20.3) - 2024-04-25
-
-### Added
-- Add GCS support for rattler auth ([#605](https://github.com/conda-incubator/rattler/pull/605))
-
-## [0.20.2](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.20.1...rattler_networking-v0.20.2) - 2024-04-19
+## [0.20.3](https://github.com/conda/rattler/compare/rattler_networking-v0.20.2...rattler_networking-v0.20.3) - 2024-04-25
 
 ### Added
-- enable zst support for OCI registry ([#601](https://github.com/conda-incubator/rattler/pull/601))
+- Add GCS support for rattler auth ([#605](https://github.com/conda/rattler/pull/605))
+
+## [0.20.2](https://github.com/conda/rattler/compare/rattler_networking-v0.20.1...rattler_networking-v0.20.2) - 2024-04-19
+
+### Added
+- enable zst support for OCI registry ([#601](https://github.com/conda/rattler/pull/601))
 
 ### Other
-- update dependencies incl. reqwest ([#606](https://github.com/conda-incubator/rattler/pull/606))
+- update dependencies incl. reqwest ([#606](https://github.com/conda/rattler/pull/606))
 
 ## [0.20.1](https://github.com/baszalmstra/rattler/compare/rattler_networking-v0.20.0...rattler_networking-v0.20.1) - 2024-04-05
 
@@ -69,26 +69,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - run post-link scripts ([#574](https://github.com/baszalmstra/rattler/pull/574))
 - properly fall back to netrc file ([#592](https://github.com/baszalmstra/rattler/pull/592))
 
-## [0.20.0](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.19.2...rattler_networking-v0.20.0) - 2024-03-21
+## [0.20.0](https://github.com/conda/rattler/compare/rattler_networking-v0.19.2...rattler_networking-v0.20.0) - 2024-03-21
 
 ### Fixed
-- implement cache for authentication filestorage backend ([#573](https://github.com/conda-incubator/rattler/pull/573))
+- implement cache for authentication filestorage backend ([#573](https://github.com/conda/rattler/pull/573))
 
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.19.1...rattler_networking-v0.19.2) - 2024-03-14
+## [0.19.2](https://github.com/conda/rattler/compare/rattler_networking-v0.19.1...rattler_networking-v0.19.2) - 2024-03-14
 
 ### Added
-- add mirror handling and OCI mirror type ([#553](https://github.com/conda-incubator/rattler/pull/553))
+- add mirror handling and OCI mirror type ([#553](https://github.com/conda/rattler/pull/553))
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler_networking-v0.19.0...rattler_networking-v0.19.1) - 2024-03-06
+## [0.19.1](https://github.com/conda/rattler/compare/rattler_networking-v0.19.0...rattler_networking-v0.19.1) - 2024-03-06
 
 ### Fixed
-- add snapshot test and use btreemap in file backend ([#543](https://github.com/conda-incubator/rattler/pull/543))
+- add snapshot test and use btreemap in file backend ([#543](https://github.com/conda/rattler/pull/543))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_networking-v0.18.0...rattler_networking-v0.19.0) - 2024-02-26
 

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -20,122 +20,122 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - mark some crates 1.0 ([#789](https://github.com/baszalmstra/rattler/pull/789))
 
-## [0.21.7](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.21.6...rattler_package_streaming-v0.21.7) - 2024-07-23
+## [0.21.7](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.21.6...rattler_package_streaming-v0.21.7) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.21.6](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.21.5...rattler_package_streaming-v0.21.6) - 2024-07-23
+## [0.21.6](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.21.5...rattler_package_streaming-v0.21.6) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.21.5](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.21.4...rattler_package_streaming-v0.21.5) - 2024-07-15
+## [0.21.5](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.21.4...rattler_package_streaming-v0.21.5) - 2024-07-15
 
 ### Other
-- bump zip to 2.1.3 ([#772](https://github.com/conda-incubator/rattler/pull/772))
+- bump zip to 2.1.3 ([#772](https://github.com/conda/rattler/pull/772))
 
-## [0.21.4](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.21.3...rattler_package_streaming-v0.21.4) - 2024-07-08
+## [0.21.4](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.21.3...rattler_package_streaming-v0.21.4) - 2024-07-08
 
 ### Fixed
-- run clippy on all targets ([#762](https://github.com/conda-incubator/rattler/pull/762))
+- run clippy on all targets ([#762](https://github.com/conda/rattler/pull/762))
 
 ## [0.21.3](https://github.com/baszalmstra/rattler/compare/rattler_package_streaming-v0.21.2...rattler_package_streaming-v0.21.3) - 2024-06-04
 
 ### Other
 - remove lfs ([#512](https://github.com/baszalmstra/rattler/pull/512))
 
-## [0.21.2](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.21.1...rattler_package_streaming-v0.21.2) - 2024-06-03
+## [0.21.2](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.21.1...rattler_package_streaming-v0.21.2) - 2024-06-03
 
 ### Fixed
-- call on_download_start also for file URLs ([#708](https://github.com/conda-incubator/rattler/pull/708))
+- call on_download_start also for file URLs ([#708](https://github.com/conda/rattler/pull/708))
 
-## [0.21.1](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.21.0...rattler_package_streaming-v0.21.1) - 2024-05-28
+## [0.21.1](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.21.0...rattler_package_streaming-v0.21.1) - 2024-05-28
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.21.0](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.10...rattler_package_streaming-v0.21.0) - 2024-05-27
+## [0.21.0](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.10...rattler_package_streaming-v0.21.0) - 2024-05-27
 
 ### Other
-- introducing the installer ([#664](https://github.com/conda-incubator/rattler/pull/664))
+- introducing the installer ([#664](https://github.com/conda/rattler/pull/664))
 
-## [0.20.10](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.9...rattler_package_streaming-v0.20.10) - 2024-05-14
-
-### Added
-- exclude repodata records based on timestamp ([#654](https://github.com/conda-incubator/rattler/pull/654))
-
-## [0.20.9](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.8...rattler_package_streaming-v0.20.9) - 2024-05-13
+## [0.20.10](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.9...rattler_package_streaming-v0.20.10) - 2024-05-14
 
 ### Added
-- high level repodata access ([#560](https://github.com/conda-incubator/rattler/pull/560))
+- exclude repodata records based on timestamp ([#654](https://github.com/conda/rattler/pull/654))
+
+## [0.20.9](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.8...rattler_package_streaming-v0.20.9) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/conda/rattler/pull/560))
 
 ### Fixed
-- set last modified for zip archive ([#649](https://github.com/conda-incubator/rattler/pull/649))
+- set last modified for zip archive ([#649](https://github.com/conda/rattler/pull/649))
 
 ### Other
 - update README.md
 
-## [0.20.8](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.7...rattler_package_streaming-v0.20.8) - 2024-05-06
+## [0.20.8](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.7...rattler_package_streaming-v0.20.8) - 2024-05-06
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_networking
 
-## [0.20.7](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.6...rattler_package_streaming-v0.20.7) - 2024-04-30
+## [0.20.7](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.6...rattler_package_streaming-v0.20.7) - 2024-04-30
 
 ### Other
 - updated the following local packages: rattler_networking
 
-## [0.20.6](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.5...rattler_package_streaming-v0.20.6) - 2024-04-25
+## [0.20.6](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.5...rattler_package_streaming-v0.20.6) - 2024-04-25
 
 ### Other
 - updated the following local packages: rattler_networking
 
-## [0.20.5](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.4...rattler_package_streaming-v0.20.5) - 2024-04-25
+## [0.20.5](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.4...rattler_package_streaming-v0.20.5) - 2024-04-25
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.4](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.3...rattler_package_streaming-v0.20.4) - 2024-04-19
+## [0.20.4](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.3...rattler_package_streaming-v0.20.4) - 2024-04-19
 
 ### Other
-- update dependencies incl. reqwest ([#606](https://github.com/conda-incubator/rattler/pull/606))
+- update dependencies incl. reqwest ([#606](https://github.com/conda/rattler/pull/606))
 
 ## [0.20.3](https://github.com/baszalmstra/rattler/compare/rattler_package_streaming-v0.20.2...rattler_package_streaming-v0.20.3) - 2024-04-05
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_networking
 
-## [0.20.2](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.1...rattler_package_streaming-v0.20.2) - 2024-03-30
+## [0.20.2](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.1...rattler_package_streaming-v0.20.2) - 2024-03-30
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.1](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.20.0...rattler_package_streaming-v0.20.1) - 2024-03-21
+## [0.20.1](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.20.0...rattler_package_streaming-v0.20.1) - 2024-03-21
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_networking
 
-## [0.20.0](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.19.2...rattler_package_streaming-v0.20.0) - 2024-03-14
+## [0.20.0](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.19.2...rattler_package_streaming-v0.20.0) - 2024-03-14
 
 ### Added
-- add mirror handling and OCI mirror type ([#553](https://github.com/conda-incubator/rattler/pull/553))
+- add mirror handling and OCI mirror type ([#553](https://github.com/conda/rattler/pull/553))
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.19.1...rattler_package_streaming-v0.19.2) - 2024-03-08
+## [0.19.2](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.19.1...rattler_package_streaming-v0.19.2) - 2024-03-08
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler_package_streaming-v0.19.0...rattler_package_streaming-v0.19.1) - 2024-03-06
+## [0.19.1](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.19.0...rattler_package_streaming-v0.19.1) - 2024-03-06
 
 ### Fixed
-- dont use workspace dependencies for local crates ([#546](https://github.com/conda-incubator/rattler/pull/546))
+- dont use workspace dependencies for local crates ([#546](https://github.com/conda/rattler/pull/546))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_package_streaming-v0.18.0...rattler_package_streaming-v0.19.0) - 2024-02-26
 

--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -19,7 +19,7 @@ use zip::result::ZipError;
 /// to find the compressed data length.
 /// Since we stream the package over a non seekable HTTP connection, this condition will cause an error during
 /// decompression. In this case, we fallback to reading the whole data to a buffer before attempting decompression.
-/// Read more in https://github.com/conda-incubator/rattler/issues/794
+/// Read more in https://github.com/conda/rattler/issues/794
 const DATA_DESCRIPTOR_ERROR_MESSAGE: &str = "The file length is not available in the local header";
 
 fn error_for_status(response: reqwest::Response) -> reqwest_middleware::Result<Response> {
@@ -154,7 +154,7 @@ pub async fn extract_conda(
             }
             Ok(result)
         }
-        // https://github.com/conda-incubator/rattler/issues/794
+        // https://github.com/conda/rattler/issues/794
         Err(ExtractError::ZipError(ZipError::UnsupportedArchive(zip_error)))
             if (zip_error.contains(DATA_DESCRIPTOR_ERROR_MESSAGE)) =>
         {

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -19,134 +19,134 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - mark some crates 1.0 ([#789](https://github.com/baszalmstra/rattler/pull/789))
 
-## [0.21.3](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.21.2...rattler_repodata_gateway-v0.21.3) - 2024-07-23
+## [0.21.3](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.2...rattler_repodata_gateway-v0.21.3) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.21.2](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.21.1...rattler_repodata_gateway-v0.21.2) - 2024-07-23
+## [0.21.2](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.1...rattler_repodata_gateway-v0.21.2) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.21.1](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.21.0...rattler_repodata_gateway-v0.21.1) - 2024-07-15
+## [0.21.1](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.0...rattler_repodata_gateway-v0.21.1) - 2024-07-15
 
 ### Other
-- bump dependencies and remove unused ones ([#771](https://github.com/conda-incubator/rattler/pull/771))
+- bump dependencies and remove unused ones ([#771](https://github.com/conda/rattler/pull/771))
 
-## [0.21.0](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.20.5...rattler_repodata_gateway-v0.21.0) - 2024-07-08
+## [0.21.0](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.20.5...rattler_repodata_gateway-v0.21.0) - 2024-07-08
 
 ### Added
-- improve error message when parsing file name ([#757](https://github.com/conda-incubator/rattler/pull/757))
-- add direct url repodata building ([#725](https://github.com/conda-incubator/rattler/pull/725))
-- add shards_base_url and write shards atomically ([#747](https://github.com/conda-incubator/rattler/pull/747))
+- improve error message when parsing file name ([#757](https://github.com/conda/rattler/pull/757))
+- add direct url repodata building ([#725](https://github.com/conda/rattler/pull/725))
+- add shards_base_url and write shards atomically ([#747](https://github.com/conda/rattler/pull/747))
 
 ### Fixed
-- direct_url query for windows ([#768](https://github.com/conda-incubator/rattler/pull/768))
-- Fix GatewayQuery.query to filter records based on provided specs ([#756](https://github.com/conda-incubator/rattler/pull/756))
-- run clippy on all targets ([#762](https://github.com/conda-incubator/rattler/pull/762))
-- allow empty json repodata ([#745](https://github.com/conda-incubator/rattler/pull/745))
+- direct_url query for windows ([#768](https://github.com/conda/rattler/pull/768))
+- Fix GatewayQuery.query to filter records based on provided specs ([#756](https://github.com/conda/rattler/pull/756))
+- run clippy on all targets ([#762](https://github.com/conda/rattler/pull/762))
+- allow empty json repodata ([#745](https://github.com/conda/rattler/pull/745))
 
 ### Other
-- document gateway features ([#737](https://github.com/conda-incubator/rattler/pull/737))
+- document gateway features ([#737](https://github.com/conda/rattler/pull/737))
 
 ## [0.20.5](https://github.com/baszalmstra/rattler/compare/rattler_repodata_gateway-v0.20.4...rattler_repodata_gateway-v0.20.5) - 2024-06-04
 
 ### Other
 - remove lfs ([#512](https://github.com/baszalmstra/rattler/pull/512))
 
-## [0.20.4](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.20.3...rattler_repodata_gateway-v0.20.4) - 2024-06-03
+## [0.20.4](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.20.3...rattler_repodata_gateway-v0.20.4) - 2024-06-03
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_conda_types
 
-## [0.20.3](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.20.2...rattler_repodata_gateway-v0.20.3) - 2024-05-28
+## [0.20.3](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.20.2...rattler_repodata_gateway-v0.20.3) - 2024-05-28
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_conda_types
 
-## [0.20.2](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.20.1...rattler_repodata_gateway-v0.20.2) - 2024-05-27
+## [0.20.2](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.20.1...rattler_repodata_gateway-v0.20.2) - 2024-05-27
 
 ### Fixed
-- result grouped by subdir instead of channel ([#666](https://github.com/conda-incubator/rattler/pull/666))
+- result grouped by subdir instead of channel ([#666](https://github.com/conda/rattler/pull/666))
 
 ### Other
-- introducing the installer ([#664](https://github.com/conda-incubator/rattler/pull/664))
+- introducing the installer ([#664](https://github.com/conda/rattler/pull/664))
 
-## [0.20.1](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.20.0...rattler_repodata_gateway-v0.20.1) - 2024-05-14
-
-### Added
-- exclude repodata records based on timestamp ([#654](https://github.com/conda-incubator/rattler/pull/654))
-
-## [0.20.0](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.11...rattler_repodata_gateway-v0.20.0) - 2024-05-13
+## [0.20.1](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.20.0...rattler_repodata_gateway-v0.20.1) - 2024-05-14
 
 ### Added
-- add clear subdir cache function to repodata gateway ([#650](https://github.com/conda-incubator/rattler/pull/650))
-- high level repodata access ([#560](https://github.com/conda-incubator/rattler/pull/560))
+- exclude repodata records based on timestamp ([#654](https://github.com/conda/rattler/pull/654))
+
+## [0.20.0](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.11...rattler_repodata_gateway-v0.20.0) - 2024-05-13
+
+### Added
+- add clear subdir cache function to repodata gateway ([#650](https://github.com/conda/rattler/pull/650))
+- high level repodata access ([#560](https://github.com/conda/rattler/pull/560))
 
 ### Other
 - update README.md
 
-## [0.19.11](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.10...rattler_repodata_gateway-v0.19.11) - 2024-05-06
+## [0.19.11](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.10...rattler_repodata_gateway-v0.19.11) - 2024-05-06
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_networking
 
-## [0.19.10](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.9...rattler_repodata_gateway-v0.19.10) - 2024-04-30
+## [0.19.10](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.9...rattler_repodata_gateway-v0.19.10) - 2024-04-30
 
 ### Added
-- create SparseRepoData from byte slices ([#624](https://github.com/conda-incubator/rattler/pull/624))
+- create SparseRepoData from byte slices ([#624](https://github.com/conda/rattler/pull/624))
 
-## [0.19.9](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.8...rattler_repodata_gateway-v0.19.9) - 2024-04-25
+## [0.19.9](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.8...rattler_repodata_gateway-v0.19.9) - 2024-04-25
 
 ### Other
 - updated the following local packages: rattler_networking
 
-## [0.19.8](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.7...rattler_repodata_gateway-v0.19.8) - 2024-04-25
+## [0.19.8](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.7...rattler_repodata_gateway-v0.19.8) - 2024-04-25
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.7](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.6...rattler_repodata_gateway-v0.19.7) - 2024-04-19
+## [0.19.7](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.6...rattler_repodata_gateway-v0.19.7) - 2024-04-19
 
 ### Added
-- make root dir configurable in channel config ([#602](https://github.com/conda-incubator/rattler/pull/602))
+- make root dir configurable in channel config ([#602](https://github.com/conda/rattler/pull/602))
 
 ### Other
-- update dependencies incl. reqwest ([#606](https://github.com/conda-incubator/rattler/pull/606))
+- update dependencies incl. reqwest ([#606](https://github.com/conda/rattler/pull/606))
 
 ## [0.19.6](https://github.com/baszalmstra/rattler/compare/rattler_repodata_gateway-v0.19.5...rattler_repodata_gateway-v0.19.6) - 2024-04-05
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_networking
 
-## [0.19.5](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.4...rattler_repodata_gateway-v0.19.5) - 2024-03-30
+## [0.19.5](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.4...rattler_repodata_gateway-v0.19.5) - 2024-03-30
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.4](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.3...rattler_repodata_gateway-v0.19.4) - 2024-03-21
+## [0.19.4](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.3...rattler_repodata_gateway-v0.19.4) - 2024-03-21
 
 ### Other
 - updated the following local packages: rattler_conda_types, rattler_networking
 
-## [0.19.3](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.2...rattler_repodata_gateway-v0.19.3) - 2024-03-14
+## [0.19.3](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.2...rattler_repodata_gateway-v0.19.3) - 2024-03-14
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.1...rattler_repodata_gateway-v0.19.2) - 2024-03-08
-
-### Fixed
-- chrono deprecation warnings ([#558](https://github.com/conda-incubator/rattler/pull/558))
-
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler_repodata_gateway-v0.19.0...rattler_repodata_gateway-v0.19.1) - 2024-03-06
+## [0.19.2](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.1...rattler_repodata_gateway-v0.19.2) - 2024-03-08
 
 ### Fixed
-- correct condition to downweigh track-feature packages ([#545](https://github.com/conda-incubator/rattler/pull/545))
-- dont use workspace dependencies for local crates ([#546](https://github.com/conda-incubator/rattler/pull/546))
+- chrono deprecation warnings ([#558](https://github.com/conda/rattler/pull/558))
+
+## [0.19.1](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.19.0...rattler_repodata_gateway-v0.19.1) - 2024-03-06
+
+### Fixed
+- correct condition to downweigh track-feature packages ([#545](https://github.com/conda/rattler/pull/545))
+- dont use workspace dependencies for local crates ([#546](https://github.com/conda/rattler/pull/546))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_repodata_gateway-v0.18.0...rattler_repodata_gateway-v0.19.0) - 2024-02-26

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -16,108 +16,108 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.21.3](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.21.2...rattler_shell-v0.21.3) - 2024-07-23
+## [0.21.3](https://github.com/conda/rattler/compare/rattler_shell-v0.21.2...rattler_shell-v0.21.3) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.21.2](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.21.1...rattler_shell-v0.21.2) - 2024-07-23
+## [0.21.2](https://github.com/conda/rattler/compare/rattler_shell-v0.21.1...rattler_shell-v0.21.2) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.21.1](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.21.0...rattler_shell-v0.21.1) - 2024-07-15
+## [0.21.1](https://github.com/conda/rattler/compare/rattler_shell-v0.21.0...rattler_shell-v0.21.1) - 2024-07-15
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.21.0](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.20.9...rattler_shell-v0.21.0) - 2024-07-08
+## [0.21.0](https://github.com/conda/rattler/compare/rattler_shell-v0.20.9...rattler_shell-v0.21.0) - 2024-07-08
 
 ### Added
-- add direct url repodata building ([#725](https://github.com/conda-incubator/rattler/pull/725))
-- allow passing custom environment to run_activation ([#743](https://github.com/conda-incubator/rattler/pull/743))
+- add direct url repodata building ([#725](https://github.com/conda/rattler/pull/725))
+- allow passing custom environment to run_activation ([#743](https://github.com/conda/rattler/pull/743))
 
-## [0.20.9](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.20.8...rattler_shell-v0.20.9) - 2024-06-06
+## [0.20.9](https://github.com/conda/rattler/compare/rattler_shell-v0.20.8...rattler_shell-v0.20.9) - 2024-06-06
 
 ### Other
-- make `prefix_paths_entries` pub ([#729](https://github.com/conda-incubator/rattler/pull/729))
+- make `prefix_paths_entries` pub ([#729](https://github.com/conda/rattler/pull/729))
 
 ## [0.20.8](https://github.com/baszalmstra/rattler/compare/rattler_shell-v0.20.7...rattler_shell-v0.20.8) - 2024-06-04
 
 ### Fixed
 - nushell environment variable quoting ([#719](https://github.com/baszalmstra/rattler/pull/719))
 
-## [0.20.7](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.20.6...rattler_shell-v0.20.7) - 2024-06-03
+## [0.20.7](https://github.com/conda/rattler/compare/rattler_shell-v0.20.6...rattler_shell-v0.20.7) - 2024-06-03
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.6](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.20.5...rattler_shell-v0.20.6) - 2024-05-28
+## [0.20.6](https://github.com/conda/rattler/compare/rattler_shell-v0.20.5...rattler_shell-v0.20.6) - 2024-05-28
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.5](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.20.4...rattler_shell-v0.20.5) - 2024-05-27
+## [0.20.5](https://github.com/conda/rattler/compare/rattler_shell-v0.20.4...rattler_shell-v0.20.5) - 2024-05-27
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.4](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.20.3...rattler_shell-v0.20.4) - 2024-05-14
+## [0.20.4](https://github.com/conda/rattler/compare/rattler_shell-v0.20.3...rattler_shell-v0.20.4) - 2024-05-14
 
 ### Added
-- exclude repodata records based on timestamp ([#654](https://github.com/conda-incubator/rattler/pull/654))
+- exclude repodata records based on timestamp ([#654](https://github.com/conda/rattler/pull/654))
 
-## [0.20.3](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.20.2...rattler_shell-v0.20.3) - 2024-05-13
-
-### Other
-- updated the following local packages: rattler_conda_types
-
-## [0.20.2](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.20.1...rattler_shell-v0.20.2) - 2024-05-06
+## [0.20.3](https://github.com/conda/rattler/compare/rattler_shell-v0.20.2...rattler_shell-v0.20.3) - 2024-05-13
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.1](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.20.0...rattler_shell-v0.20.1) - 2024-04-25
+## [0.20.2](https://github.com/conda/rattler/compare/rattler_shell-v0.20.1...rattler_shell-v0.20.2) - 2024-05-06
+
+### Other
+- updated the following local packages: rattler_conda_types
+
+## [0.20.1](https://github.com/conda/rattler/compare/rattler_shell-v0.20.0...rattler_shell-v0.20.1) - 2024-04-25
 
 ### Fixed
-- compare `UrlOrPath` ([#618](https://github.com/conda-incubator/rattler/pull/618))
+- compare `UrlOrPath` ([#618](https://github.com/conda/rattler/pull/618))
 
-## [0.20.0](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.19.6...rattler_shell-v0.20.0) - 2024-04-19
+## [0.20.0](https://github.com/conda/rattler/compare/rattler_shell-v0.19.6...rattler_shell-v0.20.0) - 2024-04-19
 
 ### Fixed
-- unicode activation issues on windows ([#604](https://github.com/conda-incubator/rattler/pull/604))
+- unicode activation issues on windows ([#604](https://github.com/conda/rattler/pull/604))
 
 ## [0.19.6](https://github.com/baszalmstra/rattler/compare/rattler_shell-v0.19.5...rattler_shell-v0.19.6) - 2024-04-05
 
 ### Fixed
 - run post-link scripts ([#574](https://github.com/baszalmstra/rattler/pull/574))
 
-## [0.19.5](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.19.4...rattler_shell-v0.19.5) - 2024-03-30
+## [0.19.5](https://github.com/conda/rattler/compare/rattler_shell-v0.19.4...rattler_shell-v0.19.5) - 2024-03-30
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.4](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.19.3...rattler_shell-v0.19.4) - 2024-03-21
+## [0.19.4](https://github.com/conda/rattler/compare/rattler_shell-v0.19.3...rattler_shell-v0.19.4) - 2024-03-21
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.3](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.19.2...rattler_shell-v0.19.3) - 2024-03-14
+## [0.19.3](https://github.com/conda/rattler/compare/rattler_shell-v0.19.2...rattler_shell-v0.19.3) - 2024-03-14
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.19.1...rattler_shell-v0.19.2) - 2024-03-08
-
-### Fixed
-- better handle utf8 paths in CmdExe and Powershell ([#561](https://github.com/conda-incubator/rattler/pull/561))
-
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler_shell-v0.19.0...rattler_shell-v0.19.1) - 2024-03-06
+## [0.19.2](https://github.com/conda/rattler/compare/rattler_shell-v0.19.1...rattler_shell-v0.19.2) - 2024-03-08
 
 ### Fixed
-- dont use workspace dependencies for local crates ([#546](https://github.com/conda-incubator/rattler/pull/546))
+- better handle utf8 paths in CmdExe and Powershell ([#561](https://github.com/conda/rattler/pull/561))
+
+## [0.19.1](https://github.com/conda/rattler/compare/rattler_shell-v0.19.0...rattler_shell-v0.19.1) - 2024-03-06
+
+### Fixed
+- dont use workspace dependencies for local crates ([#546](https://github.com/conda/rattler/pull/546))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_shell-v0.18.0...rattler_shell-v0.19.0) - 2024-02-26

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -16,148 +16,148 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - constraints on virtual packages were ignored ([#795](https://github.com/baszalmstra/rattler/pull/795))
 
-## [0.25.3](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.25.2...rattler_solve-v0.25.3) - 2024-07-23
+## [0.25.3](https://github.com/conda/rattler/compare/rattler_solve-v0.25.2...rattler_solve-v0.25.3) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.25.2](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.25.1...rattler_solve-v0.25.2) - 2024-07-23
+## [0.25.2](https://github.com/conda/rattler/compare/rattler_solve-v0.25.1...rattler_solve-v0.25.2) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.25.1](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.25.0...rattler_solve-v0.25.1) - 2024-07-15
+## [0.25.1](https://github.com/conda/rattler/compare/rattler_solve-v0.25.0...rattler_solve-v0.25.1) - 2024-07-15
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.25.0](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.24.2...rattler_solve-v0.25.0) - 2024-07-08
+## [0.25.0](https://github.com/conda/rattler/compare/rattler_solve-v0.24.2...rattler_solve-v0.25.0) - 2024-07-08
 
 ### Added
-- add direct url repodata building ([#725](https://github.com/conda-incubator/rattler/pull/725))
-- add tool to generate resolvo snapshots ([#741](https://github.com/conda-incubator/rattler/pull/741))
+- add direct url repodata building ([#725](https://github.com/conda/rattler/pull/725))
+- add tool to generate resolvo snapshots ([#741](https://github.com/conda/rattler/pull/741))
 
 ### Fixed
-- run clippy on all targets ([#762](https://github.com/conda-incubator/rattler/pull/762))
-- This fixes parsing of `ray[default,data] >=2.9.0,<3.0.0` ([#732](https://github.com/conda-incubator/rattler/pull/732))
+- run clippy on all targets ([#762](https://github.com/conda/rattler/pull/762))
+- This fixes parsing of `ray[default,data] >=2.9.0,<3.0.0` ([#732](https://github.com/conda/rattler/pull/732))
 
 ### Other
-- bump resolvo to 0.6.0 ([#733](https://github.com/conda-incubator/rattler/pull/733))
-- Document all features on docs.rs ([#734](https://github.com/conda-incubator/rattler/pull/734))
+- bump resolvo to 0.6.0 ([#733](https://github.com/conda/rattler/pull/733))
+- Document all features on docs.rs ([#734](https://github.com/conda/rattler/pull/734))
 
-## [0.24.2](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.24.1...rattler_solve-v0.24.2) - 2024-06-06
+## [0.24.2](https://github.com/conda/rattler/compare/rattler_solve-v0.24.1...rattler_solve-v0.24.2) - 2024-06-06
 
 ### Added
-- serialize packages from lock file individually ([#728](https://github.com/conda-incubator/rattler/pull/728))
+- serialize packages from lock file individually ([#728](https://github.com/conda/rattler/pull/728))
 
 ## [0.24.1](https://github.com/baszalmstra/rattler/compare/rattler_solve-v0.24.0...rattler_solve-v0.24.1) - 2024-06-04
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.24.0](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.23.2...rattler_solve-v0.24.0) - 2024-06-03
+## [0.24.0](https://github.com/conda/rattler/compare/rattler_solve-v0.23.2...rattler_solve-v0.24.0) - 2024-06-03
 
 ### Added
-- add constraints to solve ([#713](https://github.com/conda-incubator/rattler/pull/713))
+- add constraints to solve ([#713](https://github.com/conda/rattler/pull/713))
 
-## [0.23.2](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.23.1...rattler_solve-v0.23.2) - 2024-05-28
+## [0.23.2](https://github.com/conda/rattler/compare/rattler_solve-v0.23.1...rattler_solve-v0.23.2) - 2024-05-28
 
 ### Fixed
-- ChannelPriority implements Debug ([#701](https://github.com/conda-incubator/rattler/pull/701))
+- ChannelPriority implements Debug ([#701](https://github.com/conda/rattler/pull/701))
 
-## [0.23.1](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.23.0...rattler_solve-v0.23.1) - 2024-05-28
+## [0.23.1](https://github.com/conda/rattler/compare/rattler_solve-v0.23.0...rattler_solve-v0.23.1) - 2024-05-28
 
 ### Added
-- add run exports to package data ([#671](https://github.com/conda-incubator/rattler/pull/671))
+- add run exports to package data ([#671](https://github.com/conda/rattler/pull/671))
 
 ### Other
-- enable serialization of enums ([#698](https://github.com/conda-incubator/rattler/pull/698))
+- enable serialization of enums ([#698](https://github.com/conda/rattler/pull/698))
 
-## [0.23.0](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.22.0...rattler_solve-v0.23.0) - 2024-05-27
+## [0.23.0](https://github.com/conda/rattler/compare/rattler_solve-v0.22.0...rattler_solve-v0.23.0) - 2024-05-27
 
 ### Added
-- removed Ord and more ([#673](https://github.com/conda-incubator/rattler/pull/673))
-- always store purls as a key in lock file ([#669](https://github.com/conda-incubator/rattler/pull/669))
-- add solve strategies ([#660](https://github.com/conda-incubator/rattler/pull/660))
+- removed Ord and more ([#673](https://github.com/conda/rattler/pull/673))
+- always store purls as a key in lock file ([#669](https://github.com/conda/rattler/pull/669))
+- add solve strategies ([#660](https://github.com/conda/rattler/pull/660))
 
 ### Fixed
-- result grouped by subdir instead of channel ([#666](https://github.com/conda-incubator/rattler/pull/666))
+- result grouped by subdir instead of channel ([#666](https://github.com/conda/rattler/pull/666))
 
 ### Other
-- introducing the installer ([#664](https://github.com/conda-incubator/rattler/pull/664))
+- introducing the installer ([#664](https://github.com/conda/rattler/pull/664))
 
-## [0.22.0](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.21.2...rattler_solve-v0.22.0) - 2024-05-14
-
-### Added
-- exclude repodata records based on timestamp ([#654](https://github.com/conda-incubator/rattler/pull/654))
-
-## [0.21.2](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.21.1...rattler_solve-v0.21.2) - 2024-05-13
+## [0.22.0](https://github.com/conda/rattler/compare/rattler_solve-v0.21.2...rattler_solve-v0.22.0) - 2024-05-14
 
 ### Added
-- high level repodata access ([#560](https://github.com/conda-incubator/rattler/pull/560))
+- exclude repodata records based on timestamp ([#654](https://github.com/conda/rattler/pull/654))
+
+## [0.21.2](https://github.com/conda/rattler/compare/rattler_solve-v0.21.1...rattler_solve-v0.21.2) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/conda/rattler/pull/560))
 
 ### Other
 - update README.md
 
-## [0.21.1](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.21.0...rattler_solve-v0.21.1) - 2024-05-06
+## [0.21.1](https://github.com/conda/rattler/compare/rattler_solve-v0.21.0...rattler_solve-v0.21.1) - 2024-05-06
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.21.0](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.20.7...rattler_solve-v0.21.0) - 2024-04-25
+## [0.21.0](https://github.com/conda/rattler/compare/rattler_solve-v0.20.7...rattler_solve-v0.21.0) - 2024-04-25
 
 ### Added
-- add channel priority to solve task and expose to python solve ([#598](https://github.com/conda-incubator/rattler/pull/598))
+- add channel priority to solve task and expose to python solve ([#598](https://github.com/conda/rattler/pull/598))
 
-## [0.20.7](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.20.6...rattler_solve-v0.20.7) - 2024-04-25
+## [0.20.7](https://github.com/conda/rattler/compare/rattler_solve-v0.20.6...rattler_solve-v0.20.7) - 2024-04-25
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.6](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.20.5...rattler_solve-v0.20.6) - 2024-04-19
+## [0.20.6](https://github.com/conda/rattler/compare/rattler_solve-v0.20.5...rattler_solve-v0.20.6) - 2024-04-19
 
 ### Added
-- make root dir configurable in channel config ([#602](https://github.com/conda-incubator/rattler/pull/602))
+- make root dir configurable in channel config ([#602](https://github.com/conda/rattler/pull/602))
 
 ### Other
-- update dependencies incl. reqwest ([#606](https://github.com/conda-incubator/rattler/pull/606))
+- update dependencies incl. reqwest ([#606](https://github.com/conda/rattler/pull/606))
 
 ## [0.20.5](https://github.com/baszalmstra/rattler/compare/rattler_solve-v0.20.4...rattler_solve-v0.20.5) - 2024-04-05
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.4](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.20.3...rattler_solve-v0.20.4) - 2024-03-30
+## [0.20.4](https://github.com/conda/rattler/compare/rattler_solve-v0.20.3...rattler_solve-v0.20.4) - 2024-03-30
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.3](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.20.2...rattler_solve-v0.20.3) - 2024-03-21
+## [0.20.3](https://github.com/conda/rattler/compare/rattler_solve-v0.20.2...rattler_solve-v0.20.3) - 2024-03-21
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.20.2](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.20.1...rattler_solve-v0.20.2) - 2024-03-14
+## [0.20.2](https://github.com/conda/rattler/compare/rattler_solve-v0.20.1...rattler_solve-v0.20.2) - 2024-03-14
 
 ### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
 
-## [0.20.1](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.20.0...rattler_solve-v0.20.1) - 2024-03-08
+## [0.20.1](https://github.com/conda/rattler/compare/rattler_solve-v0.20.0...rattler_solve-v0.20.1) - 2024-03-08
 
 ### Other
 - update Cargo.toml dependencies
 
-## [0.20.0](https://github.com/conda-incubator/rattler/compare/rattler_solve-v0.19.0...rattler_solve-v0.20.0) - 2024-03-06
+## [0.20.0](https://github.com/conda/rattler/compare/rattler_solve-v0.19.0...rattler_solve-v0.20.0) - 2024-03-06
 
 ### Added
-- [**breaking**] optional strict parsing of matchspec and versionspec ([#552](https://github.com/conda-incubator/rattler/pull/552))
+- [**breaking**] optional strict parsing of matchspec and versionspec ([#552](https://github.com/conda/rattler/pull/552))
 
 ### Fixed
-- removal of multiple packages that clobber each other ([#556](https://github.com/conda-incubator/rattler/pull/556))
-- correct condition to downweigh track-feature packages ([#545](https://github.com/conda-incubator/rattler/pull/545))
-- dont use workspace dependencies for local crates ([#546](https://github.com/conda-incubator/rattler/pull/546))
+- removal of multiple packages that clobber each other ([#556](https://github.com/conda/rattler/pull/556))
+- correct condition to downweigh track-feature packages ([#545](https://github.com/conda/rattler/pull/545))
+- dont use workspace dependencies for local crates ([#546](https://github.com/conda/rattler/pull/546))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_solve-v0.18.0...rattler_solve-v0.19.0) - 2024-02-26

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -16,110 +16,110 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.20](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.19...rattler_virtual_packages-v0.19.20) - 2024-07-23
+## [0.19.20](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.19...rattler_virtual_packages-v0.19.20) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.19](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.18...rattler_virtual_packages-v0.19.19) - 2024-07-23
+## [0.19.19](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.18...rattler_virtual_packages-v0.19.19) - 2024-07-23
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.18](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.17...rattler_virtual_packages-v0.19.18) - 2024-07-16
+## [0.19.18](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.17...rattler_virtual_packages-v0.19.18) - 2024-07-16
 
 ### Fixed
-- add gentoo support for glibc ([#779](https://github.com/conda-incubator/rattler/pull/779))
+- add gentoo support for glibc ([#779](https://github.com/conda/rattler/pull/779))
 
-## [0.19.17](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.16...rattler_virtual_packages-v0.19.17) - 2024-07-15
+## [0.19.17](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.16...rattler_virtual_packages-v0.19.17) - 2024-07-15
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.16](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.15...rattler_virtual_packages-v0.19.16) - 2024-07-08
+## [0.19.16](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.15...rattler_virtual_packages-v0.19.16) - 2024-07-08
 
 ### Added
-- add support for zos-z ([#753](https://github.com/conda-incubator/rattler/pull/753))
+- add support for zos-z ([#753](https://github.com/conda/rattler/pull/753))
 
 ### Fixed
-- run clippy on all targets ([#762](https://github.com/conda-incubator/rattler/pull/762))
+- run clippy on all targets ([#762](https://github.com/conda/rattler/pull/762))
 
 ## [0.19.15](https://github.com/baszalmstra/rattler/compare/rattler_virtual_packages-v0.19.14...rattler_virtual_packages-v0.19.15) - 2024-06-04
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.14](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.13...rattler_virtual_packages-v0.19.14) - 2024-06-03
+## [0.19.14](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.13...rattler_virtual_packages-v0.19.14) - 2024-06-03
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.13](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.12...rattler_virtual_packages-v0.19.13) - 2024-05-28
+## [0.19.13](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.12...rattler_virtual_packages-v0.19.13) - 2024-05-28
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.12](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.11...rattler_virtual_packages-v0.19.12) - 2024-05-27
+## [0.19.12](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.11...rattler_virtual_packages-v0.19.12) - 2024-05-27
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.11](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.10...rattler_virtual_packages-v0.19.11) - 2024-05-14
+## [0.19.11](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.10...rattler_virtual_packages-v0.19.11) - 2024-05-14
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.10](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.9...rattler_virtual_packages-v0.19.10) - 2024-05-13
+## [0.19.10](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.9...rattler_virtual_packages-v0.19.10) - 2024-05-13
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.9](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.8...rattler_virtual_packages-v0.19.9) - 2024-05-06
+## [0.19.9](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.8...rattler_virtual_packages-v0.19.9) - 2024-05-06
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.8](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.7...rattler_virtual_packages-v0.19.8) - 2024-04-25
+## [0.19.8](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.7...rattler_virtual_packages-v0.19.8) - 2024-04-25
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.7](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.6...rattler_virtual_packages-v0.19.7) - 2024-04-19
+## [0.19.7](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.6...rattler_virtual_packages-v0.19.7) - 2024-04-19
 
 ### Other
-- update dependencies incl. reqwest ([#606](https://github.com/conda-incubator/rattler/pull/606))
+- update dependencies incl. reqwest ([#606](https://github.com/conda/rattler/pull/606))
 
 ## [0.19.6](https://github.com/baszalmstra/rattler/compare/rattler_virtual_packages-v0.19.5...rattler_virtual_packages-v0.19.6) - 2024-04-05
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.5](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.4...rattler_virtual_packages-v0.19.5) - 2024-03-30
+## [0.19.5](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.4...rattler_virtual_packages-v0.19.5) - 2024-03-30
 
 ### Added
-- proper archspec detection using archspec-rs ([#584](https://github.com/conda-incubator/rattler/pull/584))
+- proper archspec detection using archspec-rs ([#584](https://github.com/conda/rattler/pull/584))
 
-## [0.19.4](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.3...rattler_virtual_packages-v0.19.4) - 2024-03-21
-
-### Other
-- updated the following local packages: rattler_conda_types
-
-## [0.19.3](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.2...rattler_virtual_packages-v0.19.3) - 2024-03-14
-
-### Other
-- add pixi badge ([#563](https://github.com/conda-incubator/rattler/pull/563))
-
-## [0.19.2](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.1...rattler_virtual_packages-v0.19.2) - 2024-03-08
+## [0.19.4](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.3...rattler_virtual_packages-v0.19.4) - 2024-03-21
 
 ### Other
 - updated the following local packages: rattler_conda_types
 
-## [0.19.1](https://github.com/conda-incubator/rattler/compare/rattler_virtual_packages-v0.19.0...rattler_virtual_packages-v0.19.1) - 2024-03-06
+## [0.19.3](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.2...rattler_virtual_packages-v0.19.3) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
+
+## [0.19.2](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.1...rattler_virtual_packages-v0.19.2) - 2024-03-08
+
+### Other
+- updated the following local packages: rattler_conda_types
+
+## [0.19.1](https://github.com/conda/rattler/compare/rattler_virtual_packages-v0.19.0...rattler_virtual_packages-v0.19.1) - 2024-03-06
 
 ### Fixed
-- dont use workspace dependencies for local crates ([#546](https://github.com/conda-incubator/rattler/pull/546))
+- dont use workspace dependencies for local crates ([#546](https://github.com/conda/rattler/pull/546))
 
 ### Other
-- every crate should have its own version ([#557](https://github.com/conda-incubator/rattler/pull/557))
+- every crate should have its own version ([#557](https://github.com/conda/rattler/pull/557))
 
 ## [0.19.0](https://github.com/baszalmstra/rattler/compare/rattler_virtual_packages-v0.18.0...rattler_virtual_packages-v0.19.0) - 2024-02-26

--- a/py-rattler/docs/index.md
+++ b/py-rattler/docs/index.md
@@ -1,8 +1,8 @@
-<a href="https://github.com/conda-incubator/rattler/">
+<a href="https://github.com/conda/rattler/">
     <picture>
-      <source srcset="https://github.com/conda-incubator/rattler/assets/4995967/8f5a9786-f75c-4b55-8043-69c551b22459" type="image/webp">
-      <source srcset="https://github.com/conda-incubator/rattler/assets/4995967/7bb44c97-e77a-452f-9a00-431b7c89e136" type="image/png">
-      <img src="https://github.com/conda-incubator/rattler/assets/4995967/7bb44c97-e77a-452f-9a00-431b7c89e136" alt="banner">
+      <source srcset="https://github.com/conda/rattler/assets/4995967/8f5a9786-f75c-4b55-8043-69c551b22459" type="image/webp">
+      <source srcset="https://github.com/conda/rattler/assets/4995967/7bb44c97-e77a-452f-9a00-431b7c89e136" type="image/png">
+      <img src="https://github.com/conda/rattler/assets/4995967/7bb44c97-e77a-452f-9a00-431b7c89e136" alt="banner">
     </picture>
 </a>
 

--- a/py-rattler/mkdocs.yml
+++ b/py-rattler/mkdocs.yml
@@ -55,7 +55,7 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
-repo_url: https://github.com/conda-incubator/rattler/
+repo_url: https://github.com/conda/rattler/
 edit_uri: edit/main/py-rattler/docs/
 
 markdown_extensions:

--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -23,10 +23,10 @@ classifiers = [
 license = "BSD-3-Clause"
 
 [project.urls]
-Homepage = "https://github.com/conda-incubator/rattler"
+Homepage = "https://github.com/conda/rattler"
 Documentation = "https://conda-incubator.github.io/rattler/py-rattler/"
-Repository = "https://github.com/conda-incubator/rattler"
-Issues = "https://github.com/conda-incubator/rattler/labels/python-bindings"
+Repository = "https://github.com/conda/rattler"
+Issues = "https://github.com/conda/rattler/labels/python-bindings"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/py-rattler/rattler/package/about_json.py
+++ b/py-rattler/rattler/package/about_json.py
@@ -137,7 +137,7 @@ class AboutJson:
         ```python
         >>> about = AboutJson.from_path("../test-data/dummy-about.json")
         >>> about.dev_url
-        ['https://github.com/conda-incubator/rattler']
+        ['https://github.com/conda/rattler']
         >>>
         ```
         """
@@ -169,7 +169,7 @@ class AboutJson:
         ```python
         >>> about = AboutJson.from_path("../test-data/dummy-about.json")
         >>> about.home
-        ['http://github.com/conda-incubator/rattler']
+        ['http://github.com/conda/rattler']
         >>>
         ```
         """
@@ -224,7 +224,7 @@ class AboutJson:
         ```python
         >>> about = AboutJson.from_path("../test-data/dummy-about.json")
         >>> about.source_url
-        'https://github.com/conda-incubator/rattler'
+        'https://github.com/conda/rattler'
         >>>
         ```
         """

--- a/test-data/dummy-about.json
+++ b/test-data/dummy-about.json
@@ -3,10 +3,10 @@
     "https://conda.anaconda.org/conda-forge"
   ],
   "description": "A dummy description.",
-  "dev_url": "https://github.com/conda-incubator/rattler",
+  "dev_url": "https://github.com/conda/rattler",
   "doc_url": "https://conda-incubator.github.io/rattler/py-rattler/",
-  "home": "http://github.com/conda-incubator/rattler",
+  "home": "http://github.com/conda/rattler",
   "license": "BSD-3-Clause",
-  "source_url": "https://github.com/conda-incubator/rattler",
+  "source_url": "https://github.com/conda/rattler",
   "summary": "A dummy summary."
 }


### PR DESCRIPTION
Change all links from `conda-incubator` to `conda`