### PR TITLE
feat: default construct marker-tree

### DIFF
--- a/crates/rattler_lock/src/utils/serde/pep440_map_or_vec.rs
+++ b/crates/rattler_lock/src/utils/serde/pep440_map_or_vec.rs
@@ -35,7 +35,7 @@ impl<'de> DeserializeAs<'de, Vec<Requirement>> for Pep440MapOrVec {
                         } else {
                             Some(VersionOrUrl::VersionSpecifier(spec))
                         },
-                        marker: None,
+                        marker: Default::default(),
                         origin: None,
                     })
                 })


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This change is needed because of further changes in uv to pep440 markers. To make this compatible, we can luckily just do this change.