### PR TITLE
[wip] tiered cache

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -36,6 +36,8 @@ rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.1.
 rattler_cache = { path="../rattler_cache", version = "0.3.1", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
+# we enable the asm feature for sha2 to speed up hashing in the binary
+sha2 = { workspace = true, features = ["asm"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 itertools = { workspace = true }

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -32,6 +32,9 @@ digest.workspace = true
 fs4 = { workspace = true, features = ["fs-err3-tokio", "tokio"] }
 simple_spawn_blocking = { version = "1.0.0", path = "../simple_spawn_blocking", features = ["tokio"] }
 rayon = { workspace = true }
+bitflags = "2.6.0"
+uuid.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true


### PR DESCRIPTION
This is a starting point for a tiered cache where one could have multiple package caches, where some of the lower ones might be read-only.

A challenge is that we probably cannot do "read-locking" on read-only caches since we wouldn't be allowed to create lockfiles at all.

Another goal is that we can say: can-reflink or can-symlink per-cache (I want to store a HashMap in the cache with prefix mapping to capabilities).