### PR TITLE
feat: Match GenericVirtualPackage with MatchSpec

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -1,4 +1,7 @@
-use crate::{build_spec::BuildNumberSpec, PackageName, PackageRecord, RepoDataRecord, VersionSpec};
+use crate::{
+    build_spec::BuildNumberSpec, GenericVirtualPackage, PackageName, PackageRecord, RepoDataRecord,
+    VersionSpec,
+};
 use rattler_digest::{serde::SerializableHash, Md5Hash, Sha256Hash};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
@@ -226,6 +229,15 @@ impl MatchSpec {
                 url: self.url,
             },
         )
+    }
+
+    /// Returns whether the package is a virtual package.
+    /// This is determined by the package name starting with `__`.
+    /// Not having a package name is considered not virtual.
+    pub fn is_virtual(&self) -> bool {
+        self.name
+            .as_ref()
+            .map_or(false, |name| name.as_normalized().starts_with("__"))
     }
 }
 
@@ -481,8 +493,33 @@ impl Matches<RepoDataRecord> for NamelessMatchSpec {
     }
 }
 
+impl Matches<GenericVirtualPackage> for MatchSpec {
+    /// Match a [`MatchSpec`] against a [`GenericVirtualPackage`]
+    fn matches(&self, other: &GenericVirtualPackage) -> bool {
+        if let Some(name) = self.name.as_ref() {
+            if name != &other.name {
+                return false;
+            }
+        }
+
+        if let Some(spec) = self.version.as_ref() {
+            if !spec.matches(&other.version) {
+                return false;
+            }
+        }
+
+        if let Some(build_string) = self.build.as_ref() {
+            if !build_string.matches(&other.build_string) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
     use std::str::FromStr;
 
     use rattler_digest::{parse_digest_from_hex, Md5, Sha256};
@@ -715,5 +752,45 @@ mod tests {
             .map(|s| s.to_string())
             .collect::<Vec<String>>()
             .join("\n"));
+    }
+
+    #[rstest]
+    #[case("foo >=1.0 py37_0", true)]
+    #[case("foo >=1.0 py37*", true)]
+    #[case("foo 1.0.* py38*", false)]
+    #[case("foo * py37_1", false)]
+    #[case("foo ==1.0", true)]
+    #[case("foo >=2.0", false)]
+    #[case("foo >=1.0", true)]
+    #[case("foo", true)]
+    #[case("bar", false)]
+    fn test_match_generic_virtual_package(#[case] spec_str: &str, #[case] expected: bool) {
+        let virtual_package = crate::GenericVirtualPackage {
+            name: PackageName::new_unchecked("foo"),
+            version: Version::from_str("1.0").unwrap(),
+            build_string: String::from("py37_0"),
+        };
+
+        let spec = MatchSpec::from_str(spec_str, Strict).unwrap();
+        assert_eq!(spec.matches(&virtual_package), expected);
+    }
+
+    #[test]
+    fn test_is_virtual() {
+        let spec = MatchSpec::from_str("non_virtual_name", Strict).unwrap();
+        assert!(!spec.is_virtual());
+
+        let spec = MatchSpec::from_str("__virtual_name", Strict).unwrap();
+        assert!(spec.is_virtual());
+
+        let spec = MatchSpec::from_str("non_virtual_name >=12", Strict).unwrap();
+        assert!(!spec.is_virtual());
+
+        let spec = MatchSpec::from_str("__virtual_name >=12", Strict).unwrap();
+        assert!(spec.is_virtual());
+
+        let spec =
+            MatchSpec::from_nameless(NamelessMatchSpec::from_str(">=12", Strict).unwrap(), None);
+        assert!(!spec.is_virtual());
     }
 }

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -606,4 +606,39 @@ mod test {
             .map(|p| p.location().to_string())
             .collect::<Vec<_>>());
     }
+
+    #[test]
+    fn test_has_pypi_packages() {
+        // v4
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test-data/conda-lock")
+            .join("v4/pypi-matplotlib-lock.yml");
+        let conda_lock = LockFile::from_path(&path).unwrap();
+
+        assert!(conda_lock
+            .environment(DEFAULT_ENVIRONMENT_NAME)
+            .unwrap()
+            .has_pypi_packages(Platform::Linux64));
+
+        // v6
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test-data/conda-lock")
+            .join("v6/numpy-as-pypi-lock.yml");
+        let conda_lock = LockFile::from_path(&path).unwrap();
+
+        assert!(conda_lock
+            .environment(DEFAULT_ENVIRONMENT_NAME)
+            .unwrap()
+            .has_pypi_packages(Platform::OsxArm64));
+
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test-data/conda-lock")
+            .join("v6/python-from-conda-only-lock.yml");
+        let conda_lock = LockFile::from_path(&path).unwrap();
+
+        assert!(!conda_lock
+            .environment(DEFAULT_ENVIRONMENT_NAME)
+            .unwrap()
+            .has_pypi_packages(Platform::OsxArm64));
+    }
 }

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -419,6 +419,12 @@ impl<'lock> Environment<'lock> {
             .map(|pkgs| pkgs.filter_map(LockedPackageRef::as_pypi))
     }
 
+    /// Returns whether this environment has any pypi packages for the specified platform.
+    pub fn has_pypi_packages(&self, platform: Platform) -> bool {
+        self.pypi_packages(platform)
+            .is_some_and(|mut packages| packages.next().is_some())
+    }
+
     /// Creates a [`OwnedEnvironment`] from this environment.
     pub fn to_owned(self) -> OwnedEnvironment {
         OwnedEnvironment {

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -38,7 +38,7 @@ pub mod linux;
 pub mod osx;
 
 use std::{
-    env,
+    env, fmt,
     hash::{Hash, Hasher},
     str::FromStr,
     sync::Arc,
@@ -394,6 +394,12 @@ impl EnvOverride for LibC {
 
     fn detect_from_host() -> Result<Option<Self>, DetectVirtualPackageError> {
         Ok(Self::current()?)
+    }
+}
+
+impl fmt::Display for LibC {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}={}", self.family, self.version)
     }
 }
 

--- a/test-data/conda-lock/v6/numpy-as-pypi-lock.yml
+++ b/test-data/conda-lock/v6/numpy-as-pypi-lock.yml
@@ -1,0 +1,237 @@
+version: 6
+environments:
+  default:
+    channels:
+      - url: https://prefix.dev/conda-forge/
+    indexes:
+      - https://pypi.org/simple
+    packages:
+      osx-arm64:
+        - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+        - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-devel-5.6.3-h39f12f2_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.47.2-h3f77e49_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.13.0-hbbac1ca_101_cp313.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/python_abi-3.13-5_cp313.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+        - conda: https://prefix.dev/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/xz-5.6.3-h9a6d368_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/xz-gpl-tools-5.6.3-h9a6d368_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/xz-tools-5.6.3-h39f12f2_1.conda
+        - pypi: https://files.pythonhosted.org/packages/8c/40/5792ccccd91d45e87d9e00033abc4f6ca8a828467b193f711139ff1f1cd9/numpy-2.2.1-cp313-cp313-macosx_11_0_arm64.whl
+packages:
+  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+    sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+    md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+    depends:
+      - __osx >=11.0
+    license: bzip2-1.0.6
+    license_family: BSD
+    purls: []
+    size: 122909
+    timestamp: 1720974522888
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
+    sha256: 256be633fd0882ccc1a7a32bc278547e1703f85082c0789a87a603ee3ab8fb82
+    md5: 7cb381a6783d91902638e4ed1ebd478e
+    license: ISC
+    purls: []
+    size: 157091
+    timestamp: 1734208344343
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+    sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+    md5: 38d2656dd914feb0cab8c629370768bf
+    depends:
+      - __osx >=11.0
+    constrains:
+      - expat 2.6.4.*
+    license: MIT
+    license_family: MIT
+    purls: []
+    size: 64693
+    timestamp: 1730967175868
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+    sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+    md5: 086914b672be056eb70fd4285b6783b6
+    license: MIT
+    license_family: MIT
+    purls: []
+    size: 39020
+    timestamp: 1636488587153
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+    sha256: d863b8257406918ffdc50ae65502f2b2d6cede29404d09a094f59509d6a0aaf1
+    md5: b2553114a7f5e20ccd02378a77d836aa
+    depends:
+      - __osx >=11.0
+    license: 0BSD
+    purls: []
+    size: 99129
+    timestamp: 1733407496073
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-devel-5.6.3-h39f12f2_1.conda
+    sha256: c785d43d4758e18153b502c7d7d3a9181f3c95b2ae64a389fe49af5bf3a53f05
+    md5: 692ccac07529215d42c051c6a60bc5a5
+    depends:
+      - __osx >=11.0
+      - liblzma 5.6.3 h39f12f2_1
+    license: 0BSD
+    purls: []
+    size: 113099
+    timestamp: 1733407511832
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
+    sha256: f7917de9117d3a5fe12a39e185c7ce424f8d5010a6f97b4333e8a1dcb2889d16
+    md5: 7476305c35dd9acef48da8f754eedb40
+    depends:
+      - __osx >=11.0
+    license: BSD-2-Clause
+    license_family: BSD
+    purls: []
+    size: 69263
+    timestamp: 1723817629767
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.47.2-h3f77e49_0.conda
+    sha256: f192f3c8973de9ec4c214990715f13b781965247a5cedf9162e7f9e699cfc3c4
+    md5: 122d6f29470f1a991e85608e77e56a8a
+    depends:
+      - __osx >=11.0
+      - libzlib >=1.3.1,<2.0a0
+    license: Unlicense
+    purls: []
+    size: 850553
+    timestamp: 1733762057506
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+    sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+    md5: 369964e85dc26bfe78f41399b366c435
+    depends:
+      - __osx >=11.0
+    constrains:
+      - zlib 1.3.1 *_2
+    license: Zlib
+    license_family: Other
+    purls: []
+    size: 46438
+    timestamp: 1727963202283
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+    sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+    md5: cb2b0ea909b97b3d70cd3921d1445e1a
+    depends:
+      - __osx >=11.0
+    license: X11 AND BSD-3-Clause
+    purls: []
+    size: 802321
+    timestamp: 1724658775723
+  - pypi: https://files.pythonhosted.org/packages/8c/40/5792ccccd91d45e87d9e00033abc4f6ca8a828467b193f711139ff1f1cd9/numpy-2.2.1-cp313-cp313-macosx_11_0_arm64.whl
+    name: numpy
+    version: 2.2.1
+    sha256: 3ecc47cd7f6ea0336042be87d9e7da378e5c7e9b3c8ad0f7c966f714fc10d821
+    requires_python: '>=3.10'
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
+    sha256: 97772762abc70b3a537683ca9fc3ff3d6099eb64e4aba3b9c99e6fce48422d21
+    md5: 22f971393637480bda8c679f374d8861
+    depends:
+      - __osx >=11.0
+      - ca-certificates
+    license: Apache-2.0
+    license_family: Apache
+    purls: []
+    size: 2936415
+    timestamp: 1736086108693
+  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.13.0-hbbac1ca_101_cp313.conda
+    build_number: 101
+    sha256: 742544a4cf9a10cf2c16d35d96fb696c27d58b9df0cc29fbef5629283aeca941
+    md5: e972e146a1e0cfb1f26da42cb6f6648c
+    depends:
+      - __osx >=11.0
+      - bzip2 >=1.0.8,<2.0a0
+      - libexpat >=2.6.4,<3.0a0
+      - libffi >=3.4,<4.0a0
+      - libmpdec >=4.0.0,<5.0a0
+      - libsqlite >=3.47.0,<4.0a0
+      - libzlib >=1.3.1,<2.0a0
+      - ncurses >=6.5,<7.0a0
+      - openssl >=3.4.0,<4.0a0
+      - python_abi 3.13.* *_cp313
+      - readline >=8.2,<9.0a0
+      - tk >=8.6.13,<8.7.0a0
+      - tzdata
+      - xz >=5.2.6,<6.0a0
+    license: Python-2.0
+    purls: []
+    size: 12806496
+    timestamp: 1732735488999
+  - conda: https://prefix.dev/conda-forge/osx-arm64/python_abi-3.13-5_cp313.conda
+    build_number: 5
+    sha256: 4437198eae80310f40b23ae2f8a9e0a7e5c2b9ae411a8621eb03d87273666199
+    md5: b8e82d0a5c1664638f87f63cc5d241fb
+    constrains:
+      - python 3.13.* *_cp313
+    license: BSD-3-Clause
+    license_family: BSD
+    purls: []
+    size: 6322
+    timestamp: 1723823058879
+  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+    sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+    md5: 8cbb776a2f641b943d413b3e19df71f4
+    depends:
+      - ncurses >=6.3,<7.0a0
+    license: GPL-3.0-only
+    license_family: GPL
+    purls: []
+    size: 250351
+    timestamp: 1679532511311
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+    sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+    md5: b50a57ba89c32b62428b71a875291c9b
+    depends:
+      - libzlib >=1.2.13,<2.0.0a0
+    license: TCL
+    license_family: BSD
+    purls: []
+    size: 3145523
+    timestamp: 1699202432999
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+    sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+    md5: 8ac3367aafb1cc0a068483c580af8015
+    license: LicenseRef-Public-Domain
+    purls: []
+    size: 122354
+    timestamp: 1728047496079
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xz-5.6.3-h9a6d368_1.conda
+    sha256: 84f9405312032638a7c6249573c8f50423c314c8a4d149b34b720caecc0dc83c
+    md5: 1d79c34d99f1e839a06b4631df091b64
+    depends:
+      - __osx >=11.0
+      - liblzma 5.6.3 h39f12f2_1
+      - liblzma-devel 5.6.3 h39f12f2_1
+      - xz-gpl-tools 5.6.3 h9a6d368_1
+      - xz-tools 5.6.3 h39f12f2_1
+    license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+    purls: []
+    size: 23692
+    timestamp: 1733407556613
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xz-gpl-tools-5.6.3-h9a6d368_1.conda
+    sha256: 98f71ea5d19c9cf4daed3b26a5102862baf8c63210f039e305f283fe399554b0
+    md5: cf05cc17aa7eb2ff843ca5c45d63a324
+    depends:
+      - __osx >=11.0
+      - liblzma 5.6.3 h39f12f2_1
+    license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+    purls: []
+    size: 33402
+    timestamp: 1733407540403
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xz-tools-5.6.3-h39f12f2_1.conda
+    sha256: b785955dd3d5eb1b00e3f1b1fbc3a9bf14276b2c0a950d0735a503d9abea7b5d
+    md5: 0fea5aff7b3a33856288c26326d937f7
+    depends:
+      - __osx >=11.0
+      - liblzma 5.6.3 h39f12f2_1
+    license: 0BSD AND LGPL-2.1-or-later
+    purls: []
+    size: 81028
+    timestamp: 1733407527563

--- a/test-data/conda-lock/v6/python-from-conda-only-lock.yml
+++ b/test-data/conda-lock/v6/python-from-conda-only-lock.yml
@@ -1,0 +1,229 @@
+version: 6
+environments:
+  default:
+    channels:
+      - url: https://prefix.dev/conda-forge/
+    packages:
+      osx-arm64:
+        - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+        - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-devel-5.6.3-h39f12f2_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.47.2-h3f77e49_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.13.0-hbbac1ca_101_cp313.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/python_abi-3.13-5_cp313.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+        - conda: https://prefix.dev/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/xz-5.6.3-h9a6d368_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/xz-gpl-tools-5.6.3-h9a6d368_1.conda
+        - conda: https://prefix.dev/conda-forge/osx-arm64/xz-tools-5.6.3-h39f12f2_1.conda
+packages:
+  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+    sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
+    md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+    depends:
+      - __osx >=11.0
+    license: bzip2-1.0.6
+    license_family: BSD
+    purls: []
+    size: 122909
+    timestamp: 1720974522888
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ca-certificates-2024.12.14-hf0a4a13_0.conda
+    sha256: 256be633fd0882ccc1a7a32bc278547e1703f85082c0789a87a603ee3ab8fb82
+    md5: 7cb381a6783d91902638e4ed1ebd478e
+    license: ISC
+    purls: []
+    size: 157091
+    timestamp: 1734208344343
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.6.4-h286801f_0.conda
+    sha256: e42ab5ace927ee7c84e3f0f7d813671e1cf3529f5f06ee5899606630498c2745
+    md5: 38d2656dd914feb0cab8c629370768bf
+    depends:
+      - __osx >=11.0
+    constrains:
+      - expat 2.6.4.*
+    license: MIT
+    license_family: MIT
+    purls: []
+    size: 64693
+    timestamp: 1730967175868
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+    sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+    md5: 086914b672be056eb70fd4285b6783b6
+    license: MIT
+    license_family: MIT
+    purls: []
+    size: 39020
+    timestamp: 1636488587153
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.6.3-h39f12f2_1.conda
+    sha256: d863b8257406918ffdc50ae65502f2b2d6cede29404d09a094f59509d6a0aaf1
+    md5: b2553114a7f5e20ccd02378a77d836aa
+    depends:
+      - __osx >=11.0
+    license: 0BSD
+    purls: []
+    size: 99129
+    timestamp: 1733407496073
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-devel-5.6.3-h39f12f2_1.conda
+    sha256: c785d43d4758e18153b502c7d7d3a9181f3c95b2ae64a389fe49af5bf3a53f05
+    md5: 692ccac07529215d42c051c6a60bc5a5
+    depends:
+      - __osx >=11.0
+      - liblzma 5.6.3 h39f12f2_1
+    license: 0BSD
+    purls: []
+    size: 113099
+    timestamp: 1733407511832
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
+    sha256: f7917de9117d3a5fe12a39e185c7ce424f8d5010a6f97b4333e8a1dcb2889d16
+    md5: 7476305c35dd9acef48da8f754eedb40
+    depends:
+      - __osx >=11.0
+    license: BSD-2-Clause
+    license_family: BSD
+    purls: []
+    size: 69263
+    timestamp: 1723817629767
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.47.2-h3f77e49_0.conda
+    sha256: f192f3c8973de9ec4c214990715f13b781965247a5cedf9162e7f9e699cfc3c4
+    md5: 122d6f29470f1a991e85608e77e56a8a
+    depends:
+      - __osx >=11.0
+      - libzlib >=1.3.1,<2.0a0
+    license: Unlicense
+    purls: []
+    size: 850553
+    timestamp: 1733762057506
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+    sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+    md5: 369964e85dc26bfe78f41399b366c435
+    depends:
+      - __osx >=11.0
+    constrains:
+      - zlib 1.3.1 *_2
+    license: Zlib
+    license_family: Other
+    purls: []
+    size: 46438
+    timestamp: 1727963202283
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+    sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+    md5: cb2b0ea909b97b3d70cd3921d1445e1a
+    depends:
+      - __osx >=11.0
+    license: X11 AND BSD-3-Clause
+    purls: []
+    size: 802321
+    timestamp: 1724658775723
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.4.0-h81ee809_1.conda
+    sha256: 97772762abc70b3a537683ca9fc3ff3d6099eb64e4aba3b9c99e6fce48422d21
+    md5: 22f971393637480bda8c679f374d8861
+    depends:
+      - __osx >=11.0
+      - ca-certificates
+    license: Apache-2.0
+    license_family: Apache
+    purls: []
+    size: 2936415
+    timestamp: 1736086108693
+  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.13.0-hbbac1ca_101_cp313.conda
+    build_number: 101
+    sha256: 742544a4cf9a10cf2c16d35d96fb696c27d58b9df0cc29fbef5629283aeca941
+    md5: e972e146a1e0cfb1f26da42cb6f6648c
+    depends:
+      - __osx >=11.0
+      - bzip2 >=1.0.8,<2.0a0
+      - libexpat >=2.6.4,<3.0a0
+      - libffi >=3.4,<4.0a0
+      - libmpdec >=4.0.0,<5.0a0
+      - libsqlite >=3.47.0,<4.0a0
+      - libzlib >=1.3.1,<2.0a0
+      - ncurses >=6.5,<7.0a0
+      - openssl >=3.4.0,<4.0a0
+      - python_abi 3.13.* *_cp313
+      - readline >=8.2,<9.0a0
+      - tk >=8.6.13,<8.7.0a0
+      - tzdata
+      - xz >=5.2.6,<6.0a0
+    license: Python-2.0
+    purls: []
+    size: 12806496
+    timestamp: 1732735488999
+  - conda: https://prefix.dev/conda-forge/osx-arm64/python_abi-3.13-5_cp313.conda
+    build_number: 5
+    sha256: 4437198eae80310f40b23ae2f8a9e0a7e5c2b9ae411a8621eb03d87273666199
+    md5: b8e82d0a5c1664638f87f63cc5d241fb
+    constrains:
+      - python 3.13.* *_cp313
+    license: BSD-3-Clause
+    license_family: BSD
+    purls: []
+    size: 6322
+    timestamp: 1723823058879
+  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+    sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+    md5: 8cbb776a2f641b943d413b3e19df71f4
+    depends:
+      - ncurses >=6.3,<7.0a0
+    license: GPL-3.0-only
+    license_family: GPL
+    purls: []
+    size: 250351
+    timestamp: 1679532511311
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+    sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+    md5: b50a57ba89c32b62428b71a875291c9b
+    depends:
+      - libzlib >=1.2.13,<2.0.0a0
+    license: TCL
+    license_family: BSD
+    purls: []
+    size: 3145523
+    timestamp: 1699202432999
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+    sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+    md5: 8ac3367aafb1cc0a068483c580af8015
+    license: LicenseRef-Public-Domain
+    purls: []
+    size: 122354
+    timestamp: 1728047496079
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xz-5.6.3-h9a6d368_1.conda
+    sha256: 84f9405312032638a7c6249573c8f50423c314c8a4d149b34b720caecc0dc83c
+    md5: 1d79c34d99f1e839a06b4631df091b64
+    depends:
+      - __osx >=11.0
+      - liblzma 5.6.3 h39f12f2_1
+      - liblzma-devel 5.6.3 h39f12f2_1
+      - xz-gpl-tools 5.6.3 h9a6d368_1
+      - xz-tools 5.6.3 h39f12f2_1
+    license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+    purls: []
+    size: 23692
+    timestamp: 1733407556613
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xz-gpl-tools-5.6.3-h9a6d368_1.conda
+    sha256: 98f71ea5d19c9cf4daed3b26a5102862baf8c63210f039e305f283fe399554b0
+    md5: cf05cc17aa7eb2ff843ca5c45d63a324
+    depends:
+      - __osx >=11.0
+      - liblzma 5.6.3 h39f12f2_1
+    license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+    purls: []
+    size: 33402
+    timestamp: 1733407540403
+  - conda: https://prefix.dev/conda-forge/osx-arm64/xz-tools-5.6.3-h39f12f2_1.conda
+    sha256: b785955dd3d5eb1b00e3f1b1fbc3a9bf14276b2c0a950d0735a503d9abea7b5d
+    md5: 0fea5aff7b3a33856288c26326d937f7
+    depends:
+      - __osx >=11.0
+      - liblzma 5.6.3 h39f12f2_1
+    license: 0BSD AND LGPL-2.1-or-later
+    purls: []
+    size: 81028
+    timestamp: 1733407527563


### PR DESCRIPTION
### Description
I'm working on improving `pixi`'s implementation of the virtual package requirements.

I was reading the virtual packages from the `depends` field of the package record, which could be parsed as `MatchSpecs`. So I implemented this. But to avoid the huge overhead of parsing **all** dependencies, I later reverted to doing the `starts_with("__")` check again in pixi on the strings. I kept this feature in `rattler_conda_types::MatchSpec` however, as it seems like a useful function.

This PR also allows you to compare `MatchSpecs` with `GenericVirtualPackage`s, which I use to validate the system virtual packages with the `MatchSpecs` of a virtual dependency.

I've also added some small convenience functions to make building the logic on the lockfile a little easier. 



