### PR TITLE
fix: matchspec build / version from brackets and string serialization

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -489,7 +489,7 @@ mod tests {
 
     use crate::{
         match_spec::Matches, MatchSpec, NamelessMatchSpec, PackageName, PackageRecord,
-        ParseStrictness::*, RepoDataRecord, StringMatcher, Version, VersionSpec,
+        ParseStrictness::*, RepoDataRecord, StringMatcher, Version,
     };
     use insta::assert_snapshot;
     use std::hash::{Hash, Hasher};
@@ -609,21 +609,26 @@ mod tests {
 
     #[test]
     fn precedence_version_build() {
-        let spec = MatchSpec::from_str("foo 3.0.* [version=1.2.3, build='foobar']", Strict).unwrap();
-        assert_eq!(spec.version.unwrap(), VersionSpec::from_str("3.0.*", Strict).unwrap());
-        assert_eq!(spec.build.unwrap(), StringMatcher::from_str("foobar").unwrap());
+        let spec =
+            MatchSpec::from_str("foo 3.0.* [version=1.2.3, build='foobar']", Strict).unwrap();
+        assert_eq!(spec.version.unwrap(), "1.2.3".parse().unwrap());
+        assert_eq!(spec.build.unwrap(), "foobar".parse().unwrap());
 
-        let spec = MatchSpec::from_str("foo 3.0.* abcdef[build='foobar', version=1.2.3]", Strict).unwrap();
-        assert_eq!(spec.build.unwrap(), StringMatcher::from_str("abcdef").unwrap());
-        assert_eq!(spec.version.unwrap(), VersionSpec::from_str("3.0.*", Strict).unwrap());
+        let spec =
+            MatchSpec::from_str("foo 3.0.* abcdef[build='foobar', version=1.2.3]", Strict).unwrap();
+        assert_eq!(spec.build.unwrap(), "foobar".parse().unwrap());
+        assert_eq!(spec.version.unwrap(), "1.2.3".parse().unwrap());
 
-        let spec = NamelessMatchSpec::from_str("3.0.* [version=1.2.3, build='foobar']", Strict).unwrap();
-        assert_eq!(spec.version.unwrap(), VersionSpec::from_str("3.0.*", Strict).unwrap());
-        assert_eq!(spec.build.unwrap(), StringMatcher::from_str("foobar").unwrap());
+        let spec =
+            NamelessMatchSpec::from_str("3.0.* [version=1.2.3, build='foobar']", Strict).unwrap();
+        assert_eq!(spec.version.unwrap(), "1.2.3".parse().unwrap());
+        assert_eq!(spec.build.unwrap(), "foobar".parse().unwrap());
 
-        let spec = NamelessMatchSpec::from_str("3.0.* abcdef[build='foobar', version=1.2.3]", Strict).unwrap();
-        assert_eq!(spec.build.unwrap(), StringMatcher::from_str("abcdef").unwrap());
-        assert_eq!(spec.version.unwrap(), VersionSpec::from_str("3.0.*", Strict).unwrap());
+        let spec =
+            NamelessMatchSpec::from_str("3.0.* abcdef[build='foobar', version=1.2.3]", Strict)
+                .unwrap();
+        assert_eq!(spec.build.unwrap(), "foobar".parse().unwrap());
+        assert_eq!(spec.version.unwrap(), "1.2.3".parse().unwrap());
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -181,11 +181,23 @@ impl Display for MatchSpec {
         let mut keys = Vec::new();
 
         if let Some(md5) = &self.md5 {
-            keys.push(format!("md5={md5:x}"));
+            keys.push(format!("md5=\"{md5:x}\""));
         }
 
         if let Some(sha256) = &self.sha256 {
-            keys.push(format!("sha256={sha256:x}"));
+            keys.push(format!("sha256=\"{sha256:x}\""));
+        }
+
+        if let Some(build_number) = &self.build_number {
+            keys.push(format!("build_number=\"{}\"", build_number));
+        }
+
+        if let Some(file_name) = &self.file_name {
+            keys.push(format!("fn=\"{}\"", file_name));
+        }
+
+        if let Some(url) = &self.url {
+            keys.push(format!("url=\"{}\"", url));
         }
 
         if !keys.is_empty() {
@@ -476,7 +488,8 @@ mod tests {
     use rattler_digest::{parse_digest_from_hex, Md5, Sha256};
 
     use crate::{
-        match_spec::Matches, MatchSpec, NamelessMatchSpec, PackageName, PackageRecord, ParseStrictness::*, RepoDataRecord, StringMatcher, Version
+        match_spec::Matches, MatchSpec, NamelessMatchSpec, PackageName, PackageRecord,
+        ParseStrictness::*, RepoDataRecord, StringMatcher, Version,
     };
     use insta::assert_snapshot;
     use std::hash::{Hash, Hasher};

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -189,15 +189,15 @@ impl Display for MatchSpec {
         }
 
         if let Some(build_number) = &self.build_number {
-            keys.push(format!("build_number=\"{}\"", build_number));
+            keys.push(format!("build_number=\"{build_number}\""));
         }
 
         if let Some(file_name) = &self.file_name {
-            keys.push(format!("fn=\"{}\"", file_name));
+            keys.push(format!("fn=\"{file_name}\""));
         }
 
         if let Some(url) = &self.url {
-            keys.push(format!("url=\"{}\"", url));
+            keys.push(format!("url=\"{url}\""));
         }
 
         if !keys.is_empty() {

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1287,4 +1287,50 @@ mod tests {
             assert_eq!(subdir, expected_subdir.map(ToString::to_string));
         }
     }
+
+    #[test]
+    fn test_matchspec_to_string() {
+        let mut specs: Vec<MatchSpec> =
+            vec![MatchSpec::from_str("foo[version=1.0.*, build_number=\">6\"]", Strict).unwrap()];
+
+        // complete matchspec to verify that we print all fields
+        specs.push(MatchSpec {
+            name: Some("foo".parse().unwrap()),
+            version: Some(VersionSpec::from_str("1.0.*", Strict).unwrap()),
+            build: "py27_0*".parse().ok(),
+            build_number: Some(BuildNumberSpec::from_str(">=6").unwrap()),
+            file_name: Some("foo-1.0-py27_0.tar.bz2".to_string()),
+            channel: Some(
+                Channel::from_str("conda-forge", &channel_config())
+                    .map(Arc::new)
+                    .unwrap(),
+            ),
+            subdir: Some("linux-64".to_string()),
+            namespace: Some("foospace".to_string()),
+            md5: Some(parse_digest_from_hex::<Md5>("8b1a9953c4611296a827abf8c47804d7").unwrap()),
+            sha256: Some(
+                parse_digest_from_hex::<Sha256>(
+                    "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
+                )
+                .unwrap(),
+            ),
+            url: Some(
+                Url::parse(
+                    "https://conda.anaconda.org/conda-forge/linux-64/foo-1.0-py27_0.tar.bz2",
+                )
+                .unwrap(),
+            ),
+        });
+
+        // insta check all the strings
+        let vec_strings = specs.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        insta::assert_debug_snapshot!(vec_strings);
+
+        // parse back the strings and check if they are the same
+        let parsed_specs = vec_strings
+            .iter()
+            .map(|s| MatchSpec::from_str(s, Strict).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(specs, parsed_specs);
+    }
 }

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -482,8 +482,8 @@ impl NamelessMatchSpec {
         // Get the version and optional build string
         if !input.is_empty() {
             let (version, build) = parse_version_and_build(input, strictness)?;
-            match_spec.version = version;
-            match_spec.build = build;
+            match_spec.version = version.or(match_spec.version);
+            match_spec.build = build.or(match_spec.build)
         }
 
         Ok(match_spec)
@@ -578,8 +578,8 @@ fn matchspec_parser(
     let input = input.trim();
     if !input.is_empty() {
         let (version, build) = parse_version_and_build(input, strictness)?;
-        match_spec.version = version;
-        match_spec.build = build;
+        match_spec.version = version.or(match_spec.version);
+        match_spec.build = build.or(match_spec.build);
     }
 
     Ok(match_spec)
@@ -772,9 +772,11 @@ mod tests {
             NamelessMatchSpec::from_str("*cpu*", Strict).unwrap(),
             NamelessMatchSpec::from_str("conda-forge::foobar", Strict).unwrap(),
             NamelessMatchSpec::from_str("foobar[channel=conda-forge]", Strict).unwrap(),
+            NamelessMatchSpec::from_str("* [build=foo]", Strict).unwrap(),
+            NamelessMatchSpec::from_str(">=1.2[build=foo]", Strict).unwrap(),
+            NamelessMatchSpec::from_str("[version='>=1.2', build=foo]", Strict).unwrap(),
         ],
         @r###"
-        ---
         - version: 3.8.*
           build: "*_cpython"
         - version: "==1.0"
@@ -792,6 +794,12 @@ mod tests {
           channel:
             base_url: "https://conda.anaconda.org/conda-forge/"
             name: conda-forge
+        - version: "*"
+          build: foo
+        - version: ">=1.2"
+          build: foo
+        - version: ">=1.2"
+          build: foo
         "###);
     }
 

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -483,7 +483,7 @@ impl NamelessMatchSpec {
         if !input.is_empty() {
             let (version, build) = parse_version_and_build(input, strictness)?;
             match_spec.version = version.or(match_spec.version);
-            match_spec.build = build.or(match_spec.build)
+            match_spec.build = build.or(match_spec.build);
         }
 
         Ok(match_spec)

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -482,8 +482,8 @@ impl NamelessMatchSpec {
         // Get the version and optional build string
         if !input.is_empty() {
             let (version, build) = parse_version_and_build(input, strictness)?;
-            match_spec.version = version.or(match_spec.version);
-            match_spec.build = build.or(match_spec.build);
+            match_spec.version = match_spec.version.or(version);
+            match_spec.build = match_spec.build.or(build);
         }
 
         Ok(match_spec)
@@ -578,8 +578,8 @@ fn matchspec_parser(
     let input = input.trim();
     if !input.is_empty() {
         let (version, build) = parse_version_and_build(input, strictness)?;
-        match_spec.version = version.or(match_spec.version);
-        match_spec.build = build.or(match_spec.build);
+        match_spec.version = match_spec.version.or(version);
+        match_spec.build = match_spec.build.or(build);
     }
 
     Ok(match_spec)

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__matchspec_to_string.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__matchspec_to_string.snap
@@ -1,0 +1,8 @@
+---
+source: crates/rattler_conda_types/src/match_spec/parse.rs
+expression: vec_strings
+---
+[
+    "foo 1.0.*[build_number=\">6\"]",
+    "conda-forge/linux-64:foospace:foo 1.0.* py27_0*[md5=\"8b1a9953c4611296a827abf8c47804d7\", sha256=\"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3\", build_number=\">=6\", fn=\"foo-1.0-py27_0.tar.bz2\", url=\"https://conda.anaconda.org/conda-forge/linux-64/foo-1.0-py27_0.tar.bz2\"]",
+]

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -10,9 +10,9 @@ blas *.* mkl:
   name: foo
   url: "file:///C:/Users/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2"
 foo=1.0=py27_0:
-  error: "The build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
+  error: "the build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
 foo==1.0=py27_0:
-  error: "The build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
+  error: "the build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
 "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda":
   name: py-rattler
   url: "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda"
@@ -24,7 +24,7 @@ python 3.8.* *_cpython:
   version: 3.8.*
   build: "*_cpython"
 pytorch=*=cuda*:
-  error: "The build string '=cuda*' is not valid, it can only contain alphanumeric characters and underscores"
+  error: "the build string '=cuda*' is not valid, it can only contain alphanumeric characters and underscores"
 "x264 >=1!164.3095,<1!165":
   name: x264
   version: ">=1!164.3095,<1!165"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
@@ -14,9 +14,9 @@ expression: evaluated
 "C:\\Users\\user\\conda-bld\\linux-64\\foo-1.0-py27_0.tar.bz2":
   url: "file:///C:/Users/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2"
 "=1.0=py27_0":
-  error: "The build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
+  error: "the build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
 "==1.0=py27_0":
-  error: "The build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
+  error: "the build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
 "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda":
   url: "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda"
 "https://repo.prefix.dev/ruben-arts/linux-64/boost-cpp-1.78.0-h75c5d50_1.tar.bz2":
@@ -25,7 +25,7 @@ expression: evaluated
   version: 3.8.*
   build: "*_cpython"
 "=*=cuda*":
-  error: "The build string '=cuda*' is not valid, it can only contain alphanumeric characters and underscores"
+  error: "the build string '=cuda*' is not valid, it can only contain alphanumeric characters and underscores"
 ">=1!164.3095,<1!165":
   version: ">=1!164.3095,<1!165"
 /home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__tests__serialize_matchspec.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__tests__serialize_matchspec.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/mod.rs
-expression: "specs.into_iter().map(|s|\n                    MatchSpec::from_str(s).unwrap()).map(|s|\n                s.to_string()).collect::<Vec<String>>().join(\"\\n\")"
+expression: "specs.into_iter().map(|s|\nMatchSpec::from_str(s,\nStrict).unwrap()).map(|s| s.to_string()).collect::<Vec<String>>().join(\"\\n\")"
 ---
 mamba ==1.0 py37_0
-conda-forge::pytest ==1.0[md5=dede6252c964db3f3e41c7d30d07f6bf, sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97]
+conda-forge::pytest ==1.0[md5="dede6252c964db3f3e41c7d30d07f6bf", sha256="aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97"]
 conda-forge/linux-64::pytest
 conda-forge/linux-64::pytest ==1.0
 conda-forge/linux-64::pytest ==1.0 py37_0


### PR DESCRIPTION
We were parsing brackets correctly, but we overrode it with `None`.

This fixes matchspecs like `foo * [build="*bla*"]`

For now this is no error when the build string is set twice (e.g. `foo * bar*[build="baz"]`). I am not sure if we _should_ treat that as an error (at least in strict mode?). Same goes for the version.

cc @jaimergp thanks for discovering this today!