### PR TITLE
fix:  Release downloader lock before re-attempting fallback download 

### DIFF
--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -159,6 +159,9 @@ pub async fn extract_conda(
             if (zip_error.contains(DATA_DESCRIPTOR_ERROR_MESSAGE)) =>
         {
             tracing::warn!("Failed to stream decompress conda package from '{}' due to the presence of zip data descriptors. Falling back to non streaming decompression", url);
+            if let Some(reporter) = &reporter {
+                reporter.on_download_complete();
+            }
             let new_reader =
                 get_reader(url.clone(), client, expected_sha256, reporter.clone()).await?;
             crate::tokio::async_read::extract_conda_via_buffering(new_reader, destination).await

--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -164,7 +164,18 @@ pub async fn extract_conda(
             }
             let new_reader =
                 get_reader(url.clone(), client, expected_sha256, reporter.clone()).await?;
-            crate::tokio::async_read::extract_conda_via_buffering(new_reader, destination).await
+
+            match crate::tokio::async_read::extract_conda_via_buffering(new_reader, destination)
+                .await
+            {
+                Ok(result) => {
+                    if let Some(reporter) = &reporter {
+                        reporter.on_download_complete();
+                    }
+                    Ok(result)
+                }
+                Err(e) => Err(e),
+            }
         }
         Err(e) => Err(e),
     }


### PR DESCRIPTION

### Description
In https://github.com/conda/rattler/pull/837 locking logic was added to the download reporter to prevent multiple downloads.

This was clashing with the logic added in https://github.com/conda/rattler/pull/797 where, if we detect we're trying to download a zip that has data descriptors, we fallback to doing a full download and interrupt the streaming decompression download.

The issue comes from us not releasing the lock before attempting the second download, hitting this line https://github.com/conda/rattler/blob/8bb883536df52de46fd2c040228bb77d39c92607/crates/rattler_cache/src/package_cache/mod.rs#L439

As a fix, we report the previous download as completed before attempting the second one! Have verified in my custom setup that this works.
