### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,11 +27,11 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.27.12", default-features = false, features = ["indicatif"] }
+rattler = { path="../rattler", version = "0.27.13", default-features = false, features = ["indicatif"] }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.28.0", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.21.4", default-features = false, features = ["google-cloud-auth"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.14", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.0.8", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.15", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.0.9", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.5", default-features = false }
 rattler_cache = { path="../rattler_cache", version = "0.2.4", default-features = false }
 reqwest = { workspace = true }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.13](https://github.com/conda/rattler/compare/rattler-v0.27.12...rattler-v0.27.13) - 2024-10-01
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.27.12](https://github.com/conda/rattler/compare/rattler-v0.27.11...rattler-v0.27.12) - 2024-09-23
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.27.12"
+version = "0.27.13"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.30](https://github.com/conda/rattler/compare/rattler_index-v0.19.29...rattler_index-v0.19.30) - 2024-10-01
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.19.29](https://github.com/conda/rattler/compare/rattler_index-v0.19.28...rattler_index-v0.19.29) - 2024-09-23
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.29"
+version = "0.19.30"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.15](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.14...rattler_repodata_gateway-v0.21.15) - 2024-10-01
+
+### Other
+
+- start using fs-err in repodata_gateway ([#877](https://github.com/conda/rattler/pull/877))
+
 ## [0.21.14](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.13...rattler_repodata_gateway-v0.21.14) - 2024-09-23
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.14"
+version = "0.21.15"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.9](https://github.com/conda/rattler/compare/rattler_solve-v1.0.8...rattler_solve-v1.0.9) - 2024-10-01
+
+### Other
+
+- update resolvo ([#881](https://github.com/conda/rattler/pull/881))
+
 ## [1.0.8](https://github.com/conda/rattler/compare/rattler_solve-v1.0.7...rattler_solve-v1.0.8) - 2024-09-23
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.0.8"
+version = "1.0.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"


### PR DESCRIPTION
## 🤖 New release
* `rattler`: 0.27.12 -> 0.27.13 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.21.14 -> 0.21.15 (✓ API compatible changes)
* `rattler_solve`: 1.0.8 -> 1.0.9 (✓ API compatible changes)
* `rattler_index`: 0.19.29 -> 0.19.30 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`
<blockquote>

## [0.27.13](https://github.com/conda/rattler/compare/rattler-v0.27.12...rattler-v0.27.13) - 2024-10-01

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.15](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.14...rattler_repodata_gateway-v0.21.15) - 2024-10-01

### Other

- start using fs-err in repodata_gateway ([#877](https://github.com/conda/rattler/pull/877))
</blockquote>

## `rattler_solve`
<blockquote>

## [1.0.9](https://github.com/conda/rattler/compare/rattler_solve-v1.0.8...rattler_solve-v1.0.9) - 2024-10-01

### Other

- update resolvo ([#881](https://github.com/conda/rattler/pull/881))
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.30](https://github.com/conda/rattler/compare/rattler_index-v0.19.29...rattler_index-v0.19.30) - 2024-10-01

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).