### PR TITLE
fix: fix-up shebangs with spaces

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -91,6 +91,9 @@ pub async fn create(opt: Opt) -> anyhow::Result<()> {
     let target_prefix = opt
         .target_prefix
         .unwrap_or_else(|| current_dir.join(".prefix"));
+
+    // Make the target prefix absolute
+    let target_prefix = std::path::absolute(target_prefix)?;
     println!("Target prefix: {}", target_prefix.display());
 
     // Determine the platform we're going to install for

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -862,11 +862,19 @@ mod test {
         assert_eq!(replaced, "#!/usr/bin/env exe\\ cutable -o \"te  st\" -x");
 
         let shebang = "#!/usr/bin/env perl";
-        let replaced = super::replace_shebang(shebang.into(), ("/placeholder", "/with space"), &Platform::Linux64);
+        let replaced = super::replace_shebang(
+            shebang.into(),
+            ("/placeholder", "/with space"),
+            &Platform::Linux64,
+        );
         assert_eq!(replaced, shebang);
 
         let shebang = "#!/placeholder/perl";
-        let replaced = super::replace_shebang(shebang.into(), ("/placeholder", "/with space"), &Platform::Linux64);
+        let replaced = super::replace_shebang(
+            shebang.into(),
+            ("/placeholder", "/with space"),
+            &Platform::Linux64,
+        );
         assert_eq!(replaced, "#!/usr/bin/env perl");
     }
 

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -591,8 +591,12 @@ fn replace_shebang<'a>(
         shebang
     );
 
+
     if old_new.1.contains(' ') {
-        return convert_shebang_to_env(shebang);
+        // we convert the shebang without spaces to a new shebang, and only then replace
+        // which is relevant for the Python case
+        let new_shebang = convert_shebang_to_env(shebang).replace(old_new.0, old_new.1);
+        return new_shebang.into();
     }
 
     let shebang: Cow<'_, str> = shebang.replace(old_new.0, old_new.1).into();

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -591,6 +591,10 @@ fn replace_shebang<'a>(
     );
 
     if old_new.1.contains(' ') {
+        // Doesn't matter if we don't replace anything
+        if !shebang.contains(old_new.0) {
+            return shebang;
+        }
         // we convert the shebang without spaces to a new shebang, and only then replace
         // which is relevant for the Python case
         let new_shebang = convert_shebang_to_env(shebang).replace(old_new.0, old_new.1);
@@ -856,6 +860,14 @@ mod test {
         let shebang = "#!    /this/is/looooooooooooooooooooooooooooooooooooooooooooo\\ \\ ooooooo\\ oooooo\\ oooooo\\ ooooooooooooooooo\\ ooooooooooooooooooong/exe\\ cutable -o \"te  st\" -x";
         let replaced = super::replace_shebang(shebang.into(), ("", ""), &Platform::Linux64);
         assert_eq!(replaced, "#!/usr/bin/env exe\\ cutable -o \"te  st\" -x");
+
+        let shebang = "#!/usr/bin/env perl";
+        let replaced = super::replace_shebang(shebang.into(), ("/placeholder", "/with space"), &Platform::Linux64);
+        assert_eq!(replaced, shebang);
+
+        let shebang = "#!/placeholder/perl";
+        let replaced = super::replace_shebang(shebang.into(), ("/placeholder", "/with space"), &Platform::Linux64);
+        assert_eq!(replaced, "#!/usr/bin/env perl");
     }
 
     #[test]

--- a/crates/rattler/src/install/snapshots/rattler__install__link__test__replace_long_prefix_in_text_file.snap
+++ b/crates/rattler/src/install/snapshots/rattler__install__link__test__replace_long_prefix_in_text_file.snap
@@ -2,7 +2,7 @@
 source: crates/rattler/src/install/link.rs
 expression: replaced
 ---
-#!/usr/bin/env python -m 123123
+#!/usr/bin/env executable -m 123123
 
 # just a comment
 

--- a/crates/rattler/src/install/snapshots/rattler__install__link__test__replace_python_shebang-2.snap
+++ b/crates/rattler/src/install/snapshots/rattler__install__link__test__replace_python_shebang-2.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rattler/src/install/link.rs
+expression: replaced
+---
+#!/bin/sh
+'''exec' "/new/prefix/with spaces/bin/python3.12" -x 123 "$0" "$@" #'''

--- a/crates/rattler/src/install/snapshots/rattler__install__link__test__replace_python_shebang.snap
+++ b/crates/rattler/src/install/snapshots/rattler__install__link__test__replace_python_shebang.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rattler/src/install/link.rs
+expression: replaced
+---
+#!/bin/sh
+'''exec' "/new/prefix/with spaces/bin/python3.12" "$0" "$@" #'''

--- a/test-data/shebang_test.txt
+++ b/test-data/shebang_test.txt
@@ -1,4 +1,4 @@
-#!/this/is/placeholder/python -m 123123
+#!/this/is/placeholder/executable -m 123123
 
 # just a comment
 


### PR DESCRIPTION
This changes a little bit how we handle shebangs in text files.

When a shebang (after replacement) contains a `" "` space in the result we need to replace it with `/usr/bin/env ...` to make things work. This breaks execution in "non-activated" environments though. 

For Python scripts we can use another small trick: we can execute `/usr/bin/sh` and then run `exec "/path/to python with spaces/python" {args} ...` (which is also wrapped in a python comment). 

We are already doing this when we create Python entrypoints from scratch for noarch packages. I added this functionality here as well (duplicates code from `python.rs` though).