### PR TITLE
fix: return correct channel urls from `MatchSpec.channel.base_url`

### DIFF
--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.27.12"
+version = "0.27.13"
 dependencies = [
  "anyhow",
  "console",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.29"
+version = "0.19.30"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.14"
+version = "0.21.15"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "chrono",
  "futures",

--- a/py-rattler/rattler/channel/channel.py
+++ b/py-rattler/rattler/channel/channel.py
@@ -25,6 +25,12 @@ class Channel:
 
         self._channel = PyChannel(name, channel_configuration._channel_configuration)
 
+    @classmethod
+    def _from_py_channel(cls, py_channel: PyChannel) -> Channel:
+        channel = cls.__new__(cls)
+        channel._channel = py_channel
+        return channel
+
     def to_lock_channel(self) -> LockChannel:
         """
         Returns a new [`LockChannel`] from existing channel.

--- a/py-rattler/rattler/match_spec/match_spec.py
+++ b/py-rattler/rattler/match_spec/match_spec.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
-from rattler.channel.channel import Channel
+from urllib.parse import urlparse, urlunparse
+from rattler.channel.channel import Channel, ChannelConfig
 
 from rattler.rattler import PyMatchSpec
 
@@ -142,7 +144,14 @@ class MatchSpec:
         The channel of the package.
         """
         if (channel := self._match_spec.channel) is not None:
-            return Channel(channel.name)
+            parsed = urlparse(channel.base_url)
+            channel_alias = (
+                urlunparse((parsed.scheme, parsed.netloc, "/", "", "", ""))
+                if not parsed.scheme == "file"
+                else Path(parsed.path).as_uri()
+            )
+            channel_configuration = ChannelConfig(channel_alias=channel_alias)
+            return Channel(channel.name, channel_configuration=channel_configuration)
         return None
 
     @property

--- a/py-rattler/rattler/match_spec/match_spec.py
+++ b/py-rattler/rattler/match_spec/match_spec.py
@@ -144,16 +144,8 @@ class MatchSpec:
         """
         The channel of the package.
         """
-        if (channel := self._match_spec.channel) is not None:
-            parsed = urlparse(channel.base_url)
-            channel_alias = (
-                urlunparse((parsed.scheme, parsed.netloc, "/", "", "", ""))
-                if not parsed.scheme == "file"
-                else Path(parsed.path).as_uri()
-            )
-            channel_configuration = ChannelConfig(channel_alias=channel_alias)
-            return Channel(channel.name, channel_configuration=channel_configuration)
-        return None
+        channel = self._match_spec.channel
+        return channel and Channel._from_py_channel(channel)
 
     @property
     def subdir(self) -> Optional[str]:

--- a/py-rattler/rattler/match_spec/match_spec.py
+++ b/py-rattler/rattler/match_spec/match_spec.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
-from pathlib import Path
 from typing import TYPE_CHECKING, Optional
-from urllib.parse import urlparse, urlunparse
 from rattler.channel.channel import Channel
-from rattler.channel.channel_config import ChannelConfig
 
 from rattler.rattler import PyMatchSpec
 

--- a/py-rattler/rattler/match_spec/match_spec.py
+++ b/py-rattler/rattler/match_spec/match_spec.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 from urllib.parse import urlparse, urlunparse
-from rattler.channel.channel import Channel, ChannelConfig
+from rattler.channel.channel import Channel
+from rattler.channel.channel_config import ChannelConfig
 
 from rattler.rattler import PyMatchSpec
 

--- a/py-rattler/tests/unit/test_matchspec.py
+++ b/py-rattler/tests/unit/test_matchspec.py
@@ -19,14 +19,14 @@ def test_parse_channel_from_url_filesystem() -> None:
     m = MatchSpec("file:///Users/rattler/channel0::python[version=3.9]")
     assert m.channel is not None
     assert m.channel.name == "channel0"
-    assert m.channel.base_url == "file:///Users/rattler/channel0"
+    assert m.channel.base_url == "file:///Users/rattler/channel0/"
 
 
 def test_parse_channel_from_url_localhost() -> None:
     m = MatchSpec("http://localhost:8000/channel0::python[version=3.9]")
     assert m.channel is not None
     assert m.channel.name == "channel0"
-    assert m.channel.base_url == "http://localhost:8000/get/channel0"
+    assert m.channel.base_url == "http://localhost:8000/channel0/"
 
 
 def test_parse_no_channel() -> None:

--- a/py-rattler/tests/unit/test_matchspec.py
+++ b/py-rattler/tests/unit/test_matchspec.py
@@ -23,7 +23,14 @@ def test_parse_channel_from_url_filesystem() -> None:
 
 
 def test_parse_channel_from_url_localhost() -> None:
-    m = MatchSpec("http://localhost:8000/get/channel0::python[version=3.9]")
+    m = MatchSpec("http://localhost:8000/channel0::python[version=3.9]")
     assert m.channel is not None
     assert m.channel.name == "channel0"
     assert m.channel.base_url == "http://localhost:8000/get/channel0"
+
+
+def test_parse_no_channel() -> None:
+    m = MatchSpec("python[version=3.9]")
+    assert m.channel is None
+    assert m.name.normalized == "python"
+    assert m.version == "==3.9"

--- a/py-rattler/tests/unit/test_matchspec.py
+++ b/py-rattler/tests/unit/test_matchspec.py
@@ -13,3 +13,17 @@ def test_parse_channel_from_url() -> None:
     assert m.channel is not None
     assert m.channel.name == "conda-forge"
     assert m.channel.base_url == "https://conda.anaconda.org/conda-forge/"
+
+
+def test_parse_channel_from_url_filesystem() -> None:
+    m = MatchSpec("file:///Users/rattler/channel0::python[version=3.9]")
+    assert m.channel is not None
+    assert m.channel.name == "channel0"
+    assert m.channel.base_url == "file:///Users/rattler/channel0"
+
+
+def test_parse_channel_from_url_localhost() -> None:
+    m = MatchSpec("http://localhost:8000/get/channel0::python[version=3.9]")
+    assert m.channel is not None
+    assert m.channel.name == "channel0"
+    assert m.channel.base_url == "http://localhost:8000/get/channel0"

--- a/py-rattler/tests/unit/test_matchspec.py
+++ b/py-rattler/tests/unit/test_matchspec.py
@@ -32,5 +32,6 @@ def test_parse_channel_from_url_localhost() -> None:
 def test_parse_no_channel() -> None:
     m = MatchSpec("python[version=3.9]")
     assert m.channel is None
+    assert m.name is not None
     assert m.name.normalized == "python"
     assert m.version == "==3.9"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR adds the tests described in #884.

It also provides a (reference) fix in `MatchSpec.channel`. I say "reference" because I imagine the maintainers may prefer to handle this in some other way (perhaps by pushing the url parsing I've done in Python here to the Rust layer?), in which case I will certainly have no objection to my "fix" being discarded. But I provide it nonetheless to indicate the general shape of a possible solution.

Thanks all! Happy to contribute to this further if I am able.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
