### PR TITLE
chore: prepare py-rattler 0.9.0

### DIFF
--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "file_url"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "itertools 0.13.0",
  "percent-encoding",
@@ -1377,6 +1377,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2471,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2693,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.28.3"
+version = "0.28.4"
 dependencies = [
  "anyhow",
  "console",
@@ -2731,12 +2732,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "dashmap",
  "digest",
  "dirs",
+ "fs-err 3.0.0",
  "fs4",
  "futures",
  "fxhash",
@@ -2757,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -2806,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.36"
+version = "0.19.37"
 dependencies = [
  "fs-err 3.0.0",
  "rattler_conda_types",
@@ -2819,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.31"
+version = "0.22.32"
 dependencies = [
  "chrono",
  "file_url",
@@ -2850,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.21.6"
+version = "0.21.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2877,10 +2879,11 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.14"
+version = "0.22.15"
 dependencies = [
  "bzip2",
  "chrono",
+ "fs-err 3.0.0",
  "futures-util",
  "num_cpus",
  "rattler_conda_types",
@@ -2903,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -2912,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.23"
+version = "0.21.24"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2965,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.7"
+version = "0.22.8"
 dependencies = [
  "enum_dispatch",
  "fs-err 3.0.0",
@@ -2981,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "chrono",
  "futures",
@@ -2997,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "archspec",
  "libloading",
@@ -3121,6 +3124,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -3256,6 +3260,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.0.0",
 ]
 
 [[package]]

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 license = "BSD-3-Clause"
 publish = false


### PR DESCRIPTION
Prepare the release of `py-rattler 0.9.0`.