### PR TITLE
perf: reduce ideal concurrency limit

### DIFF
--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -51,6 +51,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
 console = { workspace = true, optional = true }
+num_cpus = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/rattler/src/install/driver.rs
+++ b/crates/rattler/src/install/driver.rs
@@ -33,11 +33,22 @@ pub struct InstallDriver {
     execute_link_scripts: bool,
 }
 
+impl InstallDriver {
+    /// Returns the ideal number of IO operations that can be performed in
+    /// parallel.
+    ///
+    /// Currently, this value is based on the number of physical CPU cores
+    /// available.
+    pub fn ideal_io_concurrency_limit() -> usize {
+        num_cpus::get_physical()
+    }
+}
+
 impl Default for InstallDriver {
     fn default() -> Self {
         Self::builder()
             .execute_link_scripts(false)
-            .with_io_concurrency_limit(100)
+            .with_io_concurrency_limit(Self::ideal_io_concurrency_limit())
             .finish()
     }
 }


### PR DESCRIPTION
@wolfv found out that the default io concurrency limit of 100 is WAY to high and actually hurts performance quite a bit. This PR uses the number of physical cores to compute an better value. 