### PR TITLE
fix: mark records as changed if hash Option value is different

### DIFF
--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -210,6 +210,11 @@ fn is_python_record(record: &PackageRecord) -> bool {
 
 /// Returns true if the `from` and `to` describe the same package content
 fn describe_same_content(from: &PackageRecord, to: &PackageRecord) -> bool {
+    // If one hash is set and the other is not, the packages are different
+    if from.sha256.is_some() != to.sha256.is_some() || from.md5.is_some() != to.md5.is_some() {
+        return false;
+    }
+
     // If the hashes of the packages match we consider them to be equal
     if let (Some(a), Some(b)) = (from.sha256.as_ref(), to.sha256.as_ref()) {
         return a == b;


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This adds the case that where the hash changed, which happened for my source build, that a re-install is triggered. I think this is the correct behavior, not sure if it will trigger *too* many re-installs but did not feel that would be the case.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
