### PR TITLE
chore: bump resolvo 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ regex = "1.10.4"
 reqwest = { version = "0.12.3", default-features = false }
 reqwest-middleware = "0.3.0"
 reqwest-retry = "0.6.0"
-resolvo = { version = "0.7.0" }
+resolvo = { version = "0.8.0" }
 retry-policies = { version = "0.4.0", default-features = false }
 rmp-serde = { version = "1.2.0" }
 rstest = { version = "0.21.0" }

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -648,11 +648,9 @@ impl super::SolverImpl for Solver {
             })
             .collect();
 
-        let problem = Problem {
-            requirements: all_requirements,
-            constraints: root_constraints,
-            ..Problem::default()
-        };
+        let problem = Problem::new()
+            .requirements(all_requirements)
+            .constraints(root_constraints);
 
         // Construct a solver and solve the problems in the queue
         let mut solver = LibSolvRsSolver::new(provider);


### PR DESCRIPTION
Bumps [resolvo to `0.8.0`](https://github.com/mamba-org/resolvo/releases/tag/resolvo-v0.8.0) we especially want https://github.com/mamba-org/resolvo/pull/61 .