### PR TITLE
chore: remove aarch64-windows-msvc-pc wheel

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -81,7 +81,6 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: "1.7.6"  # Pin maturin version to work around aarch64 linker error
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           args: --release --out dist --no-default-features --features rustls-tls

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -81,6 +81,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: "1.7.6"  # Pin maturin version to work around aarch64 linker error
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           args: --release --out dist --no-default-features --features rustls-tls

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -78,12 +78,15 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.platform.arch }}
-      - name: "Build wheels (rustls-tls)"
+      - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           args: --release --out dist --no-default-features --features rustls-tls
+        env:
+          # aarch64 build fails, see https://github.com/PyO3/maturin/issues/2110
+          XWIN_VERSION: 16
       - name: "Test wheel"
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -15,7 +15,7 @@ on:
       # When we change pyproject.toml, we want to ensure that the maturin builds still work
       - py-rattler/pyproject.toml
       # And when we change this workflow itself...
-      - .github/workflows/release-python.yaml
+      - .github/workflows/release-python.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -68,8 +68,10 @@ jobs:
             arch: x64
           - target: i686-pc-windows-msvc
             arch: x86
-          - target: aarch64-pc-windows-msvc
-            arch: x64
+#         There are a number of issues with cross compiling ring to windows on aarch64.
+#         For now, we just won't build a wheel, we will revisit this in the future.
+#          - target: aarch64-pc-windows-msvc
+#            arch: x64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -84,9 +86,6 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           args: --release --out dist --no-default-features --features rustls-tls
-        env:
-          # aarch64 build fails, see https://github.com/PyO3/maturin/issues/2110
-          XWIN_VERSION: 16
       - name: "Test wheel"
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash

--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin~=1.2.1"]
+requires = ["maturin~=1.7.6"]
 build-backend = "maturin"
 
 [project]

--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin~=1.7.8"]
+requires = ["maturin~=1.2.1"]
 build-backend = "maturin"
 
 [project]

--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin~=1.7.6"]
+requires = ["maturin==1.7.6"]
 build-backend = "maturin"
 
 [project]

--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin==1.7.6"]
+requires = ["maturin~=1.7.8"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
~~attempting to fix aarch64 windows build for py-rattler~~

I could not get CI to succeed for `aarch64-windows-msvc-pc`. The biggest problem seems to be that `ring` is a non-optional dependency of `jsonwebtoken` which is a non-optional dependency of `google-cloud-auth`.

At this point I just gave up. We'll revisit this later.