### PR TITLE
feat: upgrade reqwest middleware and retry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,8 @@ rand = "0.8.5"
 reflink-copy = "0.1.19"
 regex = "1.11.1"
 reqwest = { version = "0.12.9", default-features = false }
-reqwest-middleware = "0.3.3"
-reqwest-retry = "0.6.1"
+reqwest-middleware = "0.4.0"
+reqwest-retry = "0.7.0"
 resolvo = { version = "0.8.4" }
 retry-policies = { version = "0.4.0", default-features = false }
 rmp-serde = { version = "1.3.0" }

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.28.1"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "console",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.2.9"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.35"
+version = "0.19.36"
 dependencies = [
  "fs-err 3.0.0",
  "rattler_conda_types",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.30"
+version = "0.22.31"
 dependencies = [
  "chrono",
  "file_url",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.21.5"
+version = "0.21.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.12"
+version = "0.22.14"
 dependencies = [
  "bzip2",
  "chrono",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.21"
+version = "0.21.23"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "enum_dispatch",
  "fs-err 3.0.0",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "chrono",
  "futures",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "archspec",
  "libloading",
@@ -3142,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+checksum = "d1ccd3b55e711f91a9885a2fa6fbbb2e39db1776420b062efc058c6410f7e5e3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -47,7 +47,7 @@ pyo3-async-runtimes = { version = "0.22.0", features = ["tokio-runtime"] }
 tokio = { version = "1.41" }
 
 reqwest = { version = "0.12.9", default-features = false }
-reqwest-middleware = "0.3.3"
+reqwest-middleware = "0.4.0"
 
 thiserror = "1.0.67"
 url = "2.5.3"


### PR DESCRIPTION
## Description

Upgrade reqwest middleware and retry crates. This upgrade is needed so that we can start using these versions in pixi, in conjuction with the uv crates.


