### PR TITLE
fix: move more links to the conda org from conda-incubator

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    if: github.repository == 'conda-incubator/rattler'
+    if: github.repository == 'conda/rattler'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,7 +258,7 @@ Lock file support has been moved into its own crate (rattler_lock) and support f
 
 ### ✨ Highlights
 
-The solver has been renamed and moved to its own repository: [resolvo](https://github.com/conda-incubator/resolvo).
+The solver has been renamed and moved to its own repository: [resolvo](https://github.com/mamba-org/resolvo).
 With the latest changes to the python bindings you can now download repodata and solve environments! 
 Still no official release of the bindings though, but getting closer every day.
 
@@ -531,7 +531,7 @@ The biggest highlights are:
 JLAP is a file format to incrementally update a cached `repodata.json` without downloading the entire file.
 This can save a huge amount of bandwidth for large repodatas that change often (like those from conda-forge).
 If you have a previously cached `repodata.json` on your system only small JSON patches are downloaded to bring your cache up to date.
-The format was initially proposed through a [CEP](https://github.com/conda-incubator/ceps/pull/20) and has been available in conda as an experimental feature since `23.3.0`.
+The format was initially proposed through a [CEP](https://github.com/conda/ceps/pull/20) and has been available in conda as an experimental feature since `23.3.0`.
 
 When using rattler you get JLAP support out of the box.
 No changes are needed.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 [chat-badge]: https://img.shields.io/discord/1082332781146800168.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2&style=flat-square
 [chat-url]: https://discord.gg/kKV8ZxyzY4
 [docs-main-badge]: https://img.shields.io/badge/rust_docs-main-yellow.svg?style=flat-square
-[docs-main]: https://conda-incubator.github.io/rattler
+[docs-main]: https://conda.github.io/rattler
 [py-docs-main-badge]: https://img.shields.io/badge/python_docs-main-yellow.svg?style=flat-square
-[py-docs-main]: https://conda-incubator.github.io/rattler/py-rattler
+[py-docs-main]: https://conda.github.io/rattler/py-rattler
 [pixi-badge]:https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json
 [pixi-url]: https://pixi.sh
 
@@ -105,7 +105,7 @@ You can find these crates in the `crates` folder.
 
 Additionally, we provide Python bindings for most of the functionalities provided by the above crates.
 A python package `py-rattler` is available on [conda-forge](https://prefix.dev/channels/conda-forge/packages/py-rattler) and [PyPI](https://pypi.org/project/py-rattler/).
-Documatation for the python bindings can be found [here](https://conda-incubator.github.io/rattler/py-rattler).
+Documentation for the python bindings can be found [here](https://conda.github.io/rattler/py-rattler).
 
 ## What is conda & conda-forge?
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -6,7 +6,7 @@
 # See documentation for more information on available options.
 
 [remote.github]
-owner = "conda-incubator"
+owner = "conda"
 repo = "rattler"
 
 [changelog]

--- a/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
@@ -7,7 +7,7 @@
 //! that conda compatible applications use to query conda packages. For more information about
 //! how this file format works, please read this CEP proposal:
 //!
-//! - <https://github.com/conda-incubator/ceps/pull/20/files>
+//! - <https://github.com/conda/ceps/pull/20/files>
 //!
 //! ## Example
 //!

--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -24,7 +24,7 @@ license = "BSD-3-Clause"
 
 [project.urls]
 Homepage = "https://github.com/conda/rattler"
-Documentation = "https://conda-incubator.github.io/rattler/py-rattler/"
+Documentation = "https://conda.github.io/rattler/py-rattler/"
 Repository = "https://github.com/conda/rattler"
 Issues = "https://github.com/conda/rattler/labels/python-bindings"
 

--- a/py-rattler/rattler/package/about_json.py
+++ b/py-rattler/rattler/package/about_json.py
@@ -153,7 +153,7 @@ class AboutJson:
         ```python
         >>> about = AboutJson.from_path("../test-data/dummy-about.json")
         >>> about.doc_url
-        ['https://conda-incubator.github.io/rattler/py-rattler/']
+        ['https://conda.github.io/rattler/py-rattler/']
         >>>
         ```
         """

--- a/test-data/dummy-about.json
+++ b/test-data/dummy-about.json
@@ -4,7 +4,7 @@
   ],
   "description": "A dummy description.",
   "dev_url": "https://github.com/conda/rattler",
-  "doc_url": "https://conda-incubator.github.io/rattler/py-rattler/",
+  "doc_url": "https://conda.github.io/rattler/py-rattler/",
   "home": "http://github.com/conda/rattler",
   "license": "BSD-3-Clause",
   "source_url": "https://github.com/conda/rattler",

--- a/test-data/environments/mamba_dev_extra.environment.yaml
+++ b/test-data/environments/mamba_dev_extra.environment.yaml
@@ -1,4 +1,4 @@
-# https://github.com/conda-incubator/mamba/blob/main/dev/environment-dev-extra.yml
+# https://github.com/mamba-org/mamba/blob/main/dev/environment-dev-extra.yml
 channels:
   - conda-forge
 dependencies:

--- a/test-data/test-server/README.md
+++ b/test-data/test-server/README.md
@@ -1,5 +1,5 @@
 # test-server
 
 A simple server to serve repodata for test purposes.
-Originally implemented by [mamba](https://github.com/conda-incubator/mamba/tree/a8d595b6ff8ac182e60741c3e8cbd142e7d19905/mamba/tests)
+Originally implemented by [mamba](https://github.com/mamba-org/mamba/tree/a8d595b6ff8ac182e60741c3e8cbd142e7d19905/mamba/tests)
 under the BSD-3-Clause license.

--- a/test-data/test-server/repo/channeldata.json
+++ b/test-data/test-server/repo/channeldata.json
@@ -9,7 +9,7 @@
       "dev_url": null,
       "doc_source_url": null,
       "doc_url": null,
-      "home": "https://github.com/conda-incubator/mamba",
+      "home": "https://github.com/mamba-org/mamba",
       "icon_hash": null,
       "icon_url": null,
       "identifiers": null,

--- a/test-data/test-server/repo/index.html
+++ b/test-data/test-server/repo/index.html
@@ -78,7 +78,7 @@
 <th class="tight">noarch</th>      <th>Summary</th>
     </tr>
     <tr>
-      <td class="packagename"><a href="https://github.com/conda-incubator/mamba" alt="test-package">test-package</a></td>
+      <td class="packagename"><a href="https://github.com/mamba-org/mamba" alt="test-package">test-package</a></td>
       <td class="version">0.1</td>
       <td></td>
       <td></td>

--- a/test-data/test-server/repo/recipes/test-package/meta.yaml
+++ b/test-data/test-server/repo/recipes/test-package/meta.yaml
@@ -8,7 +8,7 @@ build:
   noarch: generic
 
 about:
-  home: https://github.com/conda-incubator/mamba
+  home: https://github.com/mamba-org/mamba
   license: BSD
   license_family: BSD
   summary: I am just a test package!

--- a/test-data/test-server/reposerver.py
+++ b/test-data/test-server/reposerver.py
@@ -1,4 +1,4 @@
-# File taken from https://github.com/conda-incubator/mamba/tree/a8d595b6ff8ac182e60741c3e8cbd142e7d19905/mamba/tests
+# File taken from https://github.com/mamba-org/mamba/tree/a8d595b6ff8ac182e60741c3e8cbd142e7d19905/mamba/tests
 # under BSD-3-Clause license
 
 import argparse


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We missed some more `conda-incubator` mentions, also move to much from `mamba-org`. 

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
