### PR TITLE
perf: update resolvo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ regex = "1.10.4"
 reqwest = { version = "0.12.3", default-features = false }
 reqwest-middleware = "0.3.0"
 reqwest-retry = "0.6.0"
-resolvo = { version = "0.8.0" }
+resolvo = { version = "0.8.1" }
 retry-policies = { version = "0.4.0", default-features = false }
 rmp-serde = { version = "1.2.0" }
 rstest = { version = "0.21.0" }

--- a/crates/rattler_solve/tests/snapshots/backends__resolvo__solve_with_error.snap
+++ b/crates/rattler_solve/tests/snapshots/backends__resolvo__solve_with_error.snap
@@ -4,9 +4,8 @@ expression: err
 ---
 Cannot solve the request because of: The following packages are incompatible
 ├─ bors >=2 can be installed with any of the following options:
-│  └─ bors 2.0
+│  └─ bors 2.0 | 2.1
 └─ foobar >=2 cannot be installed because there are no viable options:
    └─ foobar 2.0 | 2.1 would require
       └─ bors <2.0, which cannot be installed because there are no viable options:
-         ├─ bors 1.2.1, which conflicts with the versions reported above.
-         └─ bors 1.0 | 1.1, which conflicts with the versions reported above.
+         └─ bors 1.0 | 1.1 | 1.2.1, which conflicts with the versions reported above.

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.27.11"
+version = "0.27.12"
 dependencies = [
  "anyhow",
  "console",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.27.6"
+version = "0.28.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.28"
+version = "0.19.29"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.24"
+version = "0.22.25"
 dependencies = [
  "chrono",
  "file_url",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "bzip2",
  "chrono",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.13"
+version = "0.21.14"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2863,6 +2863,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "file_url",
+ "fs-err",
  "futures",
  "hex",
  "http 1.1.0",
@@ -2902,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.5.0",
@@ -2917,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "chrono",
  "futures",
@@ -2933,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "archspec",
  "libloading",
@@ -3137,15 +3138,16 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a472ebbac5a18c9e235e874df3aa0c8fb0b55611155dd5e5515a55a16520d76"
+checksum = "d68c0ae687bbcd99ab33236c7cbccd2ba1c526a7f7a59743cb991074414c5293"
 dependencies = [
  "ahash",
  "bitvec",
  "elsa",
  "event-listener",
  "futures",
+ "indexmap 2.5.0",
  "itertools 0.13.0",
  "petgraph",
  "tracing",

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "BSD-3-Clause"
 publish = false


### PR DESCRIPTION
Bumps resolvo to `0.8.1` which includes some drastic performance improvements. 

This PR also bumps py-rattler to `0.7.1` so I can also make a release of the python bindings.