### PR TITLE
chore: release

### DIFF
--- a/crates/file_url/CHANGELOG.md
+++ b/crates/file_url/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/conda/rattler/compare/file_url-v0.2.0...file_url-v0.2.1) - 2024-12-17
+
+### Other
+
+- update everything (#987)
+
 ## [0.2.0](https://github.com/conda/rattler/compare/file_url-v0.1.7...file_url-v0.2.0) - 2024-11-30
 
 ### Added

--- a/crates/file_url/Cargo.toml
+++ b/crates/file_url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_url"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Helper functions to work with file:// urls"

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.28.7", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.5", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.21.8", default-features = false, features = ["gcs"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.27", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.2.6", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.13", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.2.15", default-features = false }
+rattler = { path="../rattler", version = "0.28.8", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.6", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.21.9", default-features = false, features = ["gcs"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.28", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.3.0", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.14", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.0", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.8](https://github.com/conda/rattler/compare/rattler-v0.28.7...rattler-v0.28.8) - 2024-12-17
+
+### Added
+
+- speed up `PrefixRecord` loading (#984)
+- improve performance when linking files using `rayon` (#985)
+
 ## [0.28.7](https://github.com/conda/rattler/compare/rattler-v0.28.6...rattler-v0.28.7) - 2024-12-13
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.28.7"
+version = "0.28.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.2.15", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.5", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.8", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.10", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.18", default-features = false, features = ["reqwest"] }
+rattler_cache = { path = "../rattler_cache", version = "0.3.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.6", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.4", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.9", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.11", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.19", default-features = false, features = ["reqwest"] }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/conda/rattler/compare/rattler_cache-v0.2.15...rattler_cache-v0.3.0) - 2024-12-17
+
+### Added
+
+- speed up `PrefixRecord` loading (#984)
+- improve performance when linking files using `rayon` (#985)
+
 ## [0.2.15](https://github.com/conda/rattler/compare/rattler_cache-v0.2.14...rattler_cache-v0.2.15) - 2024-12-13
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.2.15"
+version = "0.3.0"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,10 +18,10 @@ fs-err.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.29.5", path = "../rattler_conda_types", default-features = false }
-rattler_digest = { version = "1.0.3", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.21.8", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.18", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { version = "0.29.6", path = "../rattler_conda_types", default-features = false }
+rattler_digest = { version = "1.0.4", path = "../rattler_digest", default-features = false }
+rattler_networking = { version = "0.21.9", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.19", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.6](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.5...rattler_conda_types-v0.29.6) - 2024-12-17
+
+### Added
+
+- speed up `PrefixRecord` loading (#984)
+
 ## [0.29.5](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.4...rattler_conda_types-v0.29.5) - 2024-12-13
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.29.5"
+version = "0.29.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -15,7 +15,7 @@ default = ["rayon"]
 
 [dependencies]
 chrono = { workspace = true }
-file_url = { path = "../file_url", version = "0.2.0" }
+file_url = { path = "../file_url", version = "0.2.1" }
 fxhash = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }
@@ -23,8 +23,8 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false, features = ["serde"] }
-rattler_macros = { path = "../rattler_macros", version = "1.0.3", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.4", default-features = false, features = ["serde"] }
+rattler_macros = { path = "../rattler_macros", version = "1.0.4", default-features = false }
 regex = { workspace = true }
 simd-json = { workspace = true , features = ["serde_impl"]}
 serde = { workspace = true, features = ["derive", "rc"] }
@@ -40,7 +40,7 @@ tracing = { workspace = true }
 typed-path = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 indexmap = { workspace = true }
-rattler_redaction = { version = "0.1.4", path = "../rattler_redaction" }
+rattler_redaction = { version = "0.1.5", path = "../rattler_redaction" }
 dirs = { workspace = true }
 rayon = { workspace = true, optional = true }
 fs-err = { workspace = true }

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4](https://github.com/conda/rattler/compare/rattler_digest-v1.0.3...rattler_digest-v1.0.4) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.3](https://github.com/conda/rattler/compare/rattler_digest-v1.0.2...rattler_digest-v1.0.3) - 2024-11-04
 
 ### Other

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "1.0.3"
+version = "1.0.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3](https://github.com/conda/rattler/compare/rattler_index-v0.20.2...rattler_index-v0.20.3) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.20.2](https://github.com/conda/rattler/compare/rattler_index-v0.20.1...rattler_index-v0.20.2) - 2024-12-13
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.5", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "1.0.3", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.18", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.6", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "1.0.4", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.19", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.0.3...rattler_libsolv_c-v1.1.0) - 2024-12-17
+
+### Added
+
+- speed up `PrefixRecord` loading (#984)
+
+### Other
+
+- update everything (#987)
+
 ## [1.0.3](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.0.2...rattler_libsolv_c-v1.0.3) - 2024-11-04
 
 ### Other

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "1.0.3"
+version = "1.1.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.35](https://github.com/conda/rattler/compare/rattler_lock-v0.22.34...rattler_lock-v0.22.35) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.34](https://github.com/conda/rattler/compare/rattler_lock-v0.22.33...rattler_lock-v0.22.34) - 2024-12-13
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.34"
+version = "0.22.35"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,9 +15,9 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.5", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
-file_url = { path = "../file_url", version = "0.2.0" }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.6", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.4", default-features = false }
+file_url = { path = "../file_url", version = "0.2.1" }
 pep508_rs = { workspace = true }
 pep440_rs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4](https://github.com/conda/rattler/compare/rattler_macros-v1.0.3...rattler_macros-v1.0.4) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.3](https://github.com/conda/rattler/compare/rattler_macros-v1.0.2...rattler_macros-v1.0.3) - 2024-11-04
 
 ### Other

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "1.0.3"
+version = "1.0.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.9](https://github.com/conda/rattler/compare/rattler_networking-v0.21.8...rattler_networking-v0.21.9) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.21.8](https://github.com/conda/rattler/compare/rattler_networking-v0.21.7...rattler_networking-v0.21.8) - 2024-12-05
 
 ### Fixed

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.21.8"
+version = "0.21.9"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.19](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.18...rattler_package_streaming-v0.22.19) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.18](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.17...rattler_package_streaming-v0.22.18) - 2024-12-13
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.18"
+version = "0.22.19"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,10 +16,10 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.5", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.8", default-features = false }
-rattler_redaction = { version = "0.1.4", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.6", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.4", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.21.9", default-features = false }
+rattler_redaction = { version = "0.1.5", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_redaction/CHANGELOG.md
+++ b/crates/rattler_redaction/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.4...rattler_redaction-v0.1.5) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.4](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.3...rattler_redaction-v0.1.4) - 2024-11-30
 
 ### Other

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_redaction"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Redact sensitive information from URLs (ie. conda tokens)"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.28](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.27...rattler_repodata_gateway-v0.21.28) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.21.27](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.26...rattler_repodata_gateway-v0.21.27) - 2024-12-13
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.27"
+version = "0.21.28"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -22,7 +22,7 @@ cache_control = { workspace = true }
 chrono = { workspace = true, features = ["std", "serde", "alloc", "clock"] }
 dashmap = { workspace = true }
 dirs = { workspace = true }
-file_url = { path = "../file_url", version = "0.2.0" }
+file_url = { path = "../file_url", version = "0.2.1" }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 http = { workspace = true, optional = true }
@@ -36,9 +36,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.5", default-features = false, optional = true }
-rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.21.8", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.6", default-features = false, optional = true }
+rattler_digest = { path = "../rattler_digest", version = "1.0.4", default-features = false, features = ["tokio", "serde"] }
+rattler_networking = { path = "../rattler_networking", version = "0.21.9", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -54,8 +54,8 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
-rattler_cache = { version = "0.2.15", path = "../rattler_cache" }
-rattler_redaction = { version = "0.1.4", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+rattler_cache = { version = "0.3.0", path = "../rattler_cache" }
+rattler_redaction = { version = "0.1.5", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_sandbox/CHANGELOG.md
+++ b/crates/rattler_sandbox/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.0...rattler_sandbox-v0.1.1) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_sandbox-v0.1.0) - 2024-12-12
 
 ### Added

--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_sandbox"
-version = "0.1.0"
+version = "0.1.1"
 description = "A crate to run executables in a sandbox"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.11](https://github.com/conda/rattler/compare/rattler_shell-v0.22.10...rattler_shell-v0.22.11) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.10](https://github.com/conda/rattler/compare/rattler_shell-v0.22.9...rattler_shell-v0.22.10) - 2024-12-13
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.10"
+version = "0.22.11"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.5", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.6", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/conda/rattler/compare/rattler_solve-v1.2.6...rattler_solve-v1.3.0) - 2024-12-17
+
+### Added
+
+- speed up `PrefixRecord` loading (#984)
+
+### Other
+
+- update everything (#987)
+
 ## [1.2.6](https://github.com/conda/rattler/compare/rattler_solve-v1.2.5...rattler_solve-v1.2.6) - 2024-12-13
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.2.6"
+version = "1.3.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.5", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.6", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.4", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 url = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { path = "../rattler_libsolv_c", version = "1.0.3", default-features = false, optional = true }
+rattler_libsolv_c = { path = "../rattler_libsolv_c", version = "1.1.0", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.14](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.13...rattler_virtual_packages-v1.1.14) - 2024-12-17
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.1.13](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.12...rattler_virtual_packages-v1.1.13) - 2024-12-13
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "1.1.13"
+version = "1.1.14"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.5", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.29.6", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `file_url`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `rattler`: 0.28.7 -> 0.28.8 (✓ API compatible changes)
* `rattler_cache`: 0.2.15 -> 0.3.0 (⚠️ API breaking changes)
* `rattler_conda_types`: 0.29.5 -> 0.29.6 (✓ API compatible changes)
* `rattler_digest`: 1.0.3 -> 1.0.4 (✓ API compatible changes)
* `rattler_macros`: 1.0.3 -> 1.0.4
* `rattler_redaction`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.18 -> 0.22.19 (✓ API compatible changes)
* `rattler_networking`: 0.21.8 -> 0.21.9 (✓ API compatible changes)
* `rattler_shell`: 0.22.10 -> 0.22.11 (✓ API compatible changes)
* `rattler_lock`: 0.22.34 -> 0.22.35 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.21.27 -> 0.21.28 (✓ API compatible changes)
* `rattler_solve`: 1.2.6 -> 1.3.0 (✓ API compatible changes)
* `rattler_libsolv_c`: 1.0.3 -> 1.1.0 (✓ API compatible changes)
* `rattler_virtual_packages`: 1.1.13 -> 1.1.14 (✓ API compatible changes)
* `rattler_index`: 0.20.2 -> 0.20.3 (✓ API compatible changes)
* `rattler_sandbox`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

### ⚠️ `rattler_cache` breaking changes

```
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rattler_cache::validation::validate_package_directory now takes 2 parameters instead of 1, in /tmp/.tmpg9aypi/rattler/crates/rattler_cache/src/validation.rs:102
  rattler_cache::validation::validate_package_directory_from_paths now takes 3 parameters instead of 2, in /tmp/.tmpg9aypi/rattler/crates/rattler_cache/src/validation.rs:136
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `file_url`
<blockquote>

## [0.2.1](https://github.com/conda/rattler/compare/file_url-v0.2.0...file_url-v0.2.1) - 2024-12-17

### Other

- update everything (#987)
</blockquote>

## `rattler`
<blockquote>

## [0.28.8](https://github.com/conda/rattler/compare/rattler-v0.28.7...rattler-v0.28.8) - 2024-12-17

### Added

- speed up `PrefixRecord` loading (#984)
- improve performance when linking files using `rayon` (#985)
</blockquote>

## `rattler_cache`
<blockquote>

## [0.3.0](https://github.com/conda/rattler/compare/rattler_cache-v0.2.15...rattler_cache-v0.3.0) - 2024-12-17

### Added

- speed up `PrefixRecord` loading (#984)
- improve performance when linking files using `rayon` (#985)
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.29.6](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.5...rattler_conda_types-v0.29.6) - 2024-12-17

### Added

- speed up `PrefixRecord` loading (#984)
</blockquote>

## `rattler_digest`
<blockquote>

## [1.0.4](https://github.com/conda/rattler/compare/rattler_digest-v1.0.3...rattler_digest-v1.0.4) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_macros`
<blockquote>

## [1.0.4](https://github.com/conda/rattler/compare/rattler_macros-v1.0.3...rattler_macros-v1.0.4) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_redaction`
<blockquote>

## [0.1.5](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.4...rattler_redaction-v0.1.5) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.22.19](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.18...rattler_package_streaming-v0.22.19) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_networking`
<blockquote>

## [0.21.9](https://github.com/conda/rattler/compare/rattler_networking-v0.21.8...rattler_networking-v0.21.9) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_shell`
<blockquote>

## [0.22.11](https://github.com/conda/rattler/compare/rattler_shell-v0.22.10...rattler_shell-v0.22.11) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.35](https://github.com/conda/rattler/compare/rattler_lock-v0.22.34...rattler_lock-v0.22.35) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.28](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.27...rattler_repodata_gateway-v0.21.28) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_solve`
<blockquote>

## [1.3.0](https://github.com/conda/rattler/compare/rattler_solve-v1.2.6...rattler_solve-v1.3.0) - 2024-12-17

### Added

- speed up `PrefixRecord` loading (#984)

### Other

- update everything (#987)
</blockquote>

## `rattler_libsolv_c`
<blockquote>

## [1.1.0](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.0.3...rattler_libsolv_c-v1.1.0) - 2024-12-17

### Added

- speed up `PrefixRecord` loading (#984)

### Other

- update everything (#987)
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [1.1.14](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.13...rattler_virtual_packages-v1.1.14) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_index`
<blockquote>

## [0.20.3](https://github.com/conda/rattler/compare/rattler_index-v0.20.2...rattler_index-v0.20.3) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_sandbox`
<blockquote>

## [0.1.1](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.0...rattler_sandbox-v0.1.1) - 2024-12-17

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).