### PR TITLE
fix: always index noarch even if folder already exists

### DIFF
--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -129,6 +129,10 @@ pub fn index(
     // Always create noarch subdir
     if !output_folder.join("noarch").exists() {
         std::fs::create_dir(output_folder.join("noarch"))?;
+    }
+
+    // Make sure that we index noarch if it is not already indexed
+    if !output_folder.join("noarch/repodata.json").exists() {
         platforms.insert("noarch".to_string());
     }
 


### PR DESCRIPTION
This will fix issues in staged recipes where the `noarch` folder is created, but empty:

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1057052&view=logs&jobId=dff6ff7b-316b-540a-5923-739df25f7012&j=dff6ff7b-316b-540a-5923-739df25f7012&t=2582809e-c3dc-5a5f-d883-fd3c8f9139aa