### PR TITLE
feat: set cache directory

### DIFF
--- a/crates/rattler_cache/src/lib.rs
+++ b/crates/rattler_cache/src/lib.rs
@@ -10,8 +10,8 @@ pub use consts::{PACKAGE_CACHE_DIR, REPODATA_CACHE_DIR};
 
 /// Determines the default cache directory for rattler.
 /// It first checks the environment variable `RATTLER_CACHE_DIR`.
-/// If not set, it falls back to the environment variable `XDG_CACHE_HOME`.
-/// If not set, it falls back to the standard cache directory provided by `dirs::cache_dir()`.
+/// If not set, it falls back to `XDG_CACHE_HOME/rattler/cache`.
+/// If not set, it falls back to the standard cache directory provided by `dirs::cache_dir()/rattler/cache`.
 pub fn default_cache_dir() -> anyhow::Result<PathBuf> {
     Ok(std::env::var("RATTLER_CACHE_DIR")
         .map(PathBuf::from)
@@ -23,6 +23,11 @@ pub fn default_cache_dir() -> anyhow::Result<PathBuf> {
                         anyhow::anyhow!("could not determine cache directory for current platform")
                     })
                 })
-        })?
-        .join("rattler/cache"))
+                // Append `rattler/cache` to the cache directory
+                .map(|mut p| {
+                    p.push("rattler");
+                    p.push("cache");
+                    p
+                })
+        })?)
 }

--- a/crates/rattler_cache/src/lib.rs
+++ b/crates/rattler_cache/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::Ok;
 use std::path::PathBuf;
 
 pub mod package_cache;
@@ -7,9 +8,21 @@ pub mod validation;
 mod consts;
 pub use consts::{PACKAGE_CACHE_DIR, REPODATA_CACHE_DIR};
 
-/// Returns the default cache directory used by rattler.
+/// Determines the default cache directory for rattler.
+/// It first checks the environment variable `RATTLER_CACHE_DIR`.
+/// If not set, it falls back to the environment variable `XDG_CACHE_HOME`.
+/// If not set, it falls back to the standard cache directory provided by `dirs::cache_dir()`.
 pub fn default_cache_dir() -> anyhow::Result<PathBuf> {
-    Ok(dirs::cache_dir()
-        .ok_or_else(|| anyhow::anyhow!("could not determine cache directory for current platform"))?
+    Ok(std::env::var("RATTLER_CACHE_DIR")
+        .map(PathBuf::from)
+        .or_else(|_| {
+            std::env::var("XDG_CACHE_HOME")
+                .map(PathBuf::from)
+                .or_else(|_| {
+                    dirs::cache_dir().ok_or_else(|| {
+                        anyhow::anyhow!("could not determine cache directory for current platform")
+                    })
+                })
+        })?
         .join("rattler/cache"))
 }

--- a/crates/rattler_cache/src/lib.rs
+++ b/crates/rattler_cache/src/lib.rs
@@ -11,7 +11,7 @@ pub use consts::{PACKAGE_CACHE_DIR, REPODATA_CACHE_DIR};
 /// It first checks the environment variable `RATTLER_CACHE_DIR`.
 /// If not set, it falls back to the standard cache directory provided by `dirs::cache_dir()/rattler/cache`.
 pub fn default_cache_dir() -> anyhow::Result<PathBuf> {
-    Ok(std::env::var("RATTLER_CACHE_DIR")
+    std::env::var("RATTLER_CACHE_DIR")
         .map(PathBuf::from)
         .or_else(|_| {
             dirs::cache_dir()
@@ -24,5 +24,5 @@ pub fn default_cache_dir() -> anyhow::Result<PathBuf> {
                     p.push("cache");
                     p
                 })
-        })?)
+        })
 }

--- a/crates/rattler_cache/src/lib.rs
+++ b/crates/rattler_cache/src/lib.rs
@@ -1,4 +1,3 @@
-use anyhow::Ok;
 use std::path::PathBuf;
 
 pub mod package_cache;
@@ -10,18 +9,14 @@ pub use consts::{PACKAGE_CACHE_DIR, REPODATA_CACHE_DIR};
 
 /// Determines the default cache directory for rattler.
 /// It first checks the environment variable `RATTLER_CACHE_DIR`.
-/// If not set, it falls back to `XDG_CACHE_HOME/rattler/cache`.
 /// If not set, it falls back to the standard cache directory provided by `dirs::cache_dir()/rattler/cache`.
 pub fn default_cache_dir() -> anyhow::Result<PathBuf> {
     Ok(std::env::var("RATTLER_CACHE_DIR")
         .map(PathBuf::from)
         .or_else(|_| {
-            std::env::var("XDG_CACHE_HOME")
-                .map(PathBuf::from)
-                .or_else(|_| {
-                    dirs::cache_dir().ok_or_else(|| {
-                        anyhow::anyhow!("could not determine cache directory for current platform")
-                    })
+            dirs::cache_dir()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("could not determine cache directory for current platform")
                 })
                 // Append `rattler/cache` to the cache directory
                 .map(|mut p| {


### PR DESCRIPTION
This PR allows setting the cache directory using `RATTLER_CACHE_DIR` or `XDG_CACHE_HOME` and fallback to the current `dirs::cache_dir()` if needed.

I think it makes sense to have this logic into rattler directly but the use case was for rattler-build: https://github.com/prefix-dev/rattler-build/issues/1171