### PR TITLE
fix: solver crash when using unrelated locked record

### DIFF
--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -373,8 +373,6 @@ impl<'a> CondaDependencyProvider<'a> {
                         &record.channel,
                     );
                 }
-
-                candidates.hint_dependencies_available.push(solvable_id);
             }
         }
 
@@ -393,6 +391,11 @@ impl<'a> CondaDependencyProvider<'a> {
             let candidates = records.entry(name).or_default();
             candidates.candidates.push(solvable);
             candidates.locked = Some(solvable);
+        }
+
+        // The dependencies for all candidates are always available.
+        for candidates in records.values_mut() {
+            candidates.hint_dependencies_available = candidates.candidates.clone();
         }
 
         Ok(Self {


### PR DESCRIPTION
This fixes a hard crash in the solver when a locked package was used that did match the input spec but was otherwise completely unrelated from the candidates themselves. 