### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.27.6", default-features = false, features = ["indicatif"] }
+rattler = { path="../rattler", version = "0.27.7", default-features = false, features = ["indicatif"] }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.27.2", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.21.2", default-features = false }
 rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.8", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.0.3", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.0.4", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.1.8", default-features = false }
+rattler_solve = { path="../rattler_solve", version = "1.0.4", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.0", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.1.9", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.7](https://github.com/conda/rattler/compare/rattler-v0.27.6...rattler-v0.27.7) - 2024-08-27
+
+### Other
+- updated the following local packages: rattler_package_streaming
+
 ## [0.27.6](https://github.com/conda/rattler/compare/rattler-v0.27.5...rattler-v0.27.6) - 2024-08-16
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.27.6"
+version = "0.27.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.1.8", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.1.9", default-features = false }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.2", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.21.2", default-features = false }
 rattler_shell = { path = "../rattler_shell", version = "0.21.6", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.3", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.4", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/conda/rattler/compare/rattler_cache-v0.1.8...rattler_cache-v0.1.9) - 2024-08-27
+
+### Other
+- updated the following local packages: rattler_package_streaming
+
 ## [0.1.8](https://github.com/conda/rattler/compare/rattler_cache-v0.1.7...rattler_cache-v0.1.8) - 2024-08-16
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.1.8"
+version = "0.1.9"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,7 +18,7 @@ parking_lot.workspace = true
 rattler_conda_types = { version = "0.27.2", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.1", path = "../rattler_digest", default-features = false }
 rattler_networking = { version = "0.21.2", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.3", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { version = "0.22.4", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.25](https://github.com/conda/rattler/compare/rattler_index-v0.19.24...rattler_index-v0.19.25) - 2024-08-27
+
+### Other
+- release ([#824](https://github.com/conda/rattler/pull/824))
+
 ## [0.19.24](https://github.com/conda/rattler/compare/rattler_index-v0.19.23...rattler_index-v0.19.24) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.24"
+version = "0.19.25"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -14,7 +14,7 @@ readme.workspace = true
 fs-err = { workspace = true }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.27.2", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.1", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.3", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.4", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.21](https://github.com/conda/rattler/compare/rattler_lock-v0.22.20...rattler_lock-v0.22.21) - 2024-08-27
+
+### Added
+- Add support for `CONDA_OVERRIDE_CUDA` ([#818](https://github.com/conda/rattler/pull/818))
+
 ## [0.22.20](https://github.com/conda/rattler/compare/rattler_lock-v0.22.19...rattler_lock-v0.22.20) - 2024-08-16
 
 ### Added

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.20"
+version = "0.22.21"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.4](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.3...rattler_package_streaming-v0.22.4) - 2024-08-27
+
+### Added
+- Add support for `CONDA_OVERRIDE_CUDA` ([#818](https://github.com/conda/rattler/pull/818))
+
 ## [0.22.3](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.2...rattler_package_streaming-v0.22.3) - 2024-08-16
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.3"
+version = "0.22.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -52,7 +52,7 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.1.8", path = "../rattler_cache" }
+rattler_cache = { version = "0.1.9", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.1", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4](https://github.com/conda/rattler/compare/rattler_solve-v1.0.3...rattler_solve-v1.0.4) - 2024-08-27
+
+### Fixed
+- Redact spec channel before comparing it with repodata channel  ([#831](https://github.com/conda/rattler/pull/831))
+
+### Other
+- Remove note that only libsolv is supported ([#832](https://github.com/conda/rattler/pull/832))
+
 ## [1.0.3](https://github.com/conda/rattler/compare/rattler_solve-v1.0.2...rattler_solve-v1.0.3) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.0.3"
+version = "1.0.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.0.4...rattler_virtual_packages-v1.1.0) - 2024-08-27
+
+### Added
+- Add support for `CONDA_OVERRIDE_CUDA` ([#818](https://github.com/conda/rattler/pull/818))
+
 ## [1.0.4](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.0.3...rattler_virtual_packages-v1.0.4) - 2024-08-16
 
 ### Fixed

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "1.0.4"
+version = "1.1.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION
## 🤖 New release
* `rattler_package_streaming`: 0.22.3 -> 0.22.4
* `rattler_lock`: 0.22.20 -> 0.22.21
* `rattler_solve`: 1.0.3 -> 1.0.4
* `rattler_virtual_packages`: 1.0.4 -> 1.1.0
* `rattler_index`: 0.19.24 -> 0.19.25
* `rattler`: 0.27.6 -> 0.27.7
* `rattler_cache`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_package_streaming`
<blockquote>

## [0.22.4](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.3...rattler_package_streaming-v0.22.4) - 2024-08-27

### Added
- Add support for `CONDA_OVERRIDE_CUDA` ([#818](https://github.com/conda/rattler/pull/818))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.21](https://github.com/conda/rattler/compare/rattler_lock-v0.22.20...rattler_lock-v0.22.21) - 2024-08-27

### Added
- Add support for `CONDA_OVERRIDE_CUDA` ([#818](https://github.com/conda/rattler/pull/818))
</blockquote>

## `rattler_solve`
<blockquote>

## [1.0.4](https://github.com/conda/rattler/compare/rattler_solve-v1.0.3...rattler_solve-v1.0.4) - 2024-08-27

### Fixed
- Redact spec channel before comparing it with repodata channel  ([#831](https://github.com/conda/rattler/pull/831))

### Other
- Remove note that only libsolv is supported ([#832](https://github.com/conda/rattler/pull/832))
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [1.1.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.0.4...rattler_virtual_packages-v1.1.0) - 2024-08-27

### Added
- Add support for `CONDA_OVERRIDE_CUDA` ([#818](https://github.com/conda/rattler/pull/818))
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.25](https://github.com/conda/rattler/compare/rattler_index-v0.19.24...rattler_index-v0.19.25) - 2024-08-27

### Other
- release ([#824](https://github.com/conda/rattler/pull/824))
</blockquote>

## `rattler`
<blockquote>

## [0.27.7](https://github.com/conda/rattler/compare/rattler-v0.27.6...rattler-v0.27.7) - 2024-08-27

### Other
- updated the following local packages: rattler_package_streaming
</blockquote>

## `rattler_cache`
<blockquote>

## [0.1.9](https://github.com/conda/rattler/compare/rattler_cache-v0.1.8...rattler_cache-v0.1.9) - 2024-08-27

### Other
- updated the following local packages: rattler_package_streaming
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).