### PR TITLE
fix: publish MatchSpecOrSubSection for env yaml

### DIFF
--- a/crates/rattler_conda_types/src/environment_yaml.rs
+++ b/crates/rattler_conda_types/src/environment_yaml.rs
@@ -40,7 +40,9 @@ pub struct EnvironmentYaml {
 /// `environment.yaml` file.
 #[derive(Debug, Clone, PartialEq)]
 pub enum MatchSpecOrSubSection {
+    /// A Conda package match spec
     MatchSpec(MatchSpec),
+    /// A list of specs for another package manager (pip)
     SubSection(String, Vec<String>),
 }
 

--- a/crates/rattler_conda_types/src/lib.rs
+++ b/crates/rattler_conda_types/src/lib.rs
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 pub use build_spec::{BuildNumber, BuildNumberSpec, ParseBuildNumberSpecError};
 pub use channel::{Channel, ChannelConfig, NamedChannelOrUrl, ParseChannelError};
 pub use channel_data::{ChannelData, ChannelDataPackage};
-pub use environment_yaml::EnvironmentYaml;
+pub use environment_yaml::{EnvironmentYaml, MatchSpecOrSubSection};
 pub use explicit_environment_spec::{
     ExplicitEnvironmentEntry, ExplicitEnvironmentSpec, PackageArchiveHash,
     ParseExplicitEnvironmentSpecError, ParsePackageArchiveHashError,


### PR DESCRIPTION
### Description

With the addition of `EnvironmentYaml` to rattler, I'm taking another swing at adding exporting from Pixi (replacing https://github.com/prefix-dev/pixi/pull/1427 ), and using `EnvironmentYaml` to reuse code.

Currently the `MatchSpecOrSubSection` enum isn't published at the library level, so dependencies can't be added from `MatchSpecs` or Pip subsections. This publishes the enum so that it can be used for constructing `EnvironmentYaml`s from other representations.