### PR TITLE
feat: expose ParseConstraintError

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
 expression: evaluated
-snapshot_kind: text
 ---
 blas *.* mkl:
   name: blas
@@ -48,20 +47,20 @@ pytorch=*=cuda*:
     base_url: "https://conda.anaconda.org/conda-forge"
     name: conda-forge
 python ==2.7.*.*|>=3.6:
-  error: "invalid version constraint: regex constraints are not supported"
+  error: regex constraints are not supported
 python=3.9:
   name: python
   version: 3.9.*
 python=*:
-  error: "invalid version constraint: '*' is incompatible with '=' operator'"
+  error: "'*' is incompatible with '=' operator'"
 "https://software.repos.intel.com/python/conda::python[version=3.9]":
-  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
+  error: "missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "https://c.com/p/conda/linux-64::python[version=3.9]":
-  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
+  error: "missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "https://c.com/p/conda::python[version=3.9, subdir=linux-64]":
-  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
+  error: "missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "conda-forge/linux-32::python[version=3.9, subdir=linux-64]":
-  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
+  error: "missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "conda-forge/linux-32::python ==3.9[subdir=linux-64, build_number=\"0\"]":
   name: python
   version: "==3.9"
@@ -101,7 +100,7 @@ rust ~=1.2.3:
     base_url: "file://<CRATE>/relative/channel"
     name: "./relative/channel"
 "python[channel=https://conda.anaconda.org/python/conda,version=3.9]":
-  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
+  error: "missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "channel/win-64::foobar[channel=conda-forge, subdir=linux-64]":
   name: foobar
   channel:
@@ -109,4 +108,4 @@ rust ~=1.2.3:
     name: conda-forge
   subdir: linux-64
 numpy>=2.*.*:
-  error: "invalid version constraint: regex constraints are not supported"
+  error: regex constraints are not supported

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
 expression: evaluated
-snapshot_kind: text
 ---
 2.7|>=3.6:
-  error: "invalid version constraint: missing range specifier for '2.7'. Did you mean '==2.7' or '2.7.*'?"
+  error: "missing range specifier for '2.7'. Did you mean '==2.7' or '2.7.*'?"
 "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2":
   url: "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"
 ~=1.2.3:
@@ -39,15 +38,15 @@ snapshot_kind: text
     op: Gt
     rhs: 6
 "==2.7.*.*|>=3.6":
-  error: "invalid version constraint: regex constraints are not supported"
+  error: regex constraints are not supported
 "3.9":
-  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
+  error: "missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "*":
   version: "*"
 "[version=3.9]":
-  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
+  error: "missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "[version=3.9, subdir=linux-64]":
-  error: "invalid version constraint: missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
+  error: "missing range specifier for '3.9'. Did you mean '==3.9' or '3.9.*'?"
 "==3.9[subdir=linux-64, build_number=\"0\"]":
   version: "==3.9"
   build_number:
@@ -55,4 +54,4 @@ snapshot_kind: text
     rhs: 0
   subdir: linux-64
 ">=2.*.*":
-  error: "invalid version constraint: regex constraints are not supported"
+  error: regex constraints are not supported

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -13,7 +13,7 @@ use std::{
 
 pub(crate) use constraint::is_start_of_version_constraint;
 use constraint::Constraint;
-use parse::ParseConstraintError;
+pub use parse::ParseConstraintError;
 use serde::{Deserialize, Serialize, Serializer};
 use thiserror::Error;
 use version_tree::VersionTree;
@@ -137,14 +137,14 @@ pub enum VersionSpec {
 #[allow(clippy::enum_variant_names, missing_docs)]
 #[derive(Debug, Clone, Eq, PartialEq, Error)]
 pub enum ParseVersionSpecError {
-    #[error("invalid version: {0}")]
-    InvalidVersion(#[source] ParseVersionError),
+    #[error(transparent)]
+    InvalidVersion(#[from] ParseVersionError),
 
-    #[error("invalid version tree: {0}")]
-    InvalidVersionTree(#[source] ParseVersionTreeError),
+    #[error(transparent)]
+    InvalidVersionTree(#[from] ParseVersionTreeError),
 
-    #[error("invalid version constraint: {0}")]
-    InvalidConstraint(#[source] ParseConstraintError),
+    #[error(transparent)]
+    InvalidConstraint(#[from] ParseConstraintError),
 }
 
 impl From<Constraint> for VersionSpec {

--- a/crates/rattler_conda_types/src/version_spec/parse.rs
+++ b/crates/rattler_conda_types/src/version_spec/parse.rs
@@ -55,6 +55,7 @@ fn operator_parser(input: &str) -> IResult<&str, VersionOperators, ParseVersionO
     Ok((rest, op))
 }
 
+#[allow(missing_docs)]
 #[derive(Debug, Clone, Error, Eq, PartialEq)]
 pub enum ParseConstraintError {
     #[error("'*' is incompatible with '{0}' operator'")]

--- a/crates/rattler_conda_types/src/version_spec/snapshots/rattler_conda_types__version_spec__parse__test__exact_strict.snap
+++ b/crates/rattler_conda_types/src/version_spec/snapshots/rattler_conda_types__version_spec__parse__test__exact_strict.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_conda_types/src/version_spec/parse.rs
 expression: "VersionSpec::from_str(\"1.2.3\", Strict).unwrap_err()"
-snapshot_kind: text
 ---
-invalid version constraint: missing range specifier for '1.2.3'. Did you mean '==1.2.3' or '1.2.3.*'?
+missing range specifier for '1.2.3'. Did you mean '==1.2.3' or '1.2.3.*'?


### PR DESCRIPTION
This exposes the `ParseConstraintError` type and removes some nesting of error text because it didnt make it much clearer. I need this so that I can provide a migration path in pixi.