### PR TITLE
fix: make `rattler_index::index` concurrency safe

### DIFF
--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -18,6 +18,7 @@ rattler_package_streaming = { path="../rattler_package_streaming", version = "0.
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }
+fslock = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -203,6 +203,9 @@ pub fn index(
             };
         }
         let out_file = output_folder.join(platform).join("repodata.json");
+        let lock_file_path = out_file.with_extension("lock");
+        let mut lock = fslock::LockFile::open(&lock_file_path)?;
+        lock.lock_with_pid()?;
         File::create(&out_file)?.write_all(serde_json::to_string_pretty(&repodata)?.as_bytes())?;
     }
 

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir.rs
@@ -48,9 +48,13 @@ impl RemoteSubdirClient {
             e => GatewayError::FetchRepoDataError(e),
         })?;
 
+        let repo_data_json_path = repodata.repo_data_json_path.clone();
+        // repodata holds onto a file lock for json file that sparse will need
+        drop(repodata);
+
         // Create a new sparse repodata client that can be used to read records from the repodata.
         let sparse = LocalSubdirClient::from_channel_subdir(
-            &repodata.repo_data_json_path,
+            &repo_data_json_path,
             channel.clone(),
             platform.as_str(),
         )

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -111,18 +111,14 @@ impl SparseRepoData {
         path: impl AsRef<Path>,
         patch_function: Option<fn(&mut PackageRecord)>,
     ) -> Result<Self, io::Error> {
-        if !path.as_ref().exists() {
-            Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("file not found: {:?}", path.as_ref()),
-            ))
-        } else {
+        if path.as_ref().exists() {
             let lock_file_path = path.as_ref().with_extension("lock");
             if !lock_file_path.exists() {
                 OpenOptions::new()
                     .read(true)
                     .write(true)
                     .create(true)
+                    .truncate(false)
                     .open(&lock_file_path)?;
             }
             let lock_file = LockedFile::open_ro(lock_file_path, "repodata cache")
@@ -142,6 +138,11 @@ impl SparseRepoData {
                 patch_record_fn: patch_function,
                 _lock: Some(lock_file),
             })
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("file not found: {:?}", path.as_ref()),
+            ))
         }
     }
 

--- a/py-rattler/src/networking/mod.rs
+++ b/py-rattler/src/networking/mod.rs
@@ -67,7 +67,9 @@ pub fn py_fetch_repo_data<'a>(
                 .into_iter()
                 .map(|(cache, chan)| {
                     let path = cache_path.to_string_lossy().into_owned();
-                    PySparseRepoData::new(chan, path, cache.repo_data_json_path)
+                    let repo_data_json_path = cache.repo_data_json_path.clone();
+                    drop(cache);
+                    PySparseRepoData::new(chan, path, repo_data_json_path)
                 })
                 .collect::<Result<Vec<_>, _>>(),
             Err(e) => Err(PyRattlerError::from(e).into()),


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

I've been trying to run multiple rattler-build processes concurrently and ran into a few issues mentioned here.

https://github.com/prefix-dev/rattler-build/issues/1149#issuecomment-2489321029

Whenever `rattler_index::index` was called it would error either because another process was trying to also call `rattler_index::index` or a `SparseRepoData` had one of the files memory mapped.  This PR adds locks to both locations.

The name of the lock files used match the one already used by `rattler_repodata_gateway::fetch::fetch_repo_data`


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
