### PR TITLE
chore: release

### DIFF
--- a/crates/file_url/CHANGELOG.md
+++ b/crates/file_url/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/conda/rattler/compare/file_url-v0.1.5...file_url-v0.1.6) - 2024-10-21
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.5](https://github.com/conda/rattler/compare/file_url-v0.1.4...file_url-v0.1.5) - 2024-09-05
 
 ### Fixed

--- a/crates/file_url/Cargo.toml
+++ b/crates/file_url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_url"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Helper functions to work with file:// urls"

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.27.15", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.28.2", default-features = false }
+rattler = { path="../rattler", version = "0.27.16", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.28.3", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.21.4", default-features = false, features = ["google-cloud-auth"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.17", default-features = false, features = ["gateway"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.18", default-features = false, features = ["gateway"] }
 rattler_solve = { path="../rattler_solve", version = "1.1.0", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.7", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.2.6", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.2.7", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.16](https://github.com/conda/rattler/compare/rattler-v0.27.15...rattler-v0.27.16) - 2024-10-21
+
+### Fixed
+
+- removal / linking when package name changes ([#905](https://github.com/conda/rattler/pull/905))
+
 ## [0.27.15](https://github.com/conda/rattler/compare/rattler-v0.27.14...rattler-v0.27.15) - 2024-10-07
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.27.15"
+version = "0.27.16"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,8 +32,8 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.2.6", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.2", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.2.7", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.21.4", default-features = false }
 rattler_shell = { path = "../rattler_shell", version = "0.22.4", default-features = false }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/conda/rattler/compare/rattler_cache-v0.2.6...rattler_cache-v0.2.7) - 2024-10-21
+
+### Added
+
+- use sha in cache lock file, needed for source builds. ([#901](https://github.com/conda/rattler/pull/901))
+
 ## [0.2.6](https://github.com/conda/rattler/compare/rattler_cache-v0.2.5...rattler_cache-v0.2.6) - 2024-10-07
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.2.6"
+version = "0.2.7"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -17,7 +17,7 @@ futures.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.28.2", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.28.3", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.2", path = "../rattler_digest", default-features = false }
 rattler_networking = { version = "0.21.4", path = "../rattler_networking", default-features = false }
 rattler_package_streaming = { version = "0.22.10", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.28.2...rattler_conda_types-v0.28.3) - 2024-10-21
+
+### Other
+
+- updated the following local packages: file_url
+
 ## [0.28.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.28.1...rattler_conda_types-v0.28.2) - 2024-10-07
 
 ### Other

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.28.2"
+version = "0.28.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -12,7 +12,7 @@ readme.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-file_url = { path = "../file_url", version = "0.1.5" }
+file_url = { path = "../file_url", version = "0.1.6" }
 fxhash = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.33](https://github.com/conda/rattler/compare/rattler_index-v0.19.32...rattler_index-v0.19.33) - 2024-10-21
+
+### Fixed
+
+- always index noarch even if folder already exists ([#907](https://github.com/conda/rattler/pull/907))
+
 ## [0.19.32](https://github.com/conda/rattler/compare/rattler_index-v0.19.31...rattler_index-v0.19.32) - 2024-10-07
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.32"
+version = "0.19.33"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,7 +12,7 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.28.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.28.3", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.2", default-features = false }
 rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.10", default-features = false }
 serde_json = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.28](https://github.com/conda/rattler/compare/rattler_lock-v0.22.27...rattler_lock-v0.22.28) - 2024-10-21
+
+### Other
+
+- updated the following local packages: file_url
+
 ## [0.22.27](https://github.com/conda/rattler/compare/rattler_lock-v0.22.26...rattler_lock-v0.22.27) - 2024-10-07
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.27"
+version = "0.22.28"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,9 +15,9 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
-file_url = { path = "../file_url", version = "0.1.5" }
+file_url = { path = "../file_url", version = "0.1.6" }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -15,7 +15,7 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.21.4", default-features = false }
 rattler_redaction = { version = "0.1.2", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.18](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.17...rattler_repodata_gateway-v0.21.18) - 2024-10-21
+
+### Other
+
+- updated the following local packages: file_url, rattler_cache
+
 ## [0.21.17](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.16...rattler_repodata_gateway-v0.21.17) - 2024-10-07
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.17"
+version = "0.21.18"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -22,7 +22,7 @@ cache_control = { workspace = true }
 chrono = { workspace = true, features = ["std", "serde", "alloc", "clock"] }
 dashmap = { workspace = true }
 dirs = { workspace = true }
-file_url = { path = "../file_url", version = "0.1.5" }
+file_url = { path = "../file_url", version = "0.1.6" }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 http = { workspace = true, optional = true }
@@ -36,7 +36,7 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.2", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.3", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false, features = ["tokio", "serde"] }
 rattler_networking = { path = "../rattler_networking", version = "0.21.4", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
@@ -54,7 +54,7 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.2.6", path = "../rattler_cache" }
+rattler_cache = { version = "0.2.7", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.2", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.28.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.28.3", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.28.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.2", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.28.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.28.3", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `file_url`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `rattler`: 0.27.15 -> 0.27.16 (✓ API compatible changes)
* `rattler_cache`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `rattler_index`: 0.19.32 -> 0.19.33 (✓ API compatible changes)
* `rattler_conda_types`: 0.28.2 -> 0.28.3
* `rattler_lock`: 0.22.27 -> 0.22.28
* `rattler_repodata_gateway`: 0.21.17 -> 0.21.18

<details><summary><i><b>Changelog</b></i></summary><p>

## `file_url`
<blockquote>

## [0.1.6](https://github.com/conda/rattler/compare/file_url-v0.1.5...file_url-v0.1.6) - 2024-10-21

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler`
<blockquote>

## [0.27.16](https://github.com/conda/rattler/compare/rattler-v0.27.15...rattler-v0.27.16) - 2024-10-21

### Fixed

- removal / linking when package name changes ([#905](https://github.com/conda/rattler/pull/905))
</blockquote>

## `rattler_cache`
<blockquote>

## [0.2.7](https://github.com/conda/rattler/compare/rattler_cache-v0.2.6...rattler_cache-v0.2.7) - 2024-10-21

### Added

- use sha in cache lock file, needed for source builds. ([#901](https://github.com/conda/rattler/pull/901))
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.33](https://github.com/conda/rattler/compare/rattler_index-v0.19.32...rattler_index-v0.19.33) - 2024-10-21

### Fixed

- always index noarch even if folder already exists ([#907](https://github.com/conda/rattler/pull/907))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.28.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.28.2...rattler_conda_types-v0.28.3) - 2024-10-21

### Other

- updated the following local packages: file_url
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.28](https://github.com/conda/rattler/compare/rattler_lock-v0.22.27...rattler_lock-v0.22.28) - 2024-10-21

### Other

- updated the following local packages: file_url
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.18](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.17...rattler_repodata_gateway-v0.21.18) - 2024-10-21

### Other

- updated the following local packages: file_url, rattler_cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).