### PR TITLE
fix: normalize channel in lock file

### DIFF
--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -628,6 +628,7 @@ mod test {
     #[case::v4_pypi_absolute_path("v4/absolute-path-lock.yml")]
     #[case::v5_pypi_flat_index("v5/flat-index-lock.yml")]
     #[case::v6_conda_source_path("v6/conda-path-lock.yml")]
+    #[case::v6_derived_channel("v6/derived-channel-lock.yml")]
     fn test_parse(#[case] file_name: &str) {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../test-data/conda-lock")

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v6__derived-channel-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v6__derived-channel-lock.yml.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rattler_lock/src/lib.rs
+expression: conda_lock
+---
+version: 6
+environments:
+  default:
+    channels:
+      - url: "https://conda.anaconda.org/conda-forge/"
+    packages:
+      win-64:
+        - conda: "https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda"
+        - conda: child-package
+packages:
+  - conda: child-package
+    name: child-package
+    version: 0.1.0
+    build: pyhbf21a9e_0
+    subdir: noarch
+    depends:
+      - python
+    input:
+      hash: b67010bf5bc5608db89c0399e726852b07a7ef4fb26b3aa18171f1d0f6a19c89
+      globs:
+        - pixi.toml
+  - conda: "https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda"
+    sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
+    md5: defd5d375853a2caff36a19d2d81a28e
+    license: Python-2.0
+    size: 16140836
+    timestamp: 1696321871976

--- a/test-data/conda-lock/v6/derived-channel-lock.yml
+++ b/test-data/conda-lock/v6/derived-channel-lock.yml
@@ -1,0 +1,30 @@
+version: 6
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      win-64:
+        - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
+        - conda: child-package
+packages:
+  - conda: child-package
+    name: child-package
+    version: 0.1.0
+    build: pyhbf21a9e_0
+    subdir: noarch
+    depends:
+      - python
+    input:
+      hash: b67010bf5bc5608db89c0399e726852b07a7ef4fb26b3aa18171f1d0f6a19c89
+      globs:
+        - pixi.toml
+  - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
+    sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
+    md5: defd5d375853a2caff36a19d2d81a28e
+    arch: x86_64
+    platform: win
+    channel: https://conda.anaconda.org/conda-forge/
+    license: Python-2.0
+    size: 16140836
+    timestamp: 1696321871976


### PR DESCRIPTION
Normalizes channels in lock-files to never contain a trailing slash.