### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.28.5", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.3", default-features = false }
+rattler = { path="../rattler", version = "0.28.6", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.4", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.21.8", default-features = false, features = ["gcs"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.25", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.2.4", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.11", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.2.13", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.26", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.2.5", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.12", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.2.14", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.6](https://github.com/conda/rattler/compare/rattler-v0.28.5...rattler-v0.28.6) - 2024-12-12
+
+### Other
+- updated the following local packages: rattler_cache, rattler_conda_types
+
 ## [0.28.5](https://github.com/conda/rattler/compare/rattler-v0.28.4...rattler-v0.28.5) - 2024-12-05
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.28.5"
+version = "0.28.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.2.13", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.2.14", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.4", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.21.8", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.8", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.16", default-features = false, features = ["reqwest"] }
+rattler_shell = { path = "../rattler_shell", version = "0.22.9", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.17", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14](https://github.com/conda/rattler/compare/rattler_cache-v0.2.13...rattler_cache-v0.2.14) - 2024-12-12
+
+### Fixed
+- package cache lock file_name was incorrect ([#977](https://github.com/conda/rattler/pull/977))
+
 ## [0.2.13](https://github.com/conda/rattler/compare/rattler_cache-v0.2.12...rattler_cache-v0.2.13) - 2024-12-05
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.2.13"
+version = "0.2.14"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,10 +18,10 @@ fs-err.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.29.3", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.29.4", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.3", path = "../rattler_digest", default-features = false }
 rattler_networking = { version = "0.21.8", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.16", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { version = "0.22.17", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.4](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.3...rattler_conda_types-v0.29.4) - 2024-12-12
+
+### Added
+- add `EnumIter` to `Arch` ([#972](https://github.com/conda/rattler/pull/972))
+
 ## [0.29.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.2...rattler_conda_types-v0.29.3) - 2024-11-30
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.29.3"
+version = "0.29.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1](https://github.com/conda/rattler/compare/rattler_index-v0.20.0...rattler_index-v0.20.1) - 2024-12-12
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.20.0](https://github.com/conda/rattler/compare/rattler_index-v0.19.37...rattler_index-v0.20.0) - 2024-12-05
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.4", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.3", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.16", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.17", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.33](https://github.com/conda/rattler/compare/rattler_lock-v0.22.32...rattler_lock-v0.22.33) - 2024-12-12
+
+### Fixed
+- merge purls from matching records in lock-file ([#965](https://github.com/conda/rattler/pull/965))
+
 ## [0.22.32](https://github.com/conda/rattler/compare/rattler_lock-v0.22.31...rattler_lock-v0.22.32) - 2024-11-30
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.32"
+version = "0.22.33"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.4", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
 file_url = { path = "../file_url", version = "0.2.0" }
 pep508_rs = { workspace = true }

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.17](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.16...rattler_package_streaming-v0.22.17) - 2024-12-12
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.16](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.15...rattler_package_streaming-v0.22.16) - 2024-12-05
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.16"
+version = "0.22.17"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,7 +16,7 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.4", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.21.8", default-features = false }
 rattler_redaction = { version = "0.1.4", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.26](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.25...rattler_repodata_gateway-v0.21.26) - 2024-12-12
+
+### Other
+- updated the following local packages: rattler_cache, rattler_conda_types
+
 ## [0.21.25](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.24...rattler_repodata_gateway-v0.21.25) - 2024-12-05
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.25"
+version = "0.21.26"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -36,7 +36,7 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.4", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false, features = ["tokio", "serde"] }
 rattler_networking = { path = "../rattler_networking", version = "0.21.8", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
@@ -54,7 +54,7 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.2.13", path = "../rattler_cache" }
+rattler_cache = { version = "0.2.14", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.4", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_sandbox/CHANGELOG.md
+++ b/crates/rattler_sandbox/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_sandbox-v0.1.0) - 2024-12-12
+
+### Added
+- `sandbox` trampoline implementation ([#935](https://github.com/conda/rattler/pull/935))

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.9](https://github.com/conda/rattler/compare/rattler_shell-v0.22.8...rattler_shell-v0.22.9) - 2024-12-12
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.8](https://github.com/conda/rattler/compare/rattler_shell-v0.22.7...rattler_shell-v0.22.8) - 2024-11-30
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.8"
+version = "0.22.9"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.4", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.5](https://github.com/conda/rattler/compare/rattler_solve-v1.2.4...rattler_solve-v1.2.5) - 2024-12-12
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [1.2.4](https://github.com/conda/rattler/compare/rattler_solve-v1.2.3...rattler_solve-v1.2.4) - 2024-11-30
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.2.4"
+version = "1.2.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.4", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.12](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.11...rattler_virtual_packages-v1.1.12) - 2024-12-12
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [1.1.11](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.10...rattler_virtual_packages-v1.1.11) - 2024-11-30
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "1.1.11"
+version = "1.1.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.4", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler_cache`: 0.2.13 -> 0.2.14
* `rattler_conda_types`: 0.29.3 -> 0.29.4
* `rattler_lock`: 0.22.32 -> 0.22.33
* `rattler_sandbox`: 0.1.0
* `rattler`: 0.28.5 -> 0.28.6
* `rattler_package_streaming`: 0.22.16 -> 0.22.17
* `rattler_shell`: 0.22.8 -> 0.22.9
* `rattler_repodata_gateway`: 0.21.25 -> 0.21.26
* `rattler_solve`: 1.2.4 -> 1.2.5
* `rattler_virtual_packages`: 1.1.11 -> 1.1.12
* `rattler_index`: 0.20.0 -> 0.20.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_cache`
<blockquote>

## [0.2.14](https://github.com/conda/rattler/compare/rattler_cache-v0.2.13...rattler_cache-v0.2.14) - 2024-12-12

### Fixed
- package cache lock file_name was incorrect ([#977](https://github.com/conda/rattler/pull/977))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.29.4](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.3...rattler_conda_types-v0.29.4) - 2024-12-12

### Added
- add `EnumIter` to `Arch` ([#972](https://github.com/conda/rattler/pull/972))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.33](https://github.com/conda/rattler/compare/rattler_lock-v0.22.32...rattler_lock-v0.22.33) - 2024-12-12

### Fixed
- merge purls from matching records in lock-file ([#965](https://github.com/conda/rattler/pull/965))
</blockquote>

## `rattler_sandbox`
<blockquote>

## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_sandbox-v0.1.0) - 2024-12-12

### Added
- `sandbox` trampoline implementation ([#935](https://github.com/conda/rattler/pull/935))
</blockquote>

## `rattler`
<blockquote>

## [0.28.6](https://github.com/conda/rattler/compare/rattler-v0.28.5...rattler-v0.28.6) - 2024-12-12

### Other
- updated the following local packages: rattler_cache, rattler_conda_types
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.22.17](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.16...rattler_package_streaming-v0.22.17) - 2024-12-12

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_shell`
<blockquote>

## [0.22.9](https://github.com/conda/rattler/compare/rattler_shell-v0.22.8...rattler_shell-v0.22.9) - 2024-12-12

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.26](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.25...rattler_repodata_gateway-v0.21.26) - 2024-12-12

### Other
- updated the following local packages: rattler_cache, rattler_conda_types
</blockquote>

## `rattler_solve`
<blockquote>

## [1.2.5](https://github.com/conda/rattler/compare/rattler_solve-v1.2.4...rattler_solve-v1.2.5) - 2024-12-12

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [1.1.12](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.11...rattler_virtual_packages-v1.1.12) - 2024-12-12

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.20.1](https://github.com/conda/rattler/compare/rattler_index-v0.20.0...rattler_index-v0.20.1) - 2024-12-12

### Other
- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).