### PR TITLE
refactor: stream JLAP repodata writes

### DIFF
--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -56,6 +56,7 @@ url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 rattler_cache = { version = "0.2.5", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.2", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+memmap = "0.7.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -56,7 +56,6 @@ url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 rattler_cache = { version = "0.2.5", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.2", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
-memmap = "0.7.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
@@ -81,6 +81,7 @@
 
 use blake2::digest::Output;
 use blake2::digest::{FixedOutput, Update};
+use fs_err as fs;
 use rattler_digest::{
     parse_digest_from_hex, serde::SerializableHash, Blake2b256, Blake2b256Hash, Blake2bMac256,
 };
@@ -537,7 +538,7 @@ fn apply_jlap_patches(
 
     tracing::info!("parsing cached repodata.json as JSON");
     // Read the contents of the current repodata to a string
-    let repo_data_file = std::fs::File::open(repo_data_path).map_err(JLAPError::FileSystem)?;
+    let repo_data_file = fs::File::open(repo_data_path).map_err(JLAPError::FileSystem)?;
     let repo_data_reader = std::io::BufReader::with_capacity(64 * 1024, repo_data_file);
 
     let mut repo_data: Value =
@@ -576,7 +577,6 @@ fn apply_jlap_patches(
     )
     .map_err(JLAPError::FileSystem)
     .map(rattler_digest::HashingWriter::<_, Blake2b256>::new)?;
-
     serde_json::to_writer(
         std::io::BufWriter::with_capacity(64 * 1024, &mut hashing_writer),
         &repo_data,


### PR DESCRIPTION
JLAP previously had up to three copies of repodata simultaneously: the read bytes, the in-memory Serde representation, and the to-be-written bytes. Avoid having multiple copies of repodata in-memory simultaneously by streaming repodata reads and writes, which should bring us down to just one in-memory Serde copy.

_Does anybody have tips for recreating a more heavyweight JLAP patching scenario for the purpose of testing this patch's impact? For now, I am going on green test-cases and good vibes..._