### PR TITLE
chore: release

### DIFF
--- a/crates/file_url/CHANGELOG.md
+++ b/crates/file_url/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/conda/rattler/compare/file_url-v0.1.5...file_url-v0.1.6) - 2024-10-07
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.5](https://github.com/conda/rattler/compare/file_url-v0.1.4...file_url-v0.1.5) - 2024-09-05
 
 ### Fixed

--- a/crates/file_url/Cargo.toml
+++ b/crates/file_url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_url"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Helper functions to work with file:// urls"

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.28.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.28.1...rattler_conda_types-v0.28.2) - 2024-10-07
 
+<<<<<<< Updated upstream
+=======
+### Added
+
+- total ordering for the dependency provider ([#892](https://github.com/conda/rattler/pull/892))
+
+>>>>>>> Stashed changes
 ### Other
 
 - add snapshot tests to verify solver sorting order ([#895](https://github.com/conda/rattler/pull/895))

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -12,7 +12,7 @@ readme.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-file_url = { path = "../file_url", version = "0.1.5" }
+file_url = { path = "../file_url", version = "0.1.6" }
 fxhash = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
+<<<<<<< Updated upstream
 - updated the following local packages: rattler_conda_types
+=======
+- updated the following local packages: file_url, rattler_conda_types
+>>>>>>> Stashed changes
 
 ## [0.22.26](https://github.com/conda/rattler/compare/rattler_lock-v0.22.25...rattler_lock-v0.22.26) - 2024-10-03
 

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.2", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
-file_url = { path = "../file_url", version = "0.1.5" }
+file_url = { path = "../file_url", version = "0.1.6" }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -22,7 +22,7 @@ cache_control = { workspace = true }
 chrono = { workspace = true, features = ["std", "serde", "alloc", "clock"] }
 dashmap = { workspace = true }
 dirs = { workspace = true }
-file_url = { path = "../file_url", version = "0.1.5" }
+file_url = { path = "../file_url", version = "0.1.6" }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 http = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+<<<<<<< Updated upstream
+=======
+- total ordering for the dependency provider ([#892](https://github.com/conda/rattler/pull/892))
+>>>>>>> Stashed changes
 - add sorting bench and makes test same as feature test ([#897](https://github.com/conda/rattler/pull/897))
 
 ### Fixed


### PR DESCRIPTION
## 🤖 New release
* `file_url`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `rattler`: 0.27.14 -> 0.27.15 (✓ API compatible changes)
* `rattler_conda_types`: 0.28.1 -> 0.28.2 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.9 -> 0.22.10 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.21.16 -> 0.21.17 (✓ API compatible changes)
* `rattler_solve`: 1.0.10 -> 1.1.0 (✓ API compatible changes)
* `rattler_virtual_packages`: 1.1.6 -> 1.1.7 (✓ API compatible changes)
* `rattler_cache`: 0.2.5 -> 0.2.6
* `rattler_shell`: 0.22.3 -> 0.22.4
* `rattler_lock`: 0.22.26 -> 0.22.27
* `rattler_index`: 0.19.31 -> 0.19.32

<details><summary><i><b>Changelog</b></i></summary><p>

## `file_url`
<blockquote>

## [0.1.6](https://github.com/conda/rattler/compare/file_url-v0.1.5...file_url-v0.1.6) - 2024-10-07

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler`
<blockquote>

## [0.27.15](https://github.com/conda/rattler/compare/rattler-v0.27.14...rattler-v0.27.15) - 2024-10-07

### Fixed

- self-clobber when updating/downgrading packages ([#893](https://github.com/conda/rattler/pull/893))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.28.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.28.1...rattler_conda_types-v0.28.2) - 2024-10-07

### Added

- total ordering for the dependency provider ([#892](https://github.com/conda/rattler/pull/892))

### Other

- add snapshot tests to verify solver sorting order ([#895](https://github.com/conda/rattler/pull/895))
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.22.10](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.9...rattler_package_streaming-v0.22.10) - 2024-10-07

### Added

- make `ExtractError` more informative ([#889](https://github.com/conda/rattler/pull/889))
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.17](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.16...rattler_repodata_gateway-v0.21.17) - 2024-10-07

### Other

- stream JLAP repodata writes ([#891](https://github.com/conda/rattler/pull/891))
</blockquote>

## `rattler_solve`
<blockquote>

## [1.1.0](https://github.com/conda/rattler/compare/rattler_solve-v1.0.10...rattler_solve-v1.1.0) - 2024-10-07

### Added

- total ordering for the dependency provider ([#892](https://github.com/conda/rattler/pull/892))
- add sorting bench and makes test same as feature test ([#897](https://github.com/conda/rattler/pull/897))

### Fixed

- sorting test should also load dependencies ([#896](https://github.com/conda/rattler/pull/896))

### Other

- add snapshot tests to verify solver sorting order ([#895](https://github.com/conda/rattler/pull/895))
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [1.1.7](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.6...rattler_virtual_packages-v1.1.7) - 2024-10-07

### Other

- add snapshot tests to verify solver sorting order ([#895](https://github.com/conda/rattler/pull/895))
</blockquote>

## `rattler_cache`
<blockquote>

## [0.2.6](https://github.com/conda/rattler/compare/rattler_cache-v0.2.5...rattler_cache-v0.2.6) - 2024-10-07

### Other

- updated the following local packages: rattler_conda_types, rattler_package_streaming
</blockquote>

## `rattler_shell`
<blockquote>

## [0.22.4](https://github.com/conda/rattler/compare/rattler_shell-v0.22.3...rattler_shell-v0.22.4) - 2024-10-07

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.27](https://github.com/conda/rattler/compare/rattler_lock-v0.22.26...rattler_lock-v0.22.27) - 2024-10-07

### Other

- updated the following local packages: file_url, rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.32](https://github.com/conda/rattler/compare/rattler_index-v0.19.31...rattler_index-v0.19.32) - 2024-10-07

### Other

- updated the following local packages: rattler_conda_types, rattler_package_streaming
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).