### PR TITLE
fix: GCS channels and add test

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -141,6 +141,8 @@ jobs:
 
       - name: Run tests
         if: ${{ !matrix.skip-tests }}
+        env:
+          GOOGLE_CLOUD_TEST_KEY_JSON: ${{ secrets.GOOGLE_CLOUD_TEST_KEY_JSON }}
         run: >
           cargo nextest run
           --workspace 

--- a/crates/rattler_networking/src/gcs_middleware.rs
+++ b/crates/rattler_networking/src/gcs_middleware.rs
@@ -71,6 +71,11 @@ mod tests {
             return;
         };
 
+        if credentials.is_empty() {
+            eprintln!("Skipping test as GOOGLE_CLOUD_TEST_KEY_JSON is empty");
+            return;
+        }
+
         // We have to set GOOGLE_APPLICATION_CREDENTIALS to the path of the JSON key file
         let key_file = tempfile::NamedTempFile::with_suffix(".json").unwrap();
         std::fs::write(&key_file, credentials).unwrap();

--- a/crates/rattler_networking/src/gcs_middleware.rs
+++ b/crates/rattler_networking/src/gcs_middleware.rs
@@ -36,20 +36,14 @@ impl Middleware for GCSMiddleware {
 
 /// Auth to GCS
 async fn authenticate_with_google_cloud(mut req: Request) -> MiddlewareResult<Request> {
-    let audience = "https://storage.googleapis.com/";
-    let scopes = [
-        "https://www.googleapis.com/auth/cloud-platform",
-        "https://www.googleapis.com/auth/devstorage.read_only",
-    ];
-    let config = Config::default()
-        .with_audience(audience)
-        .with_scopes(&scopes);
+    let scopes = ["https://www.googleapis.com/auth/devstorage.read_only"];
+
+    let config = Config::default().with_scopes(&scopes);
 
     match DefaultTokenSourceProvider::new(config).await {
         Ok(provider) => match provider.token_source().token().await {
             Ok(token) => {
-                let bearer_auth = format!("Bearer {token}");
-                let header_value = reqwest::header::HeaderValue::from_str(&bearer_auth)
+                let header_value = reqwest::header::HeaderValue::from_str(&token)
                     .map_err(reqwest_middleware::Error::middleware)?;
                 req.headers_mut()
                     .insert(reqwest::header::AUTHORIZATION, header_value);
@@ -61,5 +55,45 @@ async fn authenticate_with_google_cloud(mut req: Request) -> MiddlewareResult<Re
             ))),
         },
         Err(e) => Err(reqwest_middleware::Error::Middleware(anyhow::Error::new(e))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::Client;
+    use tempfile;
+
+    #[tokio::test]
+    async fn test_gcs_middleware() {
+        let Ok(credentials) = std::env::var("GOOGLE_CLOUD_TEST_KEY_JSON") else {
+            eprintln!("Skipping test as GOOGLE_CLOUD_TEST_KEY_JSON is not set");
+            return;
+        };
+
+        // We have to set GOOGLE_APPLICATION_CREDENTIALS to the path of the JSON key file
+        let key_file = tempfile::NamedTempFile::with_suffix(".json").unwrap();
+        std::fs::write(&key_file, credentials).unwrap();
+
+        let prev_value = std::env::var("GOOGLE_APPLICATION_CREDENTIALS").ok();
+        std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", key_file.path());
+
+        let client = reqwest_middleware::ClientBuilder::new(Client::new())
+            .with(GCSMiddleware)
+            .build();
+
+        let url = "gcs://test-channel/noarch/repodata.json";
+        let response = client.get(url).send().await.unwrap();
+        assert!(response.status().is_success());
+
+        let url = "gcs://test-channel-nonexist/noarch/repodata.json";
+        let response = client.get(url).send().await.unwrap();
+        assert!(response.status().is_client_error());
+
+        if let Some(value) = prev_value {
+            std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", value);
+        } else {
+            std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
+        }
     }
 }

--- a/crates/rattler_networking/src/gcs_middleware.rs
+++ b/crates/rattler_networking/src/gcs_middleware.rs
@@ -66,15 +66,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_gcs_middleware() {
-        let Ok(credentials) = std::env::var("GOOGLE_CLOUD_TEST_KEY_JSON") else {
-            eprintln!("Skipping test as GOOGLE_CLOUD_TEST_KEY_JSON is not set");
-            return;
+        let credentials = match std::env::var("GOOGLE_CLOUD_TEST_KEY_JSON") {
+            Ok(credentials) if !credentials.is_empty() => credentials,
+            Err(_) | Ok(_) => {
+                eprintln!("Skipping test as GOOGLE_CLOUD_TEST_KEY_JSON is not set");
+                return;
+            }
         };
-
-        if credentials.is_empty() {
-            eprintln!("Skipping test as GOOGLE_CLOUD_TEST_KEY_JSON is empty");
-            return;
-        }
 
         // We have to set GOOGLE_APPLICATION_CREDENTIALS to the path of the JSON key file
         let key_file = tempfile::NamedTempFile::with_suffix(".json").unwrap();

--- a/crates/rattler_networking/src/gcs_middleware.rs
+++ b/crates/rattler_networking/src/gcs_middleware.rs
@@ -73,6 +73,7 @@ mod tests {
                 return;
             }
         };
+        println!("Running GCS Test");
 
         // We have to set GOOGLE_APPLICATION_CREDENTIALS to the path of the JSON key file
         let key_file = tempfile::NamedTempFile::with_suffix(".json").unwrap();


### PR DESCRIPTION
Unfortunately a bug slipped in where we were sending `Bearer Bearer <token>` (ie. one Bearer too much). 

This fixes it and adds a test. I also added credential for a test account in the `GOOGLE_CLOUD_TEST_KEY_JSON` secret. This can access a bucket in the prefix-dev GCS (`conda-channel-test/test-channel`).

## How to use GCS channels with rattler / pixi:

To use GCS channels, you need to first login using the `gcloud` CLI tool. For automatic discovery, rattler expects the `~/.config/gcloud/application_default_credentials.json` file to be available (or the `GOOGLE_APPLICATION_CREDENTIALS` env var to contain the JSON contents). 

To login, you can use `gcloud auth application-default login` which will automatically create the JSON file in the right place.

## Logs on how the service account was created:

```
gcloud iam service-accounts create gh-action-test-bucket-reader \
    --display-name "Github Actions Test Bucket Reader"

gcloud iam roles create bucketReader \
    --project=conda-channel-test \
    --title="Bucket Reader" \
    --permissions=storage.objects.get,storage.objects.list


gsutil iam ch \
    serviceAccount:gh-action-test-bucket-reader@conda-channel-test.iam.gserviceaccount.com:roles/storage.objectViewer \
    gs://test-channel

gcloud iam service-accounts keys create key.json \
    --iam-account=gh-action-test-bucket-reader@conda-channel-test.iam.gserviceaccount.com
```
