### PR TITLE
feat: add `EnumIter` to `Arch`

### DIFF
--- a/crates/rattler_conda_types/src/platform.rs
+++ b/crates/rattler_conda_types/src/platform.rs
@@ -51,7 +51,7 @@ impl Ord for Platform {
 
 /// Known architectures supported by Conda.
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(EnumIter, Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Arch {
     X86,
     X86_64,


### PR DESCRIPTION
We already have this for `Platform`. I need it in `rattler-build` to make sure we can set everything to `false` instead of undefined, and then throw errors when encountering actually undefined values.