### PR TITLE
fix: windows python entrypoint script attribute in py-rattler

### DIFF
--- a/py-rattler/rattler/prefix/prefix_paths.py
+++ b/py-rattler/rattler/prefix/prefix_paths.py
@@ -51,18 +51,18 @@ class PrefixPathType:
         return self._inner.pyc_file
 
     @property
-    def windows_python_entry_point_script(self) -> bool:
+    def windows_python_entrypoint_script(self) -> bool:
         """
         A Windows entry point python script (a <entrypoint>-script.py Python script file)
         """
-        return self._inner.windows_python_entry_point_script
+        return self._inner.windows_python_entrypoint_script
 
     @property
-    def windows_python_entry_point_exe(self) -> bool:
+    def windows_python_entrypoint_exe(self) -> bool:
         """
         A Windows entry point python script (a <entrypoint>.exe executable)
         """
-        return self._inner.windows_python_entry_point_exe
+        return self._inner.windows_python_entrypoint_exe
 
     @property
     def unix_python_entrypoint(self) -> bool:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Fixes #667. The `windows_python_entrypoint` attribute had an extra underscore on the python side which caused the error.

This attribute was misspelled. Sorry, had this diff ready a while ago and got sidetracked.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
