### PR TITLE
feat: Add support for `CONDA_OVERRIDE_CUDA`

### DIFF
--- a/crates/rattler_lock/src/utils/serde/pep440_map_or_vec.rs
+++ b/crates/rattler_lock/src/utils/serde/pep440_map_or_vec.rs
@@ -35,7 +35,7 @@ impl<'de> DeserializeAs<'de, Vec<Requirement>> for Pep440MapOrVec {
                         } else {
                             Some(VersionOrUrl::VersionSpecifier(spec))
                         },
-                        marker: Default::default(),
+                        marker: Option::default(),
                         origin: None,
                     })
                 })

--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -19,7 +19,7 @@ use zip::result::ZipError;
 /// to find the compressed data length.
 /// Since we stream the package over a non seekable HTTP connection, this condition will cause an error during
 /// decompression. In this case, we fallback to reading the whole data to a buffer before attempting decompression.
-/// Read more in https://github.com/conda/rattler/issues/794
+/// Read more in <https://github.com/conda/rattler/issues/794>
 const DATA_DESCRIPTOR_ERROR_MESSAGE: &str = "The file length is not available in the local header";
 
 fn error_for_status(response: reqwest::Response) -> reqwest_middleware::Result<Response> {

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -13,7 +13,6 @@ use once_cell::sync::OnceCell;
 use rattler_conda_types::Version;
 use std::process::Command;
 use std::{
-    env,
     mem::MaybeUninit,
     os::raw::{c_int, c_uint, c_ulong},
     str::FromStr,

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -27,14 +27,10 @@ pub fn cuda_version() -> Option<Version> {
         .clone()
 }
 
-const CUDA_OVERRIDE_ENV: &str = "CONDA_OVERRIDE_CUDA";
 /// Attempts to detect the version of CUDA present in the current operating system by employing the
 /// best technique available for the current environment.
 pub fn detect_cuda_version() -> Option<Version> {
-    let cuda_override = env::var(CUDA_OVERRIDE_ENV);
-    if cuda_override.is_ok() {
-        Version::from_str(&cuda_override.unwrap()).ok()
-    } else if cfg!(target_env = "musl") {
+    if cfg!(target_env = "musl") {
         // Dynamically loading a library is not supported on musl so we have to fall-back to using
         // the nvidia-smi command.
         detect_cuda_version_via_nvidia_smi()
@@ -273,16 +269,5 @@ mod test {
     pub fn doesnt_crash_nvidia_smi() {
         let version = detect_cuda_version_via_nvidia_smi();
         println!("Cuda {version:?}");
-    }
-
-    #[test]
-    pub fn cuda_override(){
-        let backup = env::var(CUDA_OVERRIDE_ENV);
-        env::set_var(CUDA_OVERRIDE_ENV, "69.42");
-        let version = detect_cuda_version();
-        assert!(version.unwrap() == Version::from_str("69.42").unwrap());
-        if backup.is_ok() {
-            env::set_var(CUDA_OVERRIDE_ENV, backup.unwrap())
-        }
     }
 }

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -66,7 +66,7 @@ impl<T: From<Version>> EnvOverride for T {
     }
 
     fn default_env_name() -> String {
-        format!("CONDA_{}_OVERIDE", type_name::<T>())
+        format!("CONDA_{}_OVERIDE", type_name::<T>().to_uppercase())
     }
 }
 


### PR DESCRIPTION
### Description

Hi, I know this is terrible, not elegant, etc, but I do think that having support for something in the spirit of CONDA_OVERRIDE_CUDA is necessary on academic HPC environments. Reasons include 
- only having internet access on the login node with no gpu
- launching jobs with submitit on login nodes with no gpu.

I'm not really used to writing rust, so would be greatful for some guidance.

Thanks