### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.27.8", default-features = false, features = ["indicatif"] }
+rattler = { path="../rattler", version = "0.27.9", default-features = false, features = ["indicatif"] }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.27.4", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.21.3", default-features = false, features = ["google-cloud-auth"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.10", default-features = false, features = ["gateway"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.11", default-features = false, features = ["gateway"] }
 rattler_solve = { path="../rattler_solve", version = "1.0.5", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.1", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.2.0", default-features = false }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.2", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.2.1", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.9](https://github.com/conda/rattler/compare/rattler-v0.27.8...rattler-v0.27.9) - 2024-09-03
+
+### Other
+- updated the following local packages: rattler_cache
+
 ## [0.27.8](https://github.com/conda/rattler/compare/rattler-v0.27.7...rattler-v0.27.8) - 2024-09-03
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.27.8"
+version = "0.27.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,7 +32,7 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.2.0", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.2.1", default-features = false }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.4", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.21.3", default-features = false }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/conda/rattler/compare/rattler_cache-v0.2.0...rattler_cache-v0.2.1) - 2024-09-03
+
+### Fixed
+- allow `gcs://` and `oci://` in gateway ([#845](https://github.com/conda/rattler/pull/845))
+
 ## [0.2.0](https://github.com/conda/rattler/compare/rattler_cache-v0.1.9...rattler_cache-v0.2.0) - 2024-09-03
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.2.0"
+version = "0.2.1"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.11](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.10...rattler_repodata_gateway-v0.21.11) - 2024-09-03
+
+### Fixed
+- allow `gcs://` and `oci://` in gateway ([#845](https://github.com/conda/rattler/pull/845))
+
 ## [0.21.10](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.9...rattler_repodata_gateway-v0.21.10) - 2024-09-03
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.10"
+version = "0.21.11"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -53,7 +53,7 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.2.0", path = "../rattler_cache" }
+rattler_cache = { version = "0.2.1", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.1", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.1...rattler_virtual_packages-v1.1.2) - 2024-09-03
+
+### Fixed
+- allow `gcs://` and `oci://` in gateway ([#845](https://github.com/conda/rattler/pull/845))
+
 ## [1.1.1](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.0...rattler_virtual_packages-v1.1.1) - 2024-09-03
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "1.1.1"
+version = "1.1.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION
## 🤖 New release
* `rattler_cache`: 0.2.0 -> 0.2.1
* `rattler_repodata_gateway`: 0.21.10 -> 0.21.11
* `rattler_virtual_packages`: 1.1.1 -> 1.1.2
* `rattler`: 0.27.8 -> 0.27.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_cache`
<blockquote>

## [0.2.1](https://github.com/conda/rattler/compare/rattler_cache-v0.2.0...rattler_cache-v0.2.1) - 2024-09-03

### Fixed
- allow `gcs://` and `oci://` in gateway ([#845](https://github.com/conda/rattler/pull/845))
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.11](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.10...rattler_repodata_gateway-v0.21.11) - 2024-09-03

### Fixed
- allow `gcs://` and `oci://` in gateway ([#845](https://github.com/conda/rattler/pull/845))
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [1.1.2](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.1...rattler_virtual_packages-v1.1.2) - 2024-09-03

### Fixed
- allow `gcs://` and `oci://` in gateway ([#845](https://github.com/conda/rattler/pull/845))
</blockquote>

## `rattler`
<blockquote>

## [0.27.9](https://github.com/conda/rattler/compare/rattler-v0.27.8...rattler-v0.27.9) - 2024-09-03

### Other
- updated the following local packages: rattler_cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).