### PR TITLE
fix: Create SparseRepoData with correct subdir in py_fetch_repo_data

### DIFF
--- a/py-rattler/src/networking/mod.rs
+++ b/py-rattler/src/networking/mod.rs
@@ -35,7 +35,7 @@ pub fn py_fetch_repo_data<'a>(
     let mut meta_futures = Vec::new();
     let client = client.unwrap_or(PyClientWithMiddleware::new(None));
 
-    for (subdir, chan) in get_subdir_urls(channels, platforms)? {
+    for (subdir, chan, platform) in get_subdir_urls(channels, platforms)? {
         let callback = callback.as_ref().map(|callback| {
             Arc::new(ProgressReporter {
                 callback: callback.to_object(py),
@@ -56,7 +56,8 @@ pub fn py_fetch_repo_data<'a>(
                 )
                 .await?,
                 chan,
-            )) as Result<(CachedRepoData, PyChannel), FetchRepoDataError>
+                String::from(platform.inner.as_str()),
+            )) as Result<(CachedRepoData, PyChannel, String), FetchRepoDataError>
         });
     }
 
@@ -65,9 +66,8 @@ pub fn py_fetch_repo_data<'a>(
         match try_join_all(meta_futures).await {
             Ok(res) => res
                 .into_iter()
-                .map(|(cache, chan)| {
-                    let path = cache_path.to_string_lossy().into_owned();
-                    PySparseRepoData::new(chan, path, cache.repo_data_json_path)
+                .map(|(cache, chan, platform)| {
+                    PySparseRepoData::new(chan, platform, cache.repo_data_json_path)
                 })
                 .collect::<Result<Vec<_>, _>>(),
             Err(e) => Err(PyRattlerError::from(e).into()),
@@ -98,7 +98,7 @@ impl Reporter for ProgressReporter {
 fn get_subdir_urls(
     channels: Vec<PyChannel>,
     platforms: Vec<PyPlatform>,
-) -> PyResult<Vec<(Url, PyChannel)>> {
+) -> PyResult<Vec<(Url, PyChannel, PyPlatform)>> {
     let mut urls = Vec::new();
 
     for c in channels {
@@ -107,6 +107,7 @@ fn get_subdir_urls(
             urls.push((
                 Url::from_str(r.as_str()).map_err(PyRattlerError::from)?,
                 c.clone(),
+                p.clone(),
             ));
         }
     }

--- a/py-rattler/src/networking/mod.rs
+++ b/py-rattler/src/networking/mod.rs
@@ -107,7 +107,7 @@ fn get_subdir_urls(
             urls.push((
                 Url::from_str(r.as_str()).map_err(PyRattlerError::from)?,
                 c.clone(),
-                p.clone(),
+                *p,
             ));
         }
     }

--- a/py-rattler/tests/unit/test_fetch_repo_data.py
+++ b/py-rattler/tests/unit/test_fetch_repo_data.py
@@ -60,6 +60,7 @@ async def test_fetch_repo_data(
 
     repodata = result[0]
     assert isinstance(repodata, SparseRepoData)
+    assert repodata.subdir == str(plat)
 
     package = PackageName(repodata.package_names()[0])
     repodata_record = repodata.load_records(package)[0]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

When using the py-rattler library, the `fetch_repo_data` method incorrectly sets the `subdir` on `SparseRepoData` instances so if a channel is missing `subdir` on `PackageRecords`, it tries to append the bad subdir value to the url which can cause a panic.

This can be seen with this example

```
import asyncio
from pathlib import Path

from rattler import fetch_repo_data, solve_with_sparse_repodata
from rattler.channel import Channel, ChannelConfig, ChannelPriority
from rattler.platform import Platform
from rattler.match_spec import MatchSpec
from rattler.virtual_package import VirtualPackage

async def main():
    channel_config = ChannelConfig("https://repo.anaconda.com/pkgs/")
    channels = [Channel("free", channel_configuration=channel_config)]
    sparse = await fetch_repo_data(
        channels=channels,
        platforms=[Platform("win-64"), Platform("noarch")],
        cache_path=Path(r"D:/repos/py-sandbox/cache"),
        callback=lambda _, __: None
    )
    res = await solve_with_sparse_repodata(
        specs=[MatchSpec("python")],
        sparse_repodata=sparse,
        virtual_packages=VirtualPackage.current(),
        channel_priority=ChannelPriority.Disabled
    )


if __name__ == '__main__':
    asyncio.run(main())
```


```
thread 'tokio-runtime-worker' panicked at local_dependencies\rattler_conda_types\src\repo_data\mod.rs:273:10:
failed to join base_url and filename: RelativeUrlWithCannotBeABaseBase
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
