### PR TITLE
perf: read json to memory before parsing

### DIFF
--- a/crates/rattler_conda_types/src/package/mod.rs
+++ b/crates/rattler_conda_types/src/package/mod.rs
@@ -14,7 +14,6 @@ mod package_metadata;
 mod paths;
 mod run_exports;
 
-use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 pub use {
@@ -71,7 +70,7 @@ pub trait PackageFile: Sized {
     /// the specified path, parse the JSON string and return the resulting object. If the file is
     /// not in a parsable format or if the file could not read, this function returns an error.
     fn from_path(path: impl AsRef<Path>) -> Result<Self, std::io::Error> {
-        Self::from_reader(File::open(path)?)
+        Self::from_str(&fs_err::read_to_string(path)?)
     }
 
     /// Parses the object by looking up the appropriate file from the root of the specified Conda


### PR DESCRIPTION
I saw a lot of file system activity on macOS related to reading package cache files. 

The way we were reading them was not optimal. `std::fs::read_to_string` does a better job: it looks at the file, checks the size, and uses the size as a hint to first allocate the string and then allocate the buffer for the reading. So I hope this will improve this a bit.

<img width="1614" alt="Screenshot 2024-12-19 at 09 41 39" src="https://github.com/user-attachments/assets/6e60d4a1-2606-4f52-9387-0954b62d81e0" />
