### PR TITLE
chore: apply clippy's suggetions

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run rustfmt
         uses: actions-rust-lang/rustfmt@v1
       - name: Run clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -51,8 +51,7 @@ jobs:
       - name: Run rustfmt
         uses: actions-rust-lang/rustfmt@v1
       - name: Run clippy
-        run: cargo clippy --all-targets
-
+        run: cargo clippy --all-targets -- -D warnings
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions-rust-lang/rustfmt@v1
       - name: Run clippy
         run: cargo clippy --all-targets
+
   build:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/crates/rattler-bin/src/commands/virtual_packages.rs
+++ b/crates/rattler-bin/src/commands/virtual_packages.rs
@@ -1,10 +1,10 @@
 use rattler_conda_types::GenericVirtualPackage;
-
+use rattler_virtual_packages::{VirtualPackage, VirtualPackageOverrides};
 #[derive(Debug, clap::Parser)]
 pub struct Opt {}
 
 pub fn virtual_packages(_opt: Opt) -> anyhow::Result<()> {
-    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(&Default::default())?;
+    let virtual_packages = VirtualPackage::detect(&VirtualPackageOverrides::default())?;
     for package in virtual_packages {
         println!("{}", GenericVirtualPackage::from(package.clone()));
     }

--- a/crates/rattler-bin/src/commands/virtual_packages.rs
+++ b/crates/rattler-bin/src/commands/virtual_packages.rs
@@ -6,7 +6,6 @@ use rattler_virtual_packages::{VirtualPackage, VirtualPackageOverrides};
 pub struct Opt {}
 
 pub fn virtual_packages(_opt: Opt) -> anyhow::Result<()> {
-
     let virtual_packages = VirtualPackage::detect(&VirtualPackageOverrides::default())?;
 
     for package in virtual_packages {

--- a/crates/rattler/src/install/link_script.rs
+++ b/crates/rattler/src/install/link_script.rs
@@ -57,11 +57,11 @@ impl LinkScriptType {
     }
 }
 
-impl ToString for LinkScriptType {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for LinkScriptType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LinkScriptType::PreUnlink => "pre-unlink".to_string(),
-            LinkScriptType::PostLink => "post-link".to_string(),
+            LinkScriptType::PreUnlink => write!(f, "pre-unlink"),
+            LinkScriptType::PostLink => write!(f, "post-link"),
         }
     }
 }

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -318,7 +318,7 @@ pub async fn link_package(
 
     for (_, computed_path) in final_paths.iter_mut() {
         if let Some(clobber_rename) = clobber_paths.get(computed_path) {
-            *computed_path = clobber_rename.clone();
+            (*computed_path).clone_from(clobber_rename);
         }
     }
 

--- a/crates/rattler_conda_types/src/build_spec/parse.rs
+++ b/crates/rattler_conda_types/src/build_spec/parse.rs
@@ -64,10 +64,10 @@ impl BuildNumberSpec {
 #[derive(Debug, Clone, Error, Eq, PartialEq)]
 pub enum ParseOrdOperatorError {
     /// Indicates that operator symbols were captured,
-    /// but not interpretable as an OrdOperator
+    /// but not interpretable as an `OrdOperator`
     #[error("invalid operator '{0}'")]
     InvalidOperator(String),
-    /// Indicates no symbol sequence found for OrdOperators,
+    /// Indicates no symbol sequence found for `OrdOperators`,
     /// callers should expect explicit operators
     #[error("expected version operator")]
     ExpectedOperator,

--- a/crates/rattler_conda_types/src/environment_yaml.rs
+++ b/crates/rattler_conda_types/src/environment_yaml.rs
@@ -64,7 +64,7 @@ impl MatchSpecOrSubSection {
 
 impl EnvironmentYaml {
     /// Returns all the matchspecs in the `dependencies` section of the file.
-    pub fn match_specs(&self) -> impl Iterator<Item = &'_ MatchSpec> + DoubleEndedIterator + '_ {
+    pub fn match_specs(&self) -> impl DoubleEndedIterator<Item = &'_ MatchSpec> + '_ {
         self.dependencies
             .iter()
             .filter_map(MatchSpecOrSubSection::as_match_spec)

--- a/crates/rattler_conda_types/src/package/paths.rs
+++ b/crates/rattler_conda_types/src/package/paths.rs
@@ -176,7 +176,7 @@ impl PathsJson {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct PrefixPlaceholder {
     /// The type of the file, either binary or text. Depending on the type of file either text
-    /// replacement is performed or CString replacement.
+    /// replacement is performed or `CString` replacement.
     pub file_mode: FileMode,
 
     /// The placeholder prefix used in the file. This is the path of the prefix when the package

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -71,7 +71,7 @@ pub struct ChannelInfo {
     /// The channel's subdirectory
     pub subdir: String,
 
-    /// The base_url for all package urls. Can be an absolute or relative url.
+    /// The `base_url` for all package urls. Can be an absolute or relative url.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
 }

--- a/crates/rattler_conda_types/src/repo_data/patches.rs
+++ b/crates/rattler_conda_types/src/repo_data/patches.rs
@@ -126,22 +126,22 @@ impl PackageRecord {
     /// Apply a patch to a single package record
     pub fn apply_patch(&mut self, patch: &PackageRecordPatch) {
         if let Some(depends) = &patch.depends {
-            self.depends = depends.clone();
+            self.depends.clone_from(depends);
         }
         if let Some(constrains) = &patch.constrains {
-            self.constrains = constrains.clone();
+            self.constrains.clone_from(constrains);
         }
         if let Some(track_features) = &patch.track_features {
-            self.track_features = track_features.clone();
+            self.track_features.clone_from(track_features);
         }
         if let Some(features) = &patch.features {
-            self.features = features.clone();
+            self.features.clone_from(features);
         }
         if let Some(license) = &patch.license {
-            self.license = license.clone();
+            self.license.clone_from(license);
         }
         if let Some(license_family) = &patch.license_family {
-            self.license_family = license_family.clone();
+            self.license_family.clone_from(license_family);
         }
         if let Some(package_urls) = &patch.purls {
             self.purls = Some(package_urls.clone());

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -231,7 +231,7 @@ impl Version {
     /// Returns the individual segments of the version.
     pub fn segments(
         &self,
-    ) -> impl Iterator<Item = SegmentIter<'_>> + DoubleEndedIterator + ExactSizeIterator + '_ {
+    ) -> impl DoubleEndedIterator<Item = SegmentIter<'_>> + ExactSizeIterator + '_ {
         let mut idx = usize::from(self.has_epoch());
         let version_segments = if let Some(local_index) = self.local_segment_index() {
             &self.segments[..local_index]
@@ -259,7 +259,7 @@ impl Version {
     /// ```
     pub fn local_segments(
         &self,
-    ) -> impl Iterator<Item = SegmentIter<'_>> + DoubleEndedIterator + ExactSizeIterator + '_ {
+    ) -> impl DoubleEndedIterator<Item = SegmentIter<'_>> + ExactSizeIterator + '_ {
         if let Some(start) = self.local_segment_index() {
             let mut idx = usize::from(self.has_epoch());
             idx += self.segments[..start]
@@ -962,7 +962,7 @@ impl<'v> SegmentIter<'v> {
     }
 
     /// Returns an iterator over the components of this segment.
-    pub fn components(&self) -> impl Iterator<Item = &'v Component> + DoubleEndedIterator {
+    pub fn components(&self) -> impl DoubleEndedIterator<Item = &'v Component> {
         static IMPLICIT_DEFAULT: Component = Component::Numeral(0);
 
         let version = self.version;

--- a/crates/rattler_conda_types/src/version_spec/parse.rs
+++ b/crates/rattler_conda_types/src/version_spec/parse.rs
@@ -283,7 +283,7 @@ pub fn looks_like_infinite_starts_with(input: &str) -> bool {
     let mut input = input.strip_suffix('.').unwrap_or(input);
     while !input.is_empty() {
         match input.strip_suffix(".*") {
-            Some(rest) if rest.is_empty() => {
+            Some("") => {
                 // If we were able to continuously strip the `.*` pattern,
                 // then we found a match.
                 return true;

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -214,9 +214,7 @@ impl LockFile {
     }
 
     /// Returns an iterator over all environments defined in the lock-file.
-    pub fn environments(
-        &self,
-    ) -> impl Iterator<Item = (&str, Environment)> + ExactSizeIterator + '_ {
+    pub fn environments(&self) -> impl ExactSizeIterator<Item = (&str, Environment)> + '_ {
         self.inner
             .environment_lookup
             .iter()
@@ -251,7 +249,7 @@ impl Environment {
     }
 
     /// Returns all the platforms for which we have a locked-down environment.
-    pub fn platforms(&self) -> impl Iterator<Item = Platform> + ExactSizeIterator + '_ {
+    pub fn platforms(&self) -> impl ExactSizeIterator<Item = Platform> + '_ {
         self.data().packages.keys().copied()
     }
 
@@ -276,7 +274,7 @@ impl Environment {
     pub fn packages(
         &self,
         platform: Platform,
-    ) -> Option<impl Iterator<Item = Package> + ExactSizeIterator + DoubleEndedIterator + '_> {
+    ) -> Option<impl ExactSizeIterator<Item = Package> + DoubleEndedIterator + '_> {
         let packages = self.data().packages.get(&platform)?;
         Some(
             packages
@@ -289,13 +287,12 @@ impl Environment {
     /// environment
     pub fn packages_by_platform(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ExactSizeIterator<
         Item = (
             Platform,
-            impl Iterator<Item = Package> + ExactSizeIterator + DoubleEndedIterator + '_,
+            impl ExactSizeIterator<Item = Package> + DoubleEndedIterator + '_,
         ),
-    > + ExactSizeIterator
-           + '_ {
+    > + '_ {
         let env_data = self.data();
         env_data.packages.iter().map(move |(platform, packages)| {
             (
@@ -386,9 +383,7 @@ impl Environment {
         &self,
         platform: Platform,
     ) -> Option<Vec<(PypiPackageData, PypiPackageEnvironmentData)>> {
-        let Some(packages) = self.data().packages.get(&platform) else {
-            return None;
-        };
+        let packages = self.data().packages.get(&platform)?;
 
         Some(
             packages

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -9,7 +9,7 @@ use crate::{authentication_storage::StorageBackend, Authentication};
 #[derive(Clone, Debug)]
 /// A storage backend that stores credentials in the operating system's keyring
 pub struct KeyringAuthenticationStorage {
-    /// The store_key needs to be unique per program as it is stored
+    /// The `store_key` needs to be unique per program as it is stored
     /// in a global dictionary in the operating system
     pub store_key: String,
 }

--- a/crates/rattler_networking/src/oci_middleware.rs
+++ b/crates/rattler_networking/src/oci_middleware.rs
@@ -41,12 +41,12 @@ struct OCIToken {
     token: String,
 }
 
-impl ToString for OciAction {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for OciAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OciAction::Pull => "pull".to_string(),
-            OciAction::Push => "push".to_string(),
-            OciAction::PushPull => "push,pull".to_string(),
+            OciAction::Pull => write!(f, "pull"),
+            OciAction::Push => write!(f, "push"),
+            OciAction::PushPull => write!(f, "push,pull"),
         }
     }
 }
@@ -103,9 +103,7 @@ impl OCIUrl {
     pub fn token_url(&self, action: OciAction) -> Result<Url, ParseError> {
         format!(
             "https://{}/token?scope=repository:{}:{}",
-            self.host,
-            self.path,
-            action.to_string()
+            self.host, self.path, action
         )
         .parse()
     }

--- a/crates/rattler_package_streaming/src/tokio/async_read.rs
+++ b/crates/rattler_package_streaming/src/tokio/async_read.rs
@@ -68,12 +68,12 @@ async fn extract_conda_internal(
 
     // Spawn a block task to perform the extraction
     let destination = destination.to_owned();
-    match tokio::task::spawn_blocking(move || {
+    let res = tokio::task::spawn_blocking(move || {
         let reader: Box<dyn Read> = Box::new(reader);
         extract_fn(reader, &destination)
     })
-    .await
-    {
+    .await;
+    match res {
         Ok(result) => result,
         Err(err) => {
             if let Ok(reason) = err.try_into_panic() {

--- a/crates/rattler_repodata_gateway/src/fetch/cache/cache_headers.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/cache/cache_headers.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 /// Extracted HTTP response headers that enable caching the repodata.json files.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CacheHeaders {
-    /// The ETag HTTP cache header
+    /// The `ETag` HTTP cache header
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub etag: Option<String>,
 

--- a/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
@@ -388,6 +388,7 @@ impl<'a> JLAPResponse<'a> {
 
 /// Calculates the bytes offset. We default to zero if we receive a shorter than
 /// expected vector.
+#[allow(clippy::ptr_arg)]
 fn get_bytes_offset(lines: &Vec<&str>) -> u64 {
     if lines.len() >= JLAP_FOOTER_OFFSET {
         lines[0..lines.len() - JLAP_FOOTER_OFFSET]

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -302,7 +302,7 @@ fn parse_records<'i>(
         let mut package_record: PackageRecord = serde_json::from_str(raw_json.get())?;
         // Overwrite subdir if its empty
         if package_record.subdir.is_empty() {
-            package_record.subdir = subdir.to_owned();
+            subdir.clone_into(&mut package_record.subdir);
         }
         result.push(RepoDataRecord {
             url: compute_package_url(

--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -24,9 +24,9 @@ pub enum PathModificationBehavior {
     /// Replaces the complete path variable with specified paths.
     #[default]
     Replace,
-    /// Appends the new path variables to the path. E.g. '$PATH:/new/path'
+    /// Appends the new path variables to the path. E.g. `$PATH:/new/path`
     Append,
-    /// Prepends the new path variables to the path. E.g. '/new/path:$PATH'
+    /// Prepends the new path variables to the path. E.g. `/new/path:$PATH`
     Prepend,
 }
 

--- a/crates/rattler_solve/src/libsolv_c/wrapper/solve_problem.rs
+++ b/crates/rattler_solve/src/libsolv_c/wrapper/solve_problem.rs
@@ -36,8 +36,8 @@ pub enum SolveProblem {
         source: SolvableId,
         target: SolvableId,
     },
-    /// A constraint (run_constrained) on source is conflicting with target.
-    /// SOLVER_RULE_PKG_CONSTRAINS has a dep, but it can resolve to nothing.
+    /// A constraint (`run_constrained`) on source is conflicting with target.
+    /// `SOLVER_RULE_PKG_CONSTRAINS` has a dep, but it can resolve to nothing.
     /// The constraint conflict is actually expressed between the target and
     /// a constrains node child of the source.
     PkgConstrains {

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -343,8 +343,7 @@ impl<'a> CondaDependencyProvider<'a> {
                 // This function makes the assumption that the records are given in order of the
                 // channels.
                 if let (Some(first_channel), ChannelPriority::Strict) = (
-                    package_name_found_in_channel
-                        .get(&record.package_record.name.as_normalized().to_string()),
+                    package_name_found_in_channel.get(record.package_record.name.as_normalized()),
                     channel_priority,
                 ) {
                     // Add the record to the excluded list when it is from a different channel.

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -135,7 +135,7 @@ pub enum VirtualPackage {
     /// Available on `Unix` based platforms
     Unix,
 
-    /// Available when running on `Linux``
+    /// Available when running on `Linux`
     Linux(Linux),
 
     /// Available when running on `OSX`


### PR DESCRIPTION
I think it's sometimes helpful to use Clippy to avoid common mistakes. Unfortunately, this repo generates way too many of these.

The only one I could not figure out was 

```
#[allow(clippy::ptr_arg)]
fn get_bytes_offset(lines: &Vec<&str>)
```


This commit is not supposed to change any behavior whatsoever.