### PR TITLE
feat: wire up network config for sandbox

### DIFF
--- a/crates/rattler_sandbox/src/sandbox/mod.rs
+++ b/crates/rattler_sandbox/src/sandbox/mod.rs
@@ -52,6 +52,11 @@ fn init() {
             let _ = sandbox.add_exception(birdcage::Exception::WriteAndRead(path.into()));
         }
     }
+
+    if opts.network {
+        let _ = sandbox.add_exception(birdcage::Exception::Networking);
+    }
+
     if let Some((exe, args)) = opts.args.split_first() {
         // Initialize the sandbox; by default everything is prohibited.
         let mut command = Command::new(exe);


### PR DESCRIPTION
Looks like this was forgotten which makes network always disabled.