### PR TITLE
chore: release

### DIFF
--- a/crates/file_url/CHANGELOG.md
+++ b/crates/file_url/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/conda/rattler/compare/file_url-v0.1.4...file_url-v0.1.5) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.1.4](https://github.com/conda/rattler/compare/file_url-v0.1.3...file_url-v0.1.4) - 2024-08-15
 
 ### Fixed

--- a/crates/file_url/Cargo.toml
+++ b/crates/file_url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_url"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Helper functions to work with file:// urls"

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.27.9", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.4", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.21.3", default-features = false, features = ["google-cloud-auth"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.11", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.0.5", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.2", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.2.1", default-features = false }
+rattler = { path="../rattler", version = "0.27.10", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.27.5", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.21.4", default-features = false, features = ["google-cloud-auth"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.12", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.0.6", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.3", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.2.2", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.10](https://github.com/conda/rattler/compare/rattler-v0.27.9...rattler-v0.27.10) - 2024-09-05
+
+### Fixed
+- remaining typos ([#854](https://github.com/conda/rattler/pull/854))
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.27.9](https://github.com/conda/rattler/compare/rattler-v0.27.8...rattler-v0.27.9) - 2024-09-03
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.27.9"
+version = "0.27.10"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.2.1", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.4", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.3", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.21.8", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.5", default-features = false, features = ["reqwest"] }
+rattler_cache = { path = "../rattler_cache", version = "0.2.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.5", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.4", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.0", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.6", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/conda/rattler/compare/rattler_cache-v0.2.1...rattler_cache-v0.2.2) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.2.1](https://github.com/conda/rattler/compare/rattler_cache-v0.2.0...rattler_cache-v0.2.1) - 2024-09-03
 
 ### Fixed

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.2.1"
+version = "0.2.2"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -17,10 +17,10 @@ futures.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.27.4", path = "../rattler_conda_types", default-features = false }
-rattler_digest = { version = "1.0.1", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.21.3", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.5", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { version = "0.27.5", path = "../rattler_conda_types", default-features = false }
+rattler_digest = { version = "1.0.2", path = "../rattler_digest", default-features = false }
+rattler_networking = { version = "0.21.4", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.6", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.5](https://github.com/conda/rattler/compare/rattler_conda_types-v0.27.4...rattler_conda_types-v0.27.5) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.27.4](https://github.com/conda/rattler/compare/rattler_conda_types-v0.27.3...rattler_conda_types-v0.27.4) - 2024-09-03
 
 ### Other

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.27.4"
+version = "0.27.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -12,7 +12,7 @@ readme.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-file_url = { path = "../file_url", version = "0.1.4" }
+file_url = { path = "../file_url", version = "0.1.5" }
 fxhash = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }
@@ -20,8 +20,8 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false, features = ["serde"] }
-rattler_macros = { path = "../rattler_macros", version = "1.0.1", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false, features = ["serde"] }
+rattler_macros = { path = "../rattler_macros", version = "1.0.2", default-features = false }
 regex = { workspace = true }
 simd-json = { workspace = true , features = ["serde_impl"]}
 serde = { workspace = true, features = ["derive", "rc"] }
@@ -37,7 +37,7 @@ tracing = { workspace = true }
 typed-path = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 indexmap = { workspace = true }
-rattler_redaction = { version = "0.1.1", path = "../rattler_redaction" }
+rattler_redaction = { version = "0.1.2", path = "../rattler_redaction" }
 dirs = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/conda/rattler/compare/rattler_digest-v1.0.1...rattler_digest-v1.0.2) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [1.0.1](https://github.com/conda/rattler/compare/rattler_digest-v1.0.0...rattler_digest-v1.0.1) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "1.0.1"
+version = "1.0.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.27](https://github.com/conda/rattler/compare/rattler_index-v0.19.26...rattler_index-v0.19.27) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.19.26](https://github.com/conda/rattler/compare/rattler_index-v0.19.25...rattler_index-v0.19.26) - 2024-09-03
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.26"
+version = "0.19.27"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.4", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "1.0.1", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.5", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.27.5", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "1.0.2", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.6", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.0.1...rattler_libsolv_c-v1.0.2) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [1.0.1](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.0.0...rattler_libsolv_c-v1.0.1) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "1.0.1"
+version = "1.0.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.23](https://github.com/conda/rattler/compare/rattler_lock-v0.22.22...rattler_lock-v0.22.23) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.22.22](https://github.com/conda/rattler/compare/rattler_lock-v0.22.21...rattler_lock-v0.22.22) - 2024-09-03
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.22"
+version = "0.22.23"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,9 +15,9 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.4", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false }
-file_url = { path = "../file_url", version = "0.1.4" }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.5", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
+file_url = { path = "../file_url", version = "0.1.5" }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/conda/rattler/compare/rattler_macros-v1.0.1...rattler_macros-v1.0.2) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [1.0.1](https://github.com/conda/rattler/compare/rattler_macros-v1.0.0...rattler_macros-v1.0.1) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "1.0.1"
+version = "1.0.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.4](https://github.com/conda/rattler/compare/rattler_networking-v0.21.3...rattler_networking-v0.21.4) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.21.3](https://github.com/conda/rattler/compare/rattler_networking-v0.21.2...rattler_networking-v0.21.3) - 2024-09-03
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.21.3"
+version = "0.21.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.6](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.5...rattler_package_streaming-v0.22.6) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.22.5](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.4...rattler_package_streaming-v0.22.5) - 2024-09-03
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.5"
+version = "0.22.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -15,10 +15,10 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.4", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.3", default-features = false }
-rattler_redaction = { version = "0.1.1", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.5", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.4", default-features = false }
+rattler_redaction = { version = "0.1.2", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_redaction/CHANGELOG.md
+++ b/crates/rattler_redaction/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.1...rattler_redaction-v0.1.2) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.1.1](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.0...rattler_redaction-v0.1.1) - 2024-08-15
 
 ### Fixed

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_redaction"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Redact sensitive information from URLs (ie. conda tokens)"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.12](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.11...rattler_repodata_gateway-v0.21.12) - 2024-09-05
+
+### Fixed
+- *(gateway)* clear subdir cache based on `base_url` ([#852](https://github.com/conda/rattler/pull/852))
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.21.11](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.10...rattler_repodata_gateway-v0.21.11) - 2024-09-03
 
 ### Fixed

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.11"
+version = "0.21.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -21,7 +21,7 @@ cache_control = { workspace = true }
 chrono = { workspace = true, features = ["std", "serde", "alloc", "clock"] }
 dashmap = { workspace = true }
 dirs = { workspace = true }
-file_url = { path = "../file_url", version = "0.1.4" }
+file_url = { path = "../file_url", version = "0.1.5" }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 http = { workspace = true, optional = true }
@@ -35,9 +35,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.4", default-features = false, optional = true }
-rattler_digest = { path = "../rattler_digest", version = "1.0.1", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.21.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.5", default-features = false, optional = true }
+rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false, features = ["tokio", "serde"] }
+rattler_networking = { path = "../rattler_networking", version = "0.21.4", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -53,8 +53,8 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.2.1", path = "../rattler_cache" }
-rattler_redaction = { version = "0.1.1", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+rattler_cache = { version = "0.2.2", path = "../rattler_cache" }
+rattler_redaction = { version = "0.1.2", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/conda/rattler/compare/rattler_shell-v0.21.8...rattler_shell-v0.22.0) - 2024-09-05
+
+### Fixed
+- remaining typos ([#854](https://github.com/conda/rattler/pull/854))
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [0.21.8](https://github.com/conda/rattler/compare/rattler_shell-v0.21.7...rattler_shell-v0.21.8) - 2024-09-03
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.21.8"
+version = "0.22.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.4", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.27.5", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6](https://github.com/conda/rattler/compare/rattler_solve-v1.0.5...rattler_solve-v1.0.6) - 2024-09-05
+
+### Fixed
+- remaining typos ([#854](https://github.com/conda/rattler/pull/854))
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [1.0.5](https://github.com/conda/rattler/compare/rattler_solve-v1.0.4...rattler_solve-v1.0.5) - 2024-09-03
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.0.5"
+version = "1.0.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.4", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "1.0.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.27.5", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "1.0.2", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 url = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { path="../rattler_libsolv_c", version = "1.0.1", default-features = false, optional = true }
+rattler_libsolv_c = { path="../rattler_libsolv_c", version = "1.0.2", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.2...rattler_virtual_packages-v1.1.3) - 2024-09-05
+
+### Fixed
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+
 ## [1.1.2](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.1...rattler_virtual_packages-v1.1.2) - 2024-09-03
 
 ### Fixed

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "1.1.2"
+version = "1.1.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.4", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.27.5", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `file_url`: 0.1.4 -> 0.1.5
* `rattler`: 0.27.9 -> 0.27.10
* `rattler_cache`: 0.2.1 -> 0.2.2
* `rattler_conda_types`: 0.27.4 -> 0.27.5
* `rattler_digest`: 1.0.1 -> 1.0.2
* `rattler_macros`: 1.0.1 -> 1.0.2
* `rattler_redaction`: 0.1.1 -> 0.1.2
* `rattler_package_streaming`: 0.22.5 -> 0.22.6
* `rattler_networking`: 0.21.3 -> 0.21.4
* `rattler_shell`: 0.21.8 -> 0.22.0
* `rattler_lock`: 0.22.22 -> 0.22.23
* `rattler_repodata_gateway`: 0.21.11 -> 0.21.12
* `rattler_solve`: 1.0.5 -> 1.0.6
* `rattler_libsolv_c`: 1.0.1 -> 1.0.2
* `rattler_virtual_packages`: 1.1.2 -> 1.1.3
* `rattler_index`: 0.19.26 -> 0.19.27

<details><summary><i><b>Changelog</b></i></summary><p>

## `file_url`
<blockquote>

## [0.1.5](https://github.com/conda/rattler/compare/file_url-v0.1.4...file_url-v0.1.5) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler`
<blockquote>

## [0.27.10](https://github.com/conda/rattler/compare/rattler-v0.27.9...rattler-v0.27.10) - 2024-09-05

### Fixed
- remaining typos ([#854](https://github.com/conda/rattler/pull/854))
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_cache`
<blockquote>

## [0.2.2](https://github.com/conda/rattler/compare/rattler_cache-v0.2.1...rattler_cache-v0.2.2) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.27.5](https://github.com/conda/rattler/compare/rattler_conda_types-v0.27.4...rattler_conda_types-v0.27.5) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_digest`
<blockquote>

## [1.0.2](https://github.com/conda/rattler/compare/rattler_digest-v1.0.1...rattler_digest-v1.0.2) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_macros`
<blockquote>

## [1.0.2](https://github.com/conda/rattler/compare/rattler_macros-v1.0.1...rattler_macros-v1.0.2) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_redaction`
<blockquote>

## [0.1.2](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.1...rattler_redaction-v0.1.2) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.22.6](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.5...rattler_package_streaming-v0.22.6) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_networking`
<blockquote>

## [0.21.4](https://github.com/conda/rattler/compare/rattler_networking-v0.21.3...rattler_networking-v0.21.4) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_shell`
<blockquote>

## [0.22.0](https://github.com/conda/rattler/compare/rattler_shell-v0.21.8...rattler_shell-v0.22.0) - 2024-09-05

### Fixed
- remaining typos ([#854](https://github.com/conda/rattler/pull/854))
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.23](https://github.com/conda/rattler/compare/rattler_lock-v0.22.22...rattler_lock-v0.22.23) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.12](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.11...rattler_repodata_gateway-v0.21.12) - 2024-09-05

### Fixed
- *(gateway)* clear subdir cache based on `base_url` ([#852](https://github.com/conda/rattler/pull/852))
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_solve`
<blockquote>

## [1.0.6](https://github.com/conda/rattler/compare/rattler_solve-v1.0.5...rattler_solve-v1.0.6) - 2024-09-05

### Fixed
- remaining typos ([#854](https://github.com/conda/rattler/pull/854))
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_libsolv_c`
<blockquote>

## [1.0.2](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.0.1...rattler_libsolv_c-v1.0.2) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [1.1.3](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.2...rattler_virtual_packages-v1.1.3) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.27](https://github.com/conda/rattler/compare/rattler_index-v0.19.26...rattler_index-v0.19.27) - 2024-09-05

### Fixed
- typos ([#849](https://github.com/conda/rattler/pull/849))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).