### PR TITLE
docs(py-rattler): fix example path in mkdocs snippet

### DIFF
--- a/py-rattler/docs/index.md
+++ b/py-rattler/docs/index.md
@@ -21,7 +21,7 @@ Py-rattler is the python bindings for rattler.
 Let's see an example to learn some of the functionality the library has to offer.
 
 ```python
---8<-- "examples\solve_and_install.py"
+--8<-- "examples/solve_and_install.py"
 ```
 
 Py-rattler provides friendly high level functions to download dependencies and create environments.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fixing the example in the quickstart

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
