### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.27.5", default-features = false, features = ["indicatif"] }
+rattler = { path="../rattler", version = "0.27.6", default-features = false, features = ["indicatif"] }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.27.2", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.21.1", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.7", default-features = false, features = ["gateway"] }
+rattler_networking = { path="../rattler_networking", version = "0.21.2", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.8", default-features = false, features = ["gateway"] }
 rattler_solve = { path="../rattler_solve", version = "1.0.3", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.0.4", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.1.7", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.1.8", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.6](https://github.com/conda/rattler/compare/rattler-v0.27.5...rattler-v0.27.6) - 2024-08-16
+
+### Other
+- updated the following local packages: rattler_networking
+
 ## [0.27.5](https://github.com/conda/rattler/compare/rattler-v0.27.4...rattler-v0.27.5) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.27.5"
+version = "0.27.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.1.7", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.1.8", default-features = false }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.2", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.1", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.2", default-features = false }
 rattler_shell = { path = "../rattler_shell", version = "0.21.6", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.2", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.3", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/conda/rattler/compare/rattler_cache-v0.1.7...rattler_cache-v0.1.8) - 2024-08-16
+
+### Other
+- updated the following local packages: rattler_networking
+
 ## [0.1.7](https://github.com/conda/rattler/compare/rattler_cache-v0.1.6...rattler_cache-v0.1.7) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.1.7"
+version = "0.1.8"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -17,8 +17,8 @@ itertools.workspace = true
 parking_lot.workspace = true
 rattler_conda_types = { version = "0.27.2", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.1", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.21.1", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.2", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_networking = { version = "0.21.2", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.3", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 fs-err = { workspace = true }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.27.2", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.1", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.2", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.3", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.20](https://github.com/conda/rattler/compare/rattler_lock-v0.22.19...rattler_lock-v0.22.20) - 2024-08-16
+
+### Added
+- default construct marker-tree ([#825](https://github.com/conda/rattler/pull/825))
+
 ## [0.22.19](https://github.com/conda/rattler/compare/rattler_lock-v0.22.18...rattler_lock-v0.22.19) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.19"
+version = "0.22.20"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.2](https://github.com/conda/rattler/compare/rattler_networking-v0.21.1...rattler_networking-v0.21.2) - 2024-08-16
+
+### Other
+- bump keyring to 3.x to bump syn to 2.x ([#823](https://github.com/conda/rattler/pull/823))
+
 ## [0.21.1](https://github.com/conda/rattler/compare/rattler_networking-v0.21.0...rattler_networking-v0.21.1) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.21.1"
+version = "0.21.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.3](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.2...rattler_package_streaming-v0.22.3) - 2024-08-16
+
+### Other
+- updated the following local packages: rattler_networking
+
 ## [0.22.2](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.1...rattler_package_streaming-v0.22.2) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.2"
+version = "0.22.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -17,7 +17,7 @@ futures-util = { workspace = true }
 num_cpus = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.2", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.1", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.2", default-features = false }
 rattler_redaction = { version = "0.1.1", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.8](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.7...rattler_repodata_gateway-v0.21.8) - 2024-08-16
+
+### Other
+- updated the following local packages: rattler_networking
+
 ## [0.21.7](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.6...rattler_repodata_gateway-v0.21.7) - 2024-08-16
 
 ### Added

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.7"
+version = "0.21.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -36,7 +36,7 @@ parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.2", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.21.1", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.2", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -52,7 +52,7 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.1.7", path = "../rattler_cache" }
+rattler_cache = { version = "0.1.8", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.1", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
## 🤖 New release
* `rattler_networking`: 0.21.1 -> 0.21.2
* `rattler_lock`: 0.22.19 -> 0.22.20
* `rattler`: 0.27.5 -> 0.27.6
* `rattler_cache`: 0.1.7 -> 0.1.8
* `rattler_package_streaming`: 0.22.2 -> 0.22.3
* `rattler_repodata_gateway`: 0.21.7 -> 0.21.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_networking`
<blockquote>

## [0.21.2](https://github.com/conda/rattler/compare/rattler_networking-v0.21.1...rattler_networking-v0.21.2) - 2024-08-16

### Other
- bump keyring to 3.x to bump syn to 2.x ([#823](https://github.com/conda/rattler/pull/823))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.20](https://github.com/conda/rattler/compare/rattler_lock-v0.22.19...rattler_lock-v0.22.20) - 2024-08-16

### Added
- default construct marker-tree ([#825](https://github.com/conda/rattler/pull/825))
</blockquote>

## `rattler`
<blockquote>

## [0.27.6](https://github.com/conda/rattler/compare/rattler-v0.27.5...rattler-v0.27.6) - 2024-08-16

### Other
- updated the following local packages: rattler_networking
</blockquote>

## `rattler_cache`
<blockquote>

## [0.1.8](https://github.com/conda/rattler/compare/rattler_cache-v0.1.7...rattler_cache-v0.1.8) - 2024-08-16

### Other
- updated the following local packages: rattler_networking
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.22.3](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.2...rattler_package_streaming-v0.22.3) - 2024-08-16

### Other
- updated the following local packages: rattler_networking
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.8](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.7...rattler_repodata_gateway-v0.21.8) - 2024-08-16

### Other
- updated the following local packages: rattler_networking
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).