### PR TITLE
feat: add deserialize from string for types

### DIFF
--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -698,7 +698,9 @@ pub fn link_package_sync(
         if full_path.exists() {
             // tracing::info!("directory already exists: {:?}", directory);
             continue;
-        } else if allow_ref_links && cfg!(target_os = "macos") && !index_json.noarch.is_python() {
+        }
+
+        if allow_ref_links && cfg!(target_os = "macos") && !index_json.noarch.is_python() {
             // reflink the whole directory if possible
             // currently this does not handle noarch packages
             match reflink_copy::reflink(package_dir.join(&directory), &full_path) {
@@ -754,7 +756,7 @@ pub fn link_package_sync(
                     sha256_in_prefix: None,
                     file_mode: None,
                     prefix_placeholder: None,
-                })
+                });
             }
         }
     }

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -246,10 +246,8 @@ impl From<PackageName> for MatchSpec {
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct NamelessMatchSpec {
     /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
-    #[serde_as(as = "Option<DisplayFromStr>")]
     pub version: Option<VersionSpec>,
     /// The build string of the package (e.g. `py37_0`, `py37h6de7cb9_0`, `py*`)
-    #[serde_as(as = "Option<DisplayFromStr>")]
     pub build: Option<StringMatcher>,
     /// The build number of the package
     pub build_number: Option<BuildNumberSpec>,

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -1,7 +1,7 @@
 use crate::{build_spec::BuildNumberSpec, PackageName, PackageRecord, RepoDataRecord, VersionSpec};
 use rattler_digest::{serde::SerializableHash, Md5Hash, Sha256Hash};
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
+use serde_with::{serde_as, skip_serializing_none};
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::sync::Arc;
@@ -482,6 +482,7 @@ impl Matches<RepoDataRecord> for NamelessMatchSpec {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use itertools::Itertools;
 
     use rattler_digest::{parse_digest_from_hex, Md5, Sha256};
 
@@ -711,7 +712,24 @@ mod tests {
             .into_iter()
             .map(|s| MatchSpec::from_str(s, Strict).unwrap())
             .map(|s| s.to_string())
-            .collect::<Vec<String>>()
-            .join("\n"));
+            .format("\n")
+            .to_string());
+    }
+
+    #[test]
+    fn test_serialize_json_matchspec() {
+        let specs = ["mamba 1.0 py37_0",
+            "conda-forge::pytest[version=1.0, sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97, md5=dede6252c964db3f3e41c7d30d07f6bf]",
+            "conda-forge/linux-64::pytest",
+            "conda-forge/linux-64::pytest[version=1.0]",
+            "conda-forge/linux-64::pytest[version=1.0, build=py37_0]",
+            "conda-forge/linux-64::pytest 1.2.3"];
+
+        assert_snapshot!(specs
+            .into_iter()
+            .map(|s| MatchSpec::from_str(s, Strict).unwrap())
+            .map(|s| serde_json::to_string(&s).unwrap())
+            .format("\n")
+            .to_string());
     }
 }

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -481,8 +481,8 @@ impl Matches<RepoDataRecord> for NamelessMatchSpec {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
     use itertools::Itertools;
+    use std::str::FromStr;
 
     use rattler_digest::{parse_digest_from_hex, Md5, Sha256};
 

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -718,12 +718,12 @@ mod tests {
 
     #[test]
     fn test_serialize_json_matchspec() {
-        let specs = ["mamba 1.0 py37_0",
-            "conda-forge::pytest[version=1.0, sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97, md5=dede6252c964db3f3e41c7d30d07f6bf]",
+        let specs = ["mamba 1.0.* py37_0",
+            "conda-forge::pytest[version='==1.0', sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97, md5=dede6252c964db3f3e41c7d30d07f6bf]",
             "conda-forge/linux-64::pytest",
-            "conda-forge/linux-64::pytest[version=1.0]",
-            "conda-forge/linux-64::pytest[version=1.0, build=py37_0]",
-            "conda-forge/linux-64::pytest 1.2.3"];
+            "conda-forge/linux-64::pytest[version=1.0.*]",
+            "conda-forge/linux-64::pytest[version=1.0.*, build=py37_0]",
+            "conda-forge/linux-64::pytest ==1.2.3"];
 
         assert_snapshot!(specs
             .into_iter()

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -46,9 +46,7 @@ pytorch=*=cuda*:
 "conda-forge::foo[version=1.0.*, build_number=\">6\"]":
   name: foo
   version: 1.0.*
-  build_number:
-    op: Gt
-    rhs: 6
+  build_number: ">6"
   channel:
     base_url: "https://conda.anaconda.org/conda-forge"
     name: conda-forge
@@ -91,9 +89,7 @@ python=*:
 "conda-forge/linux-32::python ==3.9[subdir=linux-64, build_number=\"0\"]":
   name: python
   version: "==3.9"
-  build_number:
-    op: Eq
-    rhs: 0
+  build_number: "==0"
   channel:
     base_url: "https://conda.anaconda.org/conda-forge"
     name: conda-forge

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -40,9 +40,7 @@ pytorch=*=cuda*:
 "conda-forge::foo[version=1.0.*, build_number=\">6\"]":
   name: foo
   version: 1.0.*
-  build_number:
-    op: Gt
-    rhs: 6
+  build_number: ">6"
   channel:
     base_url: "https://conda.anaconda.org/conda-forge"
     name: conda-forge
@@ -83,9 +81,7 @@ python=*:
 "conda-forge/linux-32::python ==3.9[subdir=linux-64, build_number=\"0\"]":
   name: python
   version: "==3.9"
-  build_number:
-    op: Eq
-    rhs: 0
+  build_number: "==0"
   channel:
     base_url: "https://conda.anaconda.org/conda-forge"
     name: conda-forge

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Lenient.snap
@@ -37,9 +37,7 @@ expression: evaluated
   version: 1.0.*
 "[version=1.0.*, build_number=\">6\"]":
   version: 1.0.*
-  build_number:
-    op: Gt
-    rhs: 6
+  build_number: ">6"
 "==2.7.*.*|>=3.6":
   version: 2.7.*|>=3.6
 "3.9":
@@ -53,7 +51,5 @@ expression: evaluated
   subdir: linux-64
 "==3.9[subdir=linux-64, build_number=\"0\"]":
   version: "==3.9"
-  build_number:
-    op: Eq
-    rhs: 0
+  build_number: "==0"
   subdir: linux-64

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
@@ -34,9 +34,7 @@ expression: evaluated
   version: 1.0.*
 "[version=1.0.*, build_number=\">6\"]":
   version: 1.0.*
-  build_number:
-    op: Gt
-    rhs: 6
+  build_number: ">6"
 "==2.7.*.*|>=3.6":
   error: "invalid version constraint: regex constraints are not supported"
 "3.9":
@@ -50,7 +48,5 @@ expression: evaluated
   subdir: linux-64
 "==3.9[subdir=linux-64, build_number=\"0\"]":
   version: "==3.9"
-  build_number:
-    op: Eq
-    rhs: 0
+  build_number: "==0"
   subdir: linux-64

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__tests__serialize_json_matchspec.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__tests__serialize_json_matchspec.snap
@@ -1,0 +1,10 @@
+---
+source: crates/rattler_conda_types/src/match_spec/mod.rs
+expression: "specs.into_iter().map(|s|\nMatchSpec::from_str(s,\nStrict).unwrap()).map(|s|\nserde_json::to_string(&s).unwrap()).format(\"\\n\").to_string()"
+---
+{"name":"mamba","version":"==1.0","build":"py37_0"}
+{"name":"pytest","version":"==1.0","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"md5":"dede6252c964db3f3e41c7d30d07f6bf","sha256":"aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97"}
+{"name":"pytest","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}
+{"name":"pytest","version":"==1.0","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}
+{"name":"pytest","version":"==1.0","build":"py37_0","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}
+{"name":"pytest","version":"==1.2.3","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__tests__serialize_json_matchspec.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__tests__serialize_json_matchspec.snap
@@ -2,9 +2,9 @@
 source: crates/rattler_conda_types/src/match_spec/mod.rs
 expression: "specs.into_iter().map(|s|\nMatchSpec::from_str(s,\nStrict).unwrap()).map(|s|\nserde_json::to_string(&s).unwrap()).format(\"\\n\").to_string()"
 ---
-{"name":"mamba","version":"==1.0","build":"py37_0"}
+{"name":"mamba","version":"1.0.*","build":"py37_0"}
 {"name":"pytest","version":"==1.0","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"md5":"dede6252c964db3f3e41c7d30d07f6bf","sha256":"aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97"}
 {"name":"pytest","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}
-{"name":"pytest","version":"==1.0","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}
-{"name":"pytest","version":"==1.0","build":"py37_0","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}
+{"name":"pytest","version":"1.0.*","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}
+{"name":"pytest","version":"1.0.*","build":"py37_0","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}
 {"name":"pytest","version":"==1.2.3","channel":{"base_url":"https://conda.anaconda.org/conda-forge","name":"conda-forge"},"subdir":"linux-64"}

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod parse;
 pub(crate) mod version_tree;
 
 use std::{
+    borrow::Cow,
     convert::TryFrom,
     fmt::{Display, Formatter},
     str::FromStr,
@@ -20,7 +21,7 @@ use version_tree::VersionTree;
 
 use crate::{
     version::StrictVersion, version_spec::version_tree::ParseVersionTreeError, ParseStrictness,
-    ParseVersionError, Version,
+    ParseStrictness::Lenient, ParseVersionError, Version,
 };
 
 /// An operator to compare two versions.
@@ -118,7 +119,7 @@ impl LogicalOperator {
 
 /// A version specification.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum VersionSpec {
     /// No version specified
     None,
@@ -302,7 +303,17 @@ impl Serialize for VersionSpec {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&format!("{self}"))
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for VersionSpec {
+    fn deserialize<D>(deserializer: D) -> Result<VersionSpec, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = Cow::<'de, str>::deserialize(deserializer)?;
+        VersionSpec::from_str(&s, Lenient).map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
Implements `Deserialize` for some types that basically convert to a string.

We used to do this a lot:

```rust
/// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
#[serde_as(as = "Option<DisplayFromStr>")]
pub version: Option<VersionSpec>,
/// The build string of the package (e.g. `py37_0`, `py37h6de7cb9_0`, `py*`)
#[serde_as(as = "Option<DisplayFromStr>")]
pub build: Option<StringMatcher>,
``` 

With this change that is no longer needed.