### PR TITLE
fix: Add reqwest/rustls-tls-native-roots to rustls-tls feature in py-rattler

### DIFF
--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [features]
 default = ["rustls-tls"]
 native-tls = ["rattler_networking/native-tls", "rattler_repodata_gateway/native-tls"]
-rustls-tls = ["rattler_networking/rustls-tls", "rattler_repodata_gateway/rustls-tls"]
+rustls-tls = ["rattler_networking/rustls-tls", "rattler_repodata_gateway/rustls-tls", "reqwest/rustls-tls-native-roots",]
 vendored-openssl = ["openssl", "openssl/vendored"]
 
 [dependencies]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We noticed that the `py-rattler` PyPI release ignores custom certificates bundles.
We added the `reqwest/rustls-tls-native-roots` library to the `rustls-tls` feature in accordance with [how Pixi does it](https://github.com/prefix-dev/pixi/blob/1650d6a9ae4478ac7c312923579ecdba7de1824a/Cargo.toml#L168).
We tested this locally and it seems to resolve our issue.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
