### PR TITLE
feat: py-rattler - add more types to construct a paths.json type

### DIFF
--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "console",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.34"
+version = "0.19.35"
 dependencies = [
  "fs-err 3.0.0",
  "rattler_conda_types",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.29"
+version = "0.22.30"
 dependencies = [
  "chrono",
  "file_url",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.11"
+version = "0.22.12"
 dependencies = [
  "bzip2",
  "chrono",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.20"
+version = "0.21.21"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "enum_dispatch",
  "fs-err 3.0.0",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "chrono",
  "futures",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "1.1.8"
+version = "1.1.9"
 dependencies = [
  "archspec",
  "libloading",


### PR DESCRIPTION
Adds lots of setters to the paths_json and related types.

Some of the `enum`'s could be exposed in a more Pythonic way but we can also do that later :)