### PR TITLE
chore: release

### DIFF
--- a/crates/file_url/CHANGELOG.md
+++ b/crates/file_url/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/conda/rattler/compare/file_url-v0.1.7...file_url-v0.2.0) - 2024-11-30
+
+### Added
+
+- merge pixi-build branch ([#950](https://github.com/conda/rattler/pull/950))
+
 ## [0.1.7](https://github.com/conda/rattler/compare/file_url-v0.1.6...file_url-v0.1.7) - 2024-11-04
 
 ### Other

--- a/crates/file_url/Cargo.toml
+++ b/crates/file_url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_url"
-version = "0.1.7"
+version = "0.2.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Helper functions to work with file:// urls"

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.28.3", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.2", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.21.6", default-features = false, features = ["gcs"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.23", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.2.3", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.10", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.2.11", default-features = false }
+rattler = { path="../rattler", version = "0.28.4", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.3", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.21.7", default-features = false, features = ["gcs"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.24", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.2.4", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.11", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.2.12", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.4](https://github.com/conda/rattler/compare/rattler-v0.28.3...rattler-v0.28.4) - 2024-11-30
+
+### Added
+
+- use `fs-err` also for tokio ([#958](https://github.com/conda/rattler/pull/958))
+- Move files to .trash folder if they are in use ([#953](https://github.com/conda/rattler/pull/953))
+- merge pixi-build branch ([#950](https://github.com/conda/rattler/pull/950))
+
 ## [0.28.3](https://github.com/conda/rattler/compare/rattler-v0.28.2...rattler-v0.28.3) - 2024-11-18
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.28.3"
+version = "0.28.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.2.11", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.2", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.2.12", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.6", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.7", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.14", default-features = false, features = ["reqwest"] }
+rattler_networking = { path = "../rattler_networking", version = "0.21.7", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.8", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.15", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12](https://github.com/conda/rattler/compare/rattler_cache-v0.2.11...rattler_cache-v0.2.12) - 2024-11-30
+
+### Added
+
+- use `fs-err` also for tokio ([#958](https://github.com/conda/rattler/pull/958))
+
 ## [0.2.11](https://github.com/conda/rattler/compare/rattler_cache-v0.2.10...rattler_cache-v0.2.11) - 2024-11-18
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.2.11"
+version = "0.2.12"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,10 +18,10 @@ fs-err.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.29.2", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.29.3", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.3", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.21.6", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.14", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_networking = { version = "0.21.7", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.15", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.2...rattler_conda_types-v0.29.3) - 2024-11-30
+
+### Added
+
+- merge pixi-build branch ([#950](https://github.com/conda/rattler/pull/950))
+
+### Fixed
+
+- `pixi project version` doesn't reset minor and patch version numbers ([#954](https://github.com/conda/rattler/pull/954))
+
 ## [0.29.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.1...rattler_conda_types-v0.29.2) - 2024-11-18
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.29.2"
+version = "0.29.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -12,7 +12,7 @@ readme.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-file_url = { path = "../file_url", version = "0.1.7" }
+file_url = { path = "../file_url", version = "0.2.0" }
 fxhash = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }
@@ -37,7 +37,7 @@ tracing = { workspace = true }
 typed-path = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 indexmap = { workspace = true }
-rattler_redaction = { version = "0.1.3", path = "../rattler_redaction" }
+rattler_redaction = { version = "0.1.4", path = "../rattler_redaction" }
 dirs = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.37](https://github.com/conda/rattler/compare/rattler_index-v0.19.36...rattler_index-v0.19.37) - 2024-11-30
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_package_streaming
+
 ## [0.19.36](https://github.com/conda/rattler/compare/rattler_index-v0.19.35...rattler_index-v0.19.36) - 2024-11-18
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.36"
+version = "0.19.37"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.3", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.3", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.14", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.15", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.32](https://github.com/conda/rattler/compare/rattler_lock-v0.22.31...rattler_lock-v0.22.32) - 2024-11-30
+
+### Other
+
+- updated the following local packages: file_url, rattler_conda_types
+
 ## [0.22.31](https://github.com/conda/rattler/compare/rattler_lock-v0.22.30...rattler_lock-v0.22.31) - 2024-11-18
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.31"
+version = "0.22.32"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,9 +15,9 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
-file_url = { path = "../file_url", version = "0.1.7" }
+file_url = { path = "../file_url", version = "0.2.0" }
 pep508_rs = { workspace = true }
 pep440_rs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.7](https://github.com/conda/rattler/compare/rattler_networking-v0.21.6...rattler_networking-v0.21.7) - 2024-11-30
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.21.6](https://github.com/conda/rattler/compare/rattler_networking-v0.21.5...rattler_networking-v0.21.6) - 2024-11-18
 
 ### Added

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.21.6"
+version = "0.21.7"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.15](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.14...rattler_package_streaming-v0.22.15) - 2024-11-30
+
+### Added
+
+- use `fs-err` also for tokio ([#958](https://github.com/conda/rattler/pull/958))
+
 ## [0.22.14](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.13...rattler_package_streaming-v0.22.14) - 2024-11-18
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.14"
+version = "0.22.15"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,10 +16,10 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.6", default-features = false }
-rattler_redaction = { version = "0.1.3", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+rattler_networking = { path = "../rattler_networking", version = "0.21.7", default-features = false }
+rattler_redaction = { version = "0.1.4", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_redaction/CHANGELOG.md
+++ b/crates/rattler_redaction/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.3...rattler_redaction-v0.1.4) - 2024-11-30
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.3](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.2...rattler_redaction-v0.1.3) - 2024-11-04
 
 ### Other

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_redaction"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Redact sensitive information from URLs (ie. conda tokens)"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.24](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.23...rattler_repodata_gateway-v0.21.24) - 2024-11-30
+
+### Added
+
+- use `fs-err` also for tokio ([#958](https://github.com/conda/rattler/pull/958))
+
 ## [0.21.23](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.22...rattler_repodata_gateway-v0.21.23) - 2024-11-18
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.23"
+version = "0.21.24"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -22,7 +22,7 @@ cache_control = { workspace = true }
 chrono = { workspace = true, features = ["std", "serde", "alloc", "clock"] }
 dashmap = { workspace = true }
 dirs = { workspace = true }
-file_url = { path = "../file_url", version = "0.1.7" }
+file_url = { path = "../file_url", version = "0.2.0" }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 http = { workspace = true, optional = true }
@@ -36,9 +36,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.2", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.21.6", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.7", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -54,8 +54,8 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.2.11", path = "../rattler_cache" }
-rattler_redaction = { version = "0.1.3", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+rattler_cache = { version = "0.2.12", path = "../rattler_cache" }
+rattler_redaction = { version = "0.1.4", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.8](https://github.com/conda/rattler/compare/rattler_shell-v0.22.7...rattler_shell-v0.22.8) - 2024-11-30
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.7](https://github.com/conda/rattler/compare/rattler_shell-v0.22.6...rattler_shell-v0.22.7) - 2024-11-18
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.7"
+version = "0.22.8"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.3", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4](https://github.com/conda/rattler/compare/rattler_solve-v1.2.3...rattler_solve-v1.2.4) - 2024-11-30
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [1.2.3](https://github.com/conda/rattler/compare/rattler_solve-v1.2.2...rattler_solve-v1.2.3) - 2024-11-18
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.2.3"
+version = "1.2.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.11](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.10...rattler_virtual_packages-v1.1.11) - 2024-11-30
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [1.1.10](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.9...rattler_virtual_packages-v1.1.10) - 2024-11-18
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "1.1.10"
+version = "1.1.11"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.3", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `file_url`: 0.1.7 -> 0.2.0 (⚠️ API breaking changes)
* `rattler`: 0.28.3 -> 0.28.4 (✓ API compatible changes)
* `rattler_cache`: 0.2.11 -> 0.2.12 (✓ API compatible changes)
* `rattler_conda_types`: 0.29.2 -> 0.29.3 (✓ API compatible changes)
* `rattler_redaction`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.14 -> 0.22.15 (✓ API compatible changes)
* `rattler_networking`: 0.21.6 -> 0.21.7 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.21.23 -> 0.21.24 (✓ API compatible changes)
* `rattler_shell`: 0.22.7 -> 0.22.8
* `rattler_lock`: 0.22.31 -> 0.22.32
* `rattler_solve`: 1.2.3 -> 1.2.4
* `rattler_virtual_packages`: 1.1.10 -> 1.1.11
* `rattler_index`: 0.19.36 -> 0.19.37

### ⚠️ `file_url` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum file_url::FileURLParseError, previously in file /tmp/.tmpwniEdC/file_url/src/lib.rs:159
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `file_url`
<blockquote>

## [0.2.0](https://github.com/conda/rattler/compare/file_url-v0.1.7...file_url-v0.2.0) - 2024-11-30

### Added

- merge pixi-build branch ([#950](https://github.com/conda/rattler/pull/950))
</blockquote>

## `rattler`
<blockquote>

## [0.28.4](https://github.com/conda/rattler/compare/rattler-v0.28.3...rattler-v0.28.4) - 2024-11-30

### Added

- use `fs-err` also for tokio ([#958](https://github.com/conda/rattler/pull/958))
- Move files to .trash folder if they are in use ([#953](https://github.com/conda/rattler/pull/953))
- merge pixi-build branch ([#950](https://github.com/conda/rattler/pull/950))
</blockquote>

## `rattler_cache`
<blockquote>

## [0.2.12](https://github.com/conda/rattler/compare/rattler_cache-v0.2.11...rattler_cache-v0.2.12) - 2024-11-30

### Added

- use `fs-err` also for tokio ([#958](https://github.com/conda/rattler/pull/958))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.29.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.2...rattler_conda_types-v0.29.3) - 2024-11-30

### Added

- merge pixi-build branch ([#950](https://github.com/conda/rattler/pull/950))

### Fixed

- `pixi project version` doesn't reset minor and patch version numbers ([#954](https://github.com/conda/rattler/pull/954))
</blockquote>

## `rattler_redaction`
<blockquote>

## [0.1.4](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.3...rattler_redaction-v0.1.4) - 2024-11-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.22.15](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.14...rattler_package_streaming-v0.22.15) - 2024-11-30

### Added

- use `fs-err` also for tokio ([#958](https://github.com/conda/rattler/pull/958))
</blockquote>

## `rattler_networking`
<blockquote>

## [0.21.7](https://github.com/conda/rattler/compare/rattler_networking-v0.21.6...rattler_networking-v0.21.7) - 2024-11-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.24](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.23...rattler_repodata_gateway-v0.21.24) - 2024-11-30

### Added

- use `fs-err` also for tokio ([#958](https://github.com/conda/rattler/pull/958))
</blockquote>

## `rattler_shell`
<blockquote>

## [0.22.8](https://github.com/conda/rattler/compare/rattler_shell-v0.22.7...rattler_shell-v0.22.8) - 2024-11-30

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.32](https://github.com/conda/rattler/compare/rattler_lock-v0.22.31...rattler_lock-v0.22.32) - 2024-11-30

### Other

- updated the following local packages: file_url, rattler_conda_types
</blockquote>

## `rattler_solve`
<blockquote>

## [1.2.4](https://github.com/conda/rattler/compare/rattler_solve-v1.2.3...rattler_solve-v1.2.4) - 2024-11-30

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [1.1.11](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.10...rattler_virtual_packages-v1.1.11) - 2024-11-30

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.37](https://github.com/conda/rattler/compare/rattler_index-v0.19.36...rattler_index-v0.19.37) - 2024-11-30

### Other

- updated the following local packages: rattler_conda_types, rattler_package_streaming
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).