### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.27.11", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.6", default-features = false }
+rattler = { path="../rattler", version = "0.27.12", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.28.0", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.21.4", default-features = false, features = ["google-cloud-auth"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.13", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.0.7", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.4", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.2.3", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.14", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.0.8", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.5", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.2.4", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.12](https://github.com/conda/rattler/compare/rattler-v0.27.11...rattler-v0.27.12) - 2024-09-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.27.11](https://github.com/conda/rattler/compare/rattler-v0.27.10...rattler-v0.27.11) - 2024-09-09
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.27.11"
+version = "0.27.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.2.3", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.6", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.2.4", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.21.4", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.1", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.7", default-features = false, features = ["reqwest"] }
+rattler_shell = { path = "../rattler_shell", version = "0.22.2", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.8", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/conda/rattler/compare/rattler_cache-v0.2.3...rattler_cache-v0.2.4) - 2024-09-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.2.3](https://github.com/conda/rattler/compare/rattler_cache-v0.2.2...rattler_cache-v0.2.3) - 2024-09-09
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.2.3"
+version = "0.2.4"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -17,10 +17,10 @@ futures.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.27.6", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.28.0", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.2", path = "../rattler_digest", default-features = false }
 rattler_networking = { version = "0.21.4", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.7", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { version = "0.22.8", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.27.6...rattler_conda_types-v0.28.0) - 2024-09-23
+
+### Added
+
+- add path to namedchannelorurl ([#873](https://github.com/conda/rattler/pull/873))
+- add serialization for `GenericVirtualPackage` ([#865](https://github.com/conda/rattler/pull/865))
+
+### Fixed
+
+- improve when we print brackets ([#861](https://github.com/conda/rattler/pull/861))
+
 ## [0.27.6](https://github.com/conda/rattler/compare/rattler_conda_types-v0.27.5...rattler_conda_types-v0.27.6) - 2024-09-09
 
 ### Fixed

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.27.6"
+version = "0.28.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.29](https://github.com/conda/rattler/compare/rattler_index-v0.19.28...rattler_index-v0.19.29) - 2024-09-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.28](https://github.com/conda/rattler/compare/rattler_index-v0.19.27...rattler_index-v0.19.28) - 2024-09-09
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.28"
+version = "0.19.29"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.6", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.28.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.2", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.7", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.8", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.25](https://github.com/conda/rattler/compare/rattler_lock-v0.22.24...rattler_lock-v0.22.25) - 2024-09-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.24](https://github.com/conda/rattler/compare/rattler_lock-v0.22.23...rattler_lock-v0.22.24) - 2024-09-09
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.24"
+version = "0.22.25"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.6", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
 file_url = { path = "../file_url", version = "0.1.5" }
 pep508_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.8](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.7...rattler_package_streaming-v0.22.8) - 2024-09-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.7](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.6...rattler_package_streaming-v0.22.7) - 2024-09-09
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.7"
+version = "0.22.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -15,7 +15,7 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.6", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.21.4", default-features = false }
 rattler_redaction = { version = "0.1.2", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.14](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.13...rattler_repodata_gateway-v0.21.14) - 2024-09-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.21.13](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.12...rattler_repodata_gateway-v0.21.13) - 2024-09-09
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.13"
+version = "0.21.14"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -35,7 +35,7 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.27.6", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.0", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false, features = ["tokio", "serde"] }
 rattler_networking = { path = "../rattler_networking", version = "0.21.4", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
@@ -53,7 +53,7 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.2.3", path = "../rattler_cache" }
+rattler_cache = { version = "0.2.4", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.2", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2](https://github.com/conda/rattler/compare/rattler_shell-v0.22.1...rattler_shell-v0.22.2) - 2024-09-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.1](https://github.com/conda/rattler/compare/rattler_shell-v0.22.0...rattler_shell-v0.22.1) - 2024-09-09
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.1"
+version = "0.22.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.6", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.28.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8](https://github.com/conda/rattler/compare/rattler_solve-v1.0.7...rattler_solve-v1.0.8) - 2024-09-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [1.0.7](https://github.com/conda/rattler/compare/rattler_solve-v1.0.6...rattler_solve-v1.0.7) - 2024-09-09
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.0.7"
+version = "1.0.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.6", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.28.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.2", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.4...rattler_virtual_packages-v1.1.5) - 2024-09-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [1.1.4](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.3...rattler_virtual_packages-v1.1.4) - 2024-09-09
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "1.1.4"
+version = "1.1.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.27.6", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.28.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler_conda_types`: 0.27.6 -> 0.28.0 (⚠️ API breaking changes)
* `rattler`: 0.27.11 -> 0.27.12
* `rattler_cache`: 0.2.3 -> 0.2.4
* `rattler_package_streaming`: 0.22.7 -> 0.22.8
* `rattler_shell`: 0.22.1 -> 0.22.2
* `rattler_lock`: 0.22.24 -> 0.22.25
* `rattler_repodata_gateway`: 0.21.13 -> 0.21.14
* `rattler_solve`: 1.0.7 -> 1.0.8
* `rattler_virtual_packages`: 1.1.4 -> 1.1.5
* `rattler_index`: 0.19.28 -> 0.19.29

### ⚠️ `rattler_conda_types` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant NamedChannelOrUrl:Path in /tmp/.tmpg7WKI0/rattler/crates/rattler_conda_types/src/channel/mod.rs:90
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_conda_types`
<blockquote>

## [0.28.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.27.6...rattler_conda_types-v0.28.0) - 2024-09-23

### Added

- add path to namedchannelorurl ([#873](https://github.com/conda/rattler/pull/873))
- add serialization for `GenericVirtualPackage` ([#865](https://github.com/conda/rattler/pull/865))

### Fixed

- improve when we print brackets ([#861](https://github.com/conda/rattler/pull/861))
</blockquote>

## `rattler`
<blockquote>

## [0.27.12](https://github.com/conda/rattler/compare/rattler-v0.27.11...rattler-v0.27.12) - 2024-09-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_cache`
<blockquote>

## [0.2.4](https://github.com/conda/rattler/compare/rattler_cache-v0.2.3...rattler_cache-v0.2.4) - 2024-09-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.22.8](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.7...rattler_package_streaming-v0.22.8) - 2024-09-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_shell`
<blockquote>

## [0.22.2](https://github.com/conda/rattler/compare/rattler_shell-v0.22.1...rattler_shell-v0.22.2) - 2024-09-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.25](https://github.com/conda/rattler/compare/rattler_lock-v0.22.24...rattler_lock-v0.22.25) - 2024-09-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.14](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.13...rattler_repodata_gateway-v0.21.14) - 2024-09-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_solve`
<blockquote>

## [1.0.8](https://github.com/conda/rattler/compare/rattler_solve-v1.0.7...rattler_solve-v1.0.8) - 2024-09-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [1.1.5](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.4...rattler_virtual_packages-v1.1.5) - 2024-09-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.29](https://github.com/conda/rattler/compare/rattler_index-v0.19.28...rattler_index-v0.19.29) - 2024-09-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).