### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.28.2", default-features = false, features = ["indicatif"] }
+rattler = { path="../rattler", version = "0.28.3", default-features = false, features = ["indicatif"] }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.29.2", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.21.5", default-features = false, features = ["gcs"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.22", default-features = false, features = ["gateway"] }
+rattler_networking = { path="../rattler_networking", version = "0.21.6", default-features = false, features = ["gcs"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.23", default-features = false, features = ["gateway"] }
 rattler_solve = { path="../rattler_solve", version = "1.2.3", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.10", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.2.10", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.2.11", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.3](https://github.com/conda/rattler/compare/rattler-v0.28.2...rattler-v0.28.3) - 2024-11-18
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.28.2](https://github.com/conda/rattler/compare/rattler-v0.28.1...rattler-v0.28.2) - 2024-11-18
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.28.2"
+version = "0.28.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.2.10", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.2.11", default-features = false }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.2", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.5", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.6", default-features = false }
 rattler_shell = { path = "../rattler_shell", version = "0.22.7", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.13", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.14", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11](https://github.com/conda/rattler/compare/rattler_cache-v0.2.10...rattler_cache-v0.2.11) - 2024-11-18
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.2.10](https://github.com/conda/rattler/compare/rattler_cache-v0.2.9...rattler_cache-v0.2.10) - 2024-11-18
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.2.10"
+version = "0.2.11"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -19,8 +19,8 @@ itertools.workspace = true
 parking_lot.workspace = true
 rattler_conda_types = { version = "0.29.2", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.3", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.21.5", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.13", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_networking = { version = "0.21.6", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.14", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 fs-err = { workspace = true }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.29.2", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.3", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.13", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.14", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.6](https://github.com/conda/rattler/compare/rattler_networking-v0.21.5...rattler_networking-v0.21.6) - 2024-11-18
+
+### Added
+
+- more setters for about.json and index.json  ([#939](https://github.com/conda/rattler/pull/939))
+
 ## [0.21.5](https://github.com/conda/rattler/compare/rattler_networking-v0.21.4...rattler_networking-v0.21.5) - 2024-11-04
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.21.5"
+version = "0.21.6"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.14](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.13...rattler_package_streaming-v0.22.14) - 2024-11-18
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.22.13](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.12...rattler_package_streaming-v0.22.13) - 2024-11-18
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.13"
+version = "0.22.14"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -17,7 +17,7 @@ futures-util = { workspace = true }
 num_cpus = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.2", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.5", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.6", default-features = false }
 rattler_redaction = { version = "0.1.3", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.23](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.22...rattler_repodata_gateway-v0.21.23) - 2024-11-18
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.21.22](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.21...rattler_repodata_gateway-v0.21.22) - 2024-11-18
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.22"
+version = "0.21.23"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -38,7 +38,7 @@ parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.2", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.21.5", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.6", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -54,7 +54,7 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.2.10", path = "../rattler_cache" }
+rattler_cache = { version = "0.2.11", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.3", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
## 🤖 New release
* `rattler_networking`: 0.21.5 -> 0.21.6 (✓ API compatible changes)
* `rattler`: 0.28.2 -> 0.28.3
* `rattler_cache`: 0.2.10 -> 0.2.11
* `rattler_package_streaming`: 0.22.13 -> 0.22.14
* `rattler_repodata_gateway`: 0.21.22 -> 0.21.23

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_networking`
<blockquote>

## [0.21.6](https://github.com/conda/rattler/compare/rattler_networking-v0.21.5...rattler_networking-v0.21.6) - 2024-11-18

### Added

- more setters for about.json and index.json  ([#939](https://github.com/conda/rattler/pull/939))
</blockquote>

## `rattler`
<blockquote>

## [0.28.3](https://github.com/conda/rattler/compare/rattler-v0.28.2...rattler-v0.28.3) - 2024-11-18

### Other

- updated the following local packages: rattler_networking
</blockquote>

## `rattler_cache`
<blockquote>

## [0.2.11](https://github.com/conda/rattler/compare/rattler_cache-v0.2.10...rattler_cache-v0.2.11) - 2024-11-18

### Other

- updated the following local packages: rattler_networking
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.22.14](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.13...rattler_package_streaming-v0.22.14) - 2024-11-18

### Other

- updated the following local packages: rattler_networking
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.23](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.22...rattler_repodata_gateway-v0.21.23) - 2024-11-18

### Other

- updated the following local packages: rattler_networking
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).