### PR TITLE
fix: parsing of >=2.*.*

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1057,6 +1057,8 @@ mod tests {
             "./relative/channel::package",
             "python[channel=https://conda.anaconda.org/python/conda,version=3.9]",
             "channel/win-64::foobar[channel=conda-forge, subdir=linux-64]",
+            // Issue #1004
+            "numpy>=2.*.*",
         ];
 
         let evaluated: IndexMap<_, _> = specs
@@ -1127,6 +1129,8 @@ mod tests {
             // subdir in brackets take precedence
             "[version=3.9, subdir=linux-64]",
             "==3.9[subdir=linux-64, build_number=\"0\"]",
+            // Issue #1004
+            ">=2.*.*",
         ];
 
         let evaluated: IndexMap<_, _> = specs

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
 expression: evaluated
+snapshot_kind: text
 ---
 blas *.* mkl:
   name: blas
@@ -138,3 +139,6 @@ rust ~=1.2.3:
     base_url: "https://conda.anaconda.org/conda-forge"
     name: conda-forge
   subdir: linux-64
+numpy>=2.*.*:
+  name: numpy
+  version: ">=2"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
 expression: evaluated
+snapshot_kind: text
 ---
 blas *.* mkl:
   name: blas
@@ -130,3 +131,5 @@ rust ~=1.2.3:
     base_url: "https://conda.anaconda.org/conda-forge"
     name: conda-forge
   subdir: linux-64
+numpy>=2.*.*:
+  error: "invalid version constraint: regex constraints are not supported"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Lenient.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
 expression: evaluated
+snapshot_kind: text
 ---
 2.7|>=3.6:
   version: "==2.7|>=3.6"
@@ -57,3 +58,5 @@ expression: evaluated
     op: Eq
     rhs: 0
   subdir: linux-64
+">=2.*.*":
+  version: ">=2"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
 expression: evaluated
+snapshot_kind: text
 ---
 2.7|>=3.6:
   version: "==2.7|>=3.6"
@@ -54,3 +55,5 @@ expression: evaluated
     op: Eq
     rhs: 0
   subdir: linux-64
+">=2.*.*":
+  error: "invalid version constraint: regex constraints are not supported"

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -498,6 +498,16 @@ mod tests {
     }
 
     #[test]
+    fn issue_1004() {
+        assert_eq!(
+            VersionSpec::from_str(">=2.*.*", ParseStrictness::Lenient).unwrap(),
+            VersionSpec::from_str(">=2", ParseStrictness::Lenient).unwrap()
+        );
+
+        assert!(VersionSpec::from_str("0.2.18.*.*", ParseStrictness::Strict).is_err());
+    }
+
+    #[test]
     fn issue_bracket_printing() {
         let v = VersionSpec::from_str("(>=1,<2)|>3", ParseStrictness::Lenient).unwrap();
         assert_eq!(format!("{v}"), ">=1,<2|>3");

--- a/crates/rattler_conda_types/src/version_spec/parse.rs
+++ b/crates/rattler_conda_types/src/version_spec/parse.rs
@@ -212,12 +212,14 @@ fn logical_constraint_parser(
 
             // The version ends in a wildcard pattern
             (
-                "*" | ".*",
+                version_remainder,
                 Some(VersionOperators::Range(
                     RangeOperator::GreaterEquals | RangeOperator::Greater,
                 )),
                 Lenient,
-            ) => VersionOperators::Range(RangeOperator::GreaterEquals),
+            ) if is_star_or_star_dot_star(version_remainder) => {
+                VersionOperators::Range(RangeOperator::GreaterEquals)
+            }
             (
                 "*" | ".*",
                 Some(VersionOperators::Exact(EqualityOperator::NotEquals)),
@@ -227,7 +229,9 @@ fn logical_constraint_parser(
                 // even in strict mode we allow this.
                 VersionOperators::StrictRange(StrictRangeOperator::NotStartsWith)
             }
-            ("*" | ".*", Some(op), Lenient) => {
+            (version_remainder, Some(op), Lenient)
+                if is_star_or_star_dot_star(version_remainder) =>
+            {
                 // In lenient mode we simply ignore the glob.
                 op
             }
@@ -296,6 +300,18 @@ pub fn looks_like_infinite_starts_with(input: &str) -> bool {
     }
 
     false
+}
+
+/// Returns true if the input is `*` or a sequence of `.*`.
+pub fn is_star_or_star_dot_star(input: &str) -> bool {
+    if input == "*" {
+        return true;
+    }
+    let mut input = input;
+    while let Some(rest) = input.strip_suffix(".*") {
+        input = rest;
+    }
+    input.is_empty()
 }
 
 /// Parses a version constraint.


### PR DESCRIPTION
Fixes #1004 

Fixes parsing of `numpy>=2.*.*` in lenient mode. Note that this makes no sense and it is just interpreted as `>=2`.