### PR TITLE
test: add tests for py-rattler MatchSpec channel parsing

### DIFF
--- a/py-rattler/tests/unit/test_matchspec.py
+++ b/py-rattler/tests/unit/test_matchspec.py
@@ -1,0 +1,13 @@
+from rattler import MatchSpec
+
+
+def test_parse_channel_from_canonical_name():
+    m = MatchSpec("conda-forge::python[version=3.9]")
+    assert m.channel.name == "conda-forge"
+    assert m.channel.base_url == "https://conda.anaconda.org/conda-forge/"
+
+
+def test_parse_channel_from_url():
+    m = MatchSpec("https://conda.anaconda.org/conda-forge::python[version=3.9]")
+    assert m.channel.name == "conda-forge"
+    assert m.channel.base_url == "https://conda.anaconda.org/conda-forge/"

--- a/py-rattler/tests/unit/test_matchspec.py
+++ b/py-rattler/tests/unit/test_matchspec.py
@@ -3,11 +3,13 @@ from rattler import MatchSpec
 
 def test_parse_channel_from_canonical_name() -> None:
     m = MatchSpec("conda-forge::python[version=3.9]")
+    assert m.channel is not None
     assert m.channel.name == "conda-forge"
     assert m.channel.base_url == "https://conda.anaconda.org/conda-forge/"
 
 
 def test_parse_channel_from_url() -> None:
     m = MatchSpec("https://conda.anaconda.org/conda-forge::python[version=3.9]")
+    assert m.channel is not None
     assert m.channel.name == "conda-forge"
     assert m.channel.base_url == "https://conda.anaconda.org/conda-forge/"

--- a/py-rattler/tests/unit/test_matchspec.py
+++ b/py-rattler/tests/unit/test_matchspec.py
@@ -1,13 +1,13 @@
 from rattler import MatchSpec
 
 
-def test_parse_channel_from_canonical_name():
+def test_parse_channel_from_canonical_name() -> None:
     m = MatchSpec("conda-forge::python[version=3.9]")
     assert m.channel.name == "conda-forge"
     assert m.channel.base_url == "https://conda.anaconda.org/conda-forge/"
 
 
-def test_parse_channel_from_url():
+def test_parse_channel_from_url() -> None:
     m = MatchSpec("https://conda.anaconda.org/conda-forge::python[version=3.9]")
     assert m.channel.name == "conda-forge"
     assert m.channel.base_url == "https://conda.anaconda.org/conda-forge/"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Tests for MatchSpec channel parsing as requested in https://github.com/conda/rattler/issues/869#issuecomment-2364170101.

Contrary to the observations in #869, both of these tests pass for me locally when running 

```console
$ cd py-rattler
$ pixi run --manifest-path pixi.toml -e test test
```

Which perhaps means the url parsing regressing is solved in the current `main`, but broken in the `0.6.3.` release?

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
