### PR TITLE
fix: self-clobber when updating/downgrading packages

### DIFF
--- a/crates/rattler/src/install/clobber_registry.rs
+++ b/crates/rattler/src/install/clobber_registry.rs
@@ -148,11 +148,12 @@ impl ClobberRegistry {
 
         for (_, path) in computed_paths {
             // if we find an entry, we have a clobbering path!
-            if let Some(&primary_package_idx) = self.paths_registry.get(path) {
+            // let entry = self.paths_registry.get(path);
+            if let Some(&Some(primary_package_idx)) = self.paths_registry.get(path) {
                 let new_path = clobber_name(path, &self.package_names[name_idx.0]);
                 self.clobbers
                     .entry(path.clone())
-                    .or_insert_with(|| primary_package_idx.map(|v| vec![v]).unwrap_or_default())
+                    .or_insert_with(|| vec![primary_package_idx])
                     .push(name_idx);
 
                 // We insert the non-renamed path here
@@ -282,7 +283,7 @@ impl ClobberRegistry {
 
             // Rename the winner
             let winner_path = clobber_name(path, &winner.1);
-            tracing::trace!("renaming {} to {}", winner_path.display(), path.display());
+            tracing::debug!("renaming {} to {}", winner_path.display(), path.display());
             fs::rename(target_prefix.join(&winner_path), target_prefix.join(path)).map_err(
                 |e| {
                     ClobberError::IoError(

--- a/crates/rattler/src/install/clobber_registry.rs
+++ b/crates/rattler/src/install/clobber_registry.rs
@@ -934,10 +934,7 @@ mod tests {
         // check that the files are there
         assert_check_files(
             target_prefix.path(),
-            &[
-                "clobber.txt",
-                "another-clobber.txt",
-            ],
+            &["clobber.txt", "another-clobber.txt"],
         );
 
         let mut prefix_records = PrefixRecord::collect_from_prefix(target_prefix.path()).unwrap();
@@ -960,12 +957,13 @@ mod tests {
             platform: Platform::current(),
         };
 
-    
         let install_driver = InstallDriver::builder()
             .with_prefix_records(&prefix_records)
             .finish();
-    
-        install_driver.pre_process(&transaction, target_prefix.path()).unwrap();
+
+        install_driver
+            .pre_process(&transaction, target_prefix.path())
+            .unwrap();
         let dl_client = reqwest_middleware::ClientWithMiddleware::from(reqwest::Client::new());
         for op in &transaction.operations {
             execute_operation(
@@ -983,10 +981,7 @@ mod tests {
         // But also, this is a reinstall so the files should just be overwritten.
         assert_check_files(
             target_prefix.path(),
-            &[
-                "clobber.txt",
-                "another-clobber.txt",
-            ],
+            &["clobber.txt", "another-clobber.txt"],
         );
     }
 

--- a/crates/rattler/src/install/clobber_registry.rs
+++ b/crates/rattler/src/install/clobber_registry.rs
@@ -174,8 +174,8 @@ impl ClobberRegistry {
                     // We insert the non-renamed path here
                     clobber_paths.insert(path.clone(), new_path);
                 } else {
-                    // In this case, the path we are looking at was previously removed so we need to
-                    // add it back to the registry and to the clobbers (the idx in the registry is None)
+                    // In this case, the path we are looking at was previously
+                    // removed so we need to add it back to the registry
                     self.paths_registry.insert(path.clone(), Some(name_idx));
 
                     // If we previously had clobbers with this path, we need to

--- a/crates/rattler/src/install/test_utils.rs
+++ b/crates/rattler/src/install/test_utils.rs
@@ -10,6 +10,8 @@ use crate::{
     package_cache::PackageCache,
 };
 
+use super::driver::PostProcessResult;
+
 /// Install a package into the environment and write a `conda-meta` file that
 /// contains information about how the file was linked.
 pub async fn install_package_to_environment(
@@ -124,7 +126,7 @@ pub async fn execute_transaction(
     package_cache: &PackageCache,
     install_driver: &InstallDriver,
     install_options: &InstallOptions,
-) {
+) -> PostProcessResult {
     install_driver
         .pre_process(&transaction, target_prefix)
         .unwrap();
@@ -143,7 +145,7 @@ pub async fn execute_transaction(
 
     install_driver
         .post_process(&transaction, target_prefix)
-        .unwrap();
+        .unwrap()
 }
 
 pub fn find_prefix_record<'a>(


### PR DESCRIPTION
This fixes an issue where if you install `zlib=1.2` and then update to `zlib=1.3` all files were detected as "clobbered". 

This made changes really slow (e.g. when changing the version of Rust) because the un-clobbering is not really an optimized function and is expected to run only for a few files.