### PR TITLE
feat: allow using an authenticated `Client` in `Gateway`

### DIFF
--- a/py-rattler/rattler/repo_data/gateway.py
+++ b/py-rattler/rattler/repo_data/gateway.py
@@ -8,6 +8,7 @@ from rattler.rattler import PyGateway, PySourceConfig, PyMatchSpec
 
 from rattler.channel import Channel
 from rattler.match_spec import MatchSpec
+from rattler.networking import Client
 from rattler.repo_data.record import RepoDataRecord
 from rattler.platform import Platform, PlatformLiteral
 from rattler.package.package_name import PackageName
@@ -90,6 +91,7 @@ class Gateway:
         default_config: Optional[SourceConfig] = None,
         per_channel_config: Optional[dict[str, SourceConfig]] = None,
         max_concurrent_requests: int = 100,
+        client: Optional[Client] = None,
     ) -> None:
         """
         Arguments:
@@ -100,6 +102,8 @@ class Gateway:
                                 prefix, so any channel that starts with the URL uses the configuration.
                                 The configuration with the longest matching prefix is used.
             max_concurrent_requests: The maximum number of concurrent requests that can be made.
+            client: An authenticated client to use for acquiring repodata. If not specified a default
+                    client will be used.
 
         Examples
         --------
@@ -119,6 +123,7 @@ class Gateway:
                 for channel, config in (per_channel_config or {}).items()
             },
             max_concurrent_requests=max_concurrent_requests,
+            client=client._client if client is not None else None,
         )
 
     async def query(

--- a/py-rattler/src/repo_data/gateway.rs
+++ b/py-rattler/src/repo_data/gateway.rs
@@ -1,5 +1,6 @@
 use crate::error::PyRattlerError;
 use crate::match_spec::PyMatchSpec;
+use crate::networking::client::PyClientWithMiddleware;
 use crate::package_name::PyPackageName;
 use crate::platform::PyPlatform;
 use crate::record::PyRecord;
@@ -50,13 +51,14 @@ impl<'source> FromPyObject<'source> for Wrap<SubdirSelection> {
 #[pymethods]
 impl PyGateway {
     #[new]
-    #[pyo3(signature = (max_concurrent_requests, default_config, per_channel_config, cache_dir=None)
+    #[pyo3(signature = (max_concurrent_requests, default_config, per_channel_config, cache_dir=None, client=None)
     )]
     pub fn new(
         max_concurrent_requests: usize,
         default_config: PySourceConfig,
         per_channel_config: HashMap<String, PySourceConfig>,
         cache_dir: Option<PathBuf>,
+        client: Option<PyClientWithMiddleware>,
     ) -> PyResult<Self> {
         let channel_config = ChannelConfig {
             default: default_config.into(),
@@ -75,6 +77,10 @@ impl PyGateway {
 
         if let Some(cache_dir) = cache_dir {
             gateway.set_cache_dir(cache_dir);
+        }
+
+        if let Some(client) = client {
+            gateway.set_client(client.into());
         }
 
         Ok(Self {


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

I am using a private conda channel and I am able to `rattler.install`, but not `rattler.solve`!  This change allows authenticating the solver as well. Fixes #973 

I can't think of a reasonable way to unit test this, but I did test it via `pixi run repl`.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
