### PR TITLE
feat: make strict parsing even stricter

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -74,12 +74,12 @@ use matcher::StringMatcher;
 /// use std::sync::Arc;
 ///
 /// let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
-/// let spec = MatchSpec::from_str("foo 1.0 py27_0", Strict).unwrap();
+/// let spec = MatchSpec::from_str("foo 1.0.* py27_0", Strict).unwrap();
 /// assert_eq!(spec.name, Some(PackageName::new_unchecked("foo")));
-/// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0", Strict).unwrap()));
+/// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*", Strict).unwrap()));
 /// assert_eq!(spec.build, Some(StringMatcher::from_str("py27_0").unwrap()));
 ///
-/// let spec = MatchSpec::from_str("foo 1.0 py27_0", Strict).unwrap();
+/// let spec = MatchSpec::from_str("foo ==1.0 py27_0", Strict).unwrap();
 /// assert_eq!(spec.name, Some(PackageName::new_unchecked("foo")));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str("==1.0", Strict).unwrap()));
 /// assert_eq!(spec.build, Some(StringMatcher::from_str("py27_0").unwrap()));
@@ -702,12 +702,12 @@ mod tests {
 
     #[test]
     fn test_serialize_matchspec() {
-        let specs = ["mamba 1.0 py37_0",
-            "conda-forge::pytest[version=1.0, sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97, md5=dede6252c964db3f3e41c7d30d07f6bf]",
+        let specs = ["mamba 1.0.* py37_0",
+            "conda-forge::pytest[version='==1.0', sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97, md5=dede6252c964db3f3e41c7d30d07f6bf]",
             "conda-forge/linux-64::pytest",
-            "conda-forge/linux-64::pytest[version=1.0]",
-            "conda-forge/linux-64::pytest[version=1.0, build=py37_0]",
-            "conda-forge/linux-64::pytest 1.2.3"];
+            "conda-forge/linux-64::pytest[version=1.0.*]",
+            "conda-forge/linux-64::pytest[version=1.0.*, build=py37_0]",
+            "conda-forge/linux-64::pytest ==1.2.3"];
 
         assert_snapshot!(specs
             .into_iter()

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -804,11 +804,12 @@ mod tests {
     fn test_nameless_match_spec() {
         insta::assert_yaml_snapshot!([
             NamelessMatchSpec::from_str("3.8.* *_cpython", Strict).unwrap(),
-            NamelessMatchSpec::from_str("1.0 py27_0[fn=\"bla\"]", Strict).unwrap(),
+            NamelessMatchSpec::from_str("==1.0 py27_0[fn=\"bla\"]", Strict).unwrap(),
             NamelessMatchSpec::from_str("=1.0 py27_0", Strict).unwrap(),
             NamelessMatchSpec::from_str("*cpu*", Strict).unwrap(),
-            NamelessMatchSpec::from_str("conda-forge::foobar", Strict).unwrap(),
-            NamelessMatchSpec::from_str("foobar[channel=conda-forge]", Strict).unwrap(),
+            // the next two tests are a bit weird, the version is `foobar` and the channel is `conda-forge`
+            NamelessMatchSpec::from_str("conda-forge::==foobar", Strict).unwrap(),
+            NamelessMatchSpec::from_str("==foobar[channel=conda-forge]", Strict).unwrap(),
             NamelessMatchSpec::from_str("* [build=foo]", Strict).unwrap(),
             NamelessMatchSpec::from_str(">=1.2[build=foo]", Strict).unwrap(),
             NamelessMatchSpec::from_str("[version='>=1.2', build=foo]", Strict).unwrap(),

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
 expression: evaluated
+snapshot_kind: text
 ---
 blas *.* mkl:
   name: blas
@@ -54,13 +55,13 @@ python=3.9:
 python=*:
   error: "invalid version constraint: '*' is incompatible with '=' operator'"
 "https://software.repos.intel.com/python/conda::python[version=3.9]":
-  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
+  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "https://c.com/p/conda/linux-64::python[version=3.9]":
-  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
+  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "https://c.com/p/conda::python[version=3.9, subdir=linux-64]":
-  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
+  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "conda-forge/linux-32::python[version=3.9, subdir=linux-64]":
-  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
+  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "conda-forge/linux-32::python ==3.9[subdir=linux-64, build_number=\"0\"]":
   name: python
   version: "==3.9"
@@ -100,7 +101,7 @@ rust ~=1.2.3:
     base_url: "file://<CRATE>/relative/channel"
     name: "./relative/channel"
 "python[channel=https://conda.anaconda.org/python/conda,version=3.9]":
-  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
+  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "channel/win-64::foobar[channel=conda-forge, subdir=linux-64]":
   name: foobar
   channel:

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -54,32 +54,13 @@ python=3.9:
 python=*:
   error: "invalid version constraint: '*' is incompatible with '=' operator'"
 "https://software.repos.intel.com/python/conda::python[version=3.9]":
-  name: python
-  version: "==3.9"
-  channel:
-    base_url: "https://software.repos.intel.com/python/conda"
-    name: python/conda
+  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
 "https://c.com/p/conda/linux-64::python[version=3.9]":
-  name: python
-  version: "==3.9"
-  channel:
-    base_url: "https://c.com/p/conda"
-    name: p/conda
-  subdir: linux-64
+  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
 "https://c.com/p/conda::python[version=3.9, subdir=linux-64]":
-  name: python
-  version: "==3.9"
-  channel:
-    base_url: "https://c.com/p/conda"
-    name: p/conda
-  subdir: linux-64
+  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
 "conda-forge/linux-32::python[version=3.9, subdir=linux-64]":
-  name: python
-  version: "==3.9"
-  channel:
-    base_url: "https://conda.anaconda.org/conda-forge"
-    name: conda-forge
-  subdir: linux-64
+  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
 "conda-forge/linux-32::python ==3.9[subdir=linux-64, build_number=\"0\"]":
   name: python
   version: "==3.9"
@@ -119,11 +100,7 @@ rust ~=1.2.3:
     base_url: "file://<CRATE>/relative/channel"
     name: "./relative/channel"
 "python[channel=https://conda.anaconda.org/python/conda,version=3.9]":
-  name: python
-  version: "==3.9"
-  channel:
-    base_url: "https://conda.anaconda.org/python/conda"
-    name: python/conda
+  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
 "channel/win-64::foobar[channel=conda-forge, subdir=linux-64]":
   name: foobar
   channel:

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
@@ -3,7 +3,7 @@ source: crates/rattler_conda_types/src/match_spec/parse.rs
 expression: evaluated
 ---
 2.7|>=3.6:
-  version: "==2.7|>=3.6"
+  error: "invalid version constraint: ambiguous. Do you mean ==2.7 or 2.7.*?"
 "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2":
   url: "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"
 ~=1.2.3:
@@ -40,14 +40,13 @@ expression: evaluated
 "==2.7.*.*|>=3.6":
   error: "invalid version constraint: regex constraints are not supported"
 "3.9":
-  version: "==3.9"
+  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
 "*":
   version: "*"
 "[version=3.9]":
-  version: "==3.9"
+  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
 "[version=3.9, subdir=linux-64]":
-  version: "==3.9"
-  subdir: linux-64
+  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
 "==3.9[subdir=linux-64, build_number=\"0\"]":
   version: "==3.9"
   build_number:

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
 expression: evaluated
+snapshot_kind: text
 ---
 2.7|>=3.6:
-  error: "invalid version constraint: ambiguous. Do you mean ==2.7 or 2.7.*?"
+  error: "invalid version constraint: missing range specifier for '2.7'. Did you mean '==2.7' or '2.7.*'?"
 "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2":
   url: "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"
 ~=1.2.3:
@@ -40,13 +41,13 @@ expression: evaluated
 "==2.7.*.*|>=3.6":
   error: "invalid version constraint: regex constraints are not supported"
 "3.9":
-  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
+  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "*":
   version: "*"
 "[version=3.9]":
-  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
+  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "[version=3.9, subdir=linux-64]":
-  error: "invalid version constraint: ambiguous. Do you mean ==3.9 or 3.9.*?"
+  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "==3.9[subdir=linux-64, build_number=\"0\"]":
   version: "==3.9"
   build_number:

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__tests__serialize_matchspec.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__tests__serialize_matchspec.snap
@@ -2,9 +2,9 @@
 source: crates/rattler_conda_types/src/match_spec/mod.rs
 expression: "specs.into_iter().map(|s|\nMatchSpec::from_str(s,\nStrict).unwrap()).map(|s| s.to_string()).collect::<Vec<String>>().join(\"\\n\")"
 ---
-mamba ==1.0 py37_0
+mamba 1.0.* py37_0
 conda-forge::pytest ==1.0[md5="dede6252c964db3f3e41c7d30d07f6bf", sha256="aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97"]
 conda-forge/linux-64::pytest
-conda-forge/linux-64::pytest ==1.0
-conda-forge/linux-64::pytest ==1.0 py37_0
+conda-forge/linux-64::pytest 1.0.*
+conda-forge/linux-64::pytest 1.0.* py37_0
 conda-forge/linux-64::pytest ==1.2.3

--- a/crates/rattler_conda_types/src/version_spec/constraint.rs
+++ b/crates/rattler_conda_types/src/version_spec/constraint.rs
@@ -279,7 +279,7 @@ mod test {
     #[rstest]
     fn test_exact(#[values(Lenient, Strict)] strictness: ParseStrictness) {
         assert_eq!(
-            Constraint::from_str("1.2.3", strictness),
+            Constraint::from_str("==1.2.3", strictness),
             Ok(Constraint::Exact(
                 EqualityOperator::Equals,
                 Version::from_str("1.2.3").unwrap(),

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -350,15 +350,15 @@ mod tests {
     use crate::{
         version_spec::{
             parse::ParseConstraintError, EqualityOperator, LogicalOperator, ParseVersionSpecError,
-            RangeOperator,
+            RangeOperator, StrictRangeOperator,
         },
-        ParseStrictness, Version, VersionSpec,
+        ParseStrictness, StrictVersion, Version, VersionSpec,
     };
 
     #[test]
     fn test_simple() {
         assert_eq!(
-            VersionSpec::from_str("1.2.3", ParseStrictness::Strict),
+            VersionSpec::from_str("==1.2.3", ParseStrictness::Strict),
             Ok(VersionSpec::Exact(
                 EqualityOperator::Equals,
                 Version::from_str("1.2.3").unwrap(),
@@ -369,6 +369,13 @@ mod tests {
             Ok(VersionSpec::Range(
                 RangeOperator::GreaterEquals,
                 Version::from_str("1.2.3").unwrap(),
+            ))
+        );
+        assert_eq!(
+            VersionSpec::from_str("=1.2.3", ParseStrictness::Strict),
+            Ok(VersionSpec::StrictRange(
+                StrictRangeOperator::StartsWith,
+                StrictVersion::from_str("1.2.3").unwrap(),
             ))
         );
     }
@@ -422,7 +429,7 @@ mod tests {
         let vs1 = VersionSpec::from_str(">=1.2.3,<2.0.0", ParseStrictness::Strict).unwrap();
         assert!(!vs1.matches(&v1));
 
-        let vs2 = VersionSpec::from_str("1.2", ParseStrictness::Strict).unwrap();
+        let vs2 = VersionSpec::from_str("==1.2.0", ParseStrictness::Strict).unwrap();
         assert!(vs2.matches(&v1));
 
         let v2 = Version::from_str("1.2.3").unwrap();
@@ -430,13 +437,15 @@ mod tests {
         assert!(!vs2.matches(&v2));
 
         let v3 = Version::from_str("1!1.2.3").unwrap();
-        println!("{v3:?}");
 
         assert!(!vs1.matches(&v3));
         assert!(!vs2.matches(&v3));
 
         let vs3 = VersionSpec::from_str(">=1!1.2,<1!2", ParseStrictness::Strict).unwrap();
         assert!(vs3.matches(&v3));
+
+        let vs4 = VersionSpec::from_str("1!1.2.*", ParseStrictness::Strict).unwrap();
+        assert!(vs4.matches(&v3));
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/version_spec/parse.rs
+++ b/crates/rattler_conda_types/src/version_spec/parse.rs
@@ -411,7 +411,7 @@ mod test {
     #[rstest]
     fn parse_logical_constraint(#[values(Lenient, Strict)] strictness: ParseStrictness) {
         assert_eq!(
-            logical_constraint_parser(strictness)("3.1"),
+            logical_constraint_parser(strictness)("==3.1"),
             Ok((
                 "",
                 Constraint::Exact(EqualityOperator::Equals, Version::from_str("3.1").unwrap())
@@ -520,7 +520,7 @@ mod test {
 
     #[test]
     fn pixi_issue_278() {
-        assert!(VersionSpec::from_str("1.8.1+g6b29558", Strict).is_ok());
+        assert!(VersionSpec::from_str("=1.8.1+g6b29558", Strict).is_ok());
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/version_spec/parse.rs
+++ b/crates/rattler_conda_types/src/version_spec/parse.rs
@@ -67,7 +67,7 @@ pub enum ParseConstraintError {
     InvalidOperator(String),
     #[error(transparent)]
     InvalidVersion(#[from] ParseVersionError),
-    #[error("ambiguous. Do you mean =={0} or {0}.*?")]
+    #[error("missing range specifier for '{0}'. Did you mean '=={0}' or '{0}.*'?")]
     AmbiguousVersion(String),
     /// Expected a version
     #[error("expected a version")]

--- a/crates/rattler_conda_types/src/version_spec/snapshots/rattler_conda_types__version_spec__parse__test__exact_strict.snap
+++ b/crates/rattler_conda_types/src/version_spec/snapshots/rattler_conda_types__version_spec__parse__test__exact_strict.snap
@@ -1,0 +1,5 @@
+---
+source: crates/rattler_conda_types/src/version_spec/parse.rs
+expression: "VersionSpec::from_str(\"1.2.3\", Strict).unwrap_err()"
+---
+invalid version constraint: ambiguous. Do you mean ==1.2.3 or 1.2.3.*?

--- a/crates/rattler_conda_types/src/version_spec/snapshots/rattler_conda_types__version_spec__parse__test__exact_strict.snap
+++ b/crates/rattler_conda_types/src/version_spec/snapshots/rattler_conda_types__version_spec__parse__test__exact_strict.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/version_spec/parse.rs
 expression: "VersionSpec::from_str(\"1.2.3\", Strict).unwrap_err()"
+snapshot_kind: text
 ---
-invalid version constraint: ambiguous. Do you mean ==1.2.3 or 1.2.3.*?
+invalid version constraint: missing range specifier for '1.2.3'. Did you mean '==1.2.3' or '1.2.3.*'?

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -411,7 +411,8 @@ mod test {
             .query(
                 vec![index],
                 vec![Platform::Linux64],
-                vec![MatchSpec::from_str("openssl 3.3.1 h2466b09_1", Strict).unwrap()].into_iter(),
+                vec![MatchSpec::from_str("openssl ==3.3.1 h2466b09_1", Strict).unwrap()]
+                    .into_iter(),
             )
             .recursive(true)
             .await
@@ -454,7 +455,7 @@ mod test {
                 vec![index.clone()],
                 vec![Platform::Linux64],
                 vec![
-                    MatchSpec::from_str("mamba 0.9.2 py39h951de11_0", Strict).unwrap(),
+                    MatchSpec::from_str("mamba ==0.9.2 py39h951de11_0", Strict).unwrap(),
                     MatchSpec::from_str(openssl_url, Strict).unwrap(),
                 ]
                 .into_iter(),
@@ -491,7 +492,7 @@ mod test {
             .query(
                 vec![index.clone()],
                 vec![Platform::Linux64],
-                vec![MatchSpec::from_str("mamba 0.9.2 py39h951de11_0", Strict).unwrap()]
+                vec![MatchSpec::from_str("mamba ==0.9.2 py39h951de11_0", Strict).unwrap()]
                     .into_iter(),
             )
             .recursive(true)

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "arbitrary"
@@ -132,11 +132,11 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
 dependencies = [
- "bzip2",
+ "bzip2 0.4.4",
  "flate2",
  "futures-core",
  "memchr",
@@ -169,7 +169,7 @@ dependencies = [
  "cfg-if",
  "pin-project",
  "rustix",
- "thiserror",
+ "thiserror 1.0.67",
  "tokio",
  "windows-sys 0.52.0",
 ]
@@ -397,15 +397,25 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bzip2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafdbf26611df8c14810e268ddceda071c297570a5fb360ceddf617fe417ef58"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -462,9 +472,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -496,15 +506,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -549,6 +559,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -726,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -808,12 +837,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -845,11 +874,11 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "file_url"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "itertools 0.13.0",
  "percent-encoding",
- "thiserror",
+ "thiserror 2.0.9",
  "typed-path",
  "url",
 ]
@@ -923,16 +952,6 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
-dependencies = [
- "autocfg",
- "tokio",
-]
-
-[[package]]
-name = "fs-err"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb60e7409f34ef959985bc9d9c5ee8f5db24ee46ed9775850548021710f807f"
@@ -943,12 +962,13 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc91b3da7f1a7968b00f9f65a4971252f6a927d3cb9eec05d91cbeaff678f9a"
+checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
 dependencies = [
- "fs-err 2.11.0",
+ "fs-err",
  "rustix",
+ "tokio",
  "windows-sys 0.52.0",
 ]
 
@@ -1117,9 +1137,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "google-cloud-auth"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357160f51a60ec3e32169ad687f4abe0ee1e90c73b449aa5d11256c4f1cf2ff6"
+checksum = "e57a13fbacc5e9c41ded3ad8d0373175a6b7a6ad430d99e89d314ac121b7ab06"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -1130,7 +1150,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.67",
  "time",
  "tokio",
  "tracing",
@@ -1144,7 +1164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f945a208886a13d07636f38fb978da371d0abc3e34bad338124b9f8c135a8f"
 dependencies = [
  "reqwest",
- "thiserror",
+ "thiserror 1.0.67",
  "tokio",
 ]
 
@@ -1169,7 +1189,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1270,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -1601,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.0",
@@ -1612,15 +1632,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
 dependencies = [
  "console",
- "instant",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.1.14",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -1637,15 +1657,6 @@ checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1711,7 +1722,7 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.67",
 ]
 
 [[package]]
@@ -1779,12 +1790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -2234,12 +2239,13 @@ dependencies = [
 
 [[package]]
 name = "pep440_rs"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0922a442c78611fa8c5ed6065d2d898a820cf12fa90604217fdb2d01675efec7"
+checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
 dependencies = [
+ "once_cell",
  "serde",
- "unicode-width 0.2.0",
+ "unicode-width",
  "unscanny",
  "version-ranges",
 ]
@@ -2251,7 +2257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2feee999fa547bacab06a4881bacc74688858b92fa8ef1e206c748b0a76048"
 dependencies = [
  "boxcar",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itertools 0.13.0",
  "once_cell",
  "pep440_rs",
@@ -2259,8 +2265,8 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
- "thiserror",
- "unicode-width 0.2.0",
+ "thiserror 1.0.67",
+ "unicode-width",
  "url",
  "urlencoding",
  "version-ranges",
@@ -2279,7 +2285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
 ]
 
 [[package]]
@@ -2382,7 +2388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "quick-xml",
  "serde",
  "time",
@@ -2435,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2466,7 +2472,7 @@ dependencies = [
  "phf",
  "serde",
  "smartstring",
- "thiserror",
+ "thiserror 1.0.67",
  "unicase",
 ]
 
@@ -2497,7 +2503,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.67",
  "tokio",
  "url",
 ]
@@ -2611,7 +2617,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 1.0.67",
  "tokio",
  "tracing",
 ]
@@ -2628,7 +2634,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "slab",
- "thiserror",
+ "thiserror 1.0.67",
  "tinyvec",
  "tracing",
 ]
@@ -2694,16 +2700,16 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.28.5"
+version = "0.28.8"
 dependencies = [
  "anyhow",
  "console",
  "digest",
  "dirs",
- "fs-err 3.0.0",
+ "fs-err",
  "futures",
  "humantime",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "indicatif",
  "itertools 0.13.0",
  "memchr",
@@ -2716,6 +2722,7 @@ dependencies = [
  "rattler_networking",
  "rattler_package_streaming",
  "rattler_shell",
+ "rayon",
  "reflink-copy",
  "regex",
  "reqwest",
@@ -2723,7 +2730,7 @@ dependencies = [
  "simple_spawn_blocking",
  "smallvec",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -2732,13 +2739,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.2.13"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "dashmap",
  "digest",
  "dirs",
- "fs-err 3.0.0",
+ "fs-err",
  "fs4",
  "futures",
  "fxhash",
@@ -2748,10 +2755,11 @@ dependencies = [
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
+ "rayon",
  "reqwest",
  "reqwest-middleware",
  "simple_spawn_blocking",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -2759,15 +2767,16 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.29.3"
+version = "0.29.6"
 dependencies = [
  "chrono",
  "dirs",
  "file_url",
+ "fs-err",
  "fxhash",
  "glob",
  "hex",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itertools 0.13.0",
  "lazy-regex",
  "nom",
@@ -2785,7 +2794,7 @@ dependencies = [
  "simd-json",
  "smallvec",
  "strum",
- "thiserror",
+ "thiserror 2.0.9",
  "tracing",
  "typed-path",
  "url",
@@ -2793,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "blake2",
  "digest",
@@ -2808,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.20.0"
+version = "0.20.3"
 dependencies = [
- "fs-err 3.0.0",
+ "fs-err",
  "rattler_conda_types",
  "rattler_digest",
  "rattler_package_streaming",
@@ -2821,12 +2830,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.32"
+version = "0.22.35"
 dependencies = [
  "chrono",
  "file_url",
  "fxhash",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itertools 0.13.0",
  "pep440_rs",
  "pep508_rs",
@@ -2837,14 +2846,14 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.9",
  "typed-path",
  "url",
 ]
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "quote",
  "syn",
@@ -2852,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.21.8"
+version = "0.21.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2872,18 +2881,18 @@ dependencies = [
  "retry-policies",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.9",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.16"
+version = "0.22.19"
 dependencies = [
- "bzip2",
+ "bzip2 0.5.0",
  "chrono",
- "fs-err 3.0.0",
+ "fs-err",
  "futures-util",
  "num_cpus",
  "rattler_conda_types",
@@ -2895,7 +2904,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2906,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -2915,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.25"
+version = "0.21.28"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2928,7 +2937,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "file_url",
- "fs-err 3.0.0",
+ "fs-err",
  "futures",
  "hex",
  "http",
@@ -2957,7 +2966,7 @@ dependencies = [
  "simple_spawn_blocking",
  "superslice",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2968,23 +2977,23 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.8"
+version = "0.22.11"
 dependencies = [
  "enum_dispatch",
- "fs-err 3.0.0",
- "indexmap 2.6.0",
+ "fs-err",
+ "indexmap 2.7.0",
  "itertools 0.13.0",
  "rattler_conda_types",
  "serde_json",
  "shlex",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "tracing",
 ]
 
 [[package]]
 name = "rattler_solve"
-version = "1.2.4"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "futures",
@@ -2993,14 +3002,14 @@ dependencies = [
  "rattler_digest",
  "resolvo",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "1.1.11"
+version = "1.1.14"
 dependencies = [
  "archspec",
  "libloading",
@@ -3010,8 +3019,28 @@ dependencies = [
  "rattler_conda_types",
  "regex",
  "serde",
- "thiserror",
+ "thiserror 2.0.9",
  "tracing",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3031,7 +3060,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.67",
 ]
 
 [[package]]
@@ -3056,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31414597d1cd7fdd2422798b7652a6329dda0fe0219e6335a13d5bcaa9aeb6"
+checksum = "17400ed684c3a0615932f00c271ae3eea13e47056a1455821995122348ab6438"
 dependencies = [
  "cfg-if",
  "rustix",
@@ -3156,7 +3185,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "thiserror",
+ "thiserror 1.0.67",
  "tower-service",
 ]
 
@@ -3171,7 +3200,7 @@ dependencies = [
  "elsa",
  "event-listener",
  "futures",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itertools 0.13.0",
  "petgraph",
  "tracing",
@@ -3237,15 +3266,15 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"
-version = "0.38.38"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3393,9 +3422,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -3423,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3434,11 +3463,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3478,7 +3507,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3504,7 +3533,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itoa",
  "ryu",
  "serde",
@@ -3556,9 +3585,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simd-json"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1df0290e9bfe79ddd5ff8798ca887cd107b75353d2957efe9777296e17f26b5"
+checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
 dependencies = [
  "getrandom",
  "halfbrown",
@@ -3583,7 +3612,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.67",
  "time",
 ]
 
@@ -3699,9 +3728,9 @@ checksum = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3738,7 +3767,7 @@ dependencies = [
  "byteorder",
  "enum-as-inner",
  "libc",
- "thiserror",
+ "thiserror 1.0.67",
  "walkdir",
 ]
 
@@ -3767,9 +3796,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3784,7 +3813,16 @@ version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.67",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+dependencies = [
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -3792,6 +3830,17 @@ name = "thiserror-impl"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3856,9 +3905,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3905,9 +3954,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3928,7 +3977,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "toml_datetime",
  "winnow",
 ]
@@ -3941,9 +3990,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3952,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3963,9 +4012,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -3978,9 +4027,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-path"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
+checksum = "41713888c5ccfd99979fcd1afd47b71652e331b3d4a0e19d30769e80fec76cce"
 
 [[package]]
 name = "typeid"
@@ -4019,12 +4068,6 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
@@ -4055,9 +4098,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4113,9 +4156,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-ranges"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284649eba55872c1253f3f6ec15f22303a784e60684babd01d01e4c6ebb85b91"
+checksum = "f8d079415ceb2be83fc355adbadafe401307d5c309c7e6ade6638e6f9f42f42d"
 dependencies = [
  "smallvec",
 ]
@@ -4236,6 +4279,16 @@ name = "web-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4728,18 +4781,18 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "memchr",
- "thiserror",
+ "thiserror 2.0.9",
  "time",
  "zopfli",
 ]

--- a/py-rattler/tests/unit/test_gateway.py
+++ b/py-rattler/tests/unit/test_gateway.py
@@ -6,7 +6,7 @@ from rattler import Gateway, Channel
 @pytest.mark.asyncio
 async def test_single_record_in_recursive_query(gateway: Gateway, conda_forge_channel: Channel) -> None:
     subdirs = await gateway.query(
-        [conda_forge_channel], ["linux-64", "noarch"], ["python 3.10.0 h543edf9_1_cpython"], recursive=True
+        [conda_forge_channel], ["linux-64", "noarch"], ["python ==3.10.0 h543edf9_1_cpython"], recursive=True
     )
 
     python_records = [record for subdir in subdirs for record in subdir if record.name == "python"]

--- a/py-rattler/tests/unit/test_solver.py
+++ b/py-rattler/tests/unit/test_solver.py
@@ -110,7 +110,7 @@ async def test_solve_channel_priority_disabled(
 ) -> None:
     solved_data = await solve(
         [conda_forge_channel, pytorch_channel],
-        ["pytorch-cpu 0.4.1 py36_cpu_1"],
+        ["pytorch-cpu ==0.4.1 py36_cpu_1"],
         platforms=["linux-64"],
         gateway=gateway,
         channel_priority=ChannelPriority.Disabled,


### PR DESCRIPTION
This PR makes parsing even stricter. With these changes, `foo 1.2.3` throws an error and suggests either `==1.2.3`, or `1.2.3.*`.

Note: there seems to be a bug (not sure if new?) when parsing `1!1.2.3.*` - it says "ExpectedEof".