### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.28.12", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.10", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.21.10", default-features = false, features = ["gcs"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.32", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.3.4", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.2.0", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.4", default-features = false }
+rattler = { path="../rattler", version = "0.29.0", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.0", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.22.0", default-features = false, features = ["gcs"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.33", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.3.5", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.0", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.5", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0](https://github.com/conda/rattler/compare/rattler-v0.28.12...rattler-v0.29.0) - 2025-01-23
+
+### Other
+
+- Improve AuthenticationStorage (#1026)
+
 ## [0.28.12](https://github.com/conda/rattler/compare/rattler-v0.28.11...rattler-v0.28.12) - 2025-01-09
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.28.12"
+version = "0.29.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.4", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.10", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.5", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.10", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.15", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.23", default-features = false, features = ["reqwest"] }
+rattler_networking = { path = "../rattler_networking", version = "0.22.0", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.16", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.24", default-features = false, features = ["reqwest"] }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/conda/rattler/compare/rattler_cache-v0.3.4...rattler_cache-v0.3.5) - 2025-01-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.3.4](https://github.com/conda/rattler/compare/rattler_cache-v0.3.3...rattler_cache-v0.3.4) - 2025-01-09
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.4"
+version = "0.3.5"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,10 +18,10 @@ fs-err.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.29.10", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.30.0", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.5", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.21.10", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.23", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_networking = { version = "0.22.0", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.24", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.10...rattler_conda_types-v0.30.0) - 2025-01-23
+
+### Added
+
+- add linux-ppc (PPC32 BE) platform to rattler (#1024)
+
 ## [0.29.10](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.9...rattler_conda_types-v0.29.10) - 2025-01-09
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.29.10"
+version = "0.30.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.8](https://github.com/conda/rattler/compare/rattler_index-v0.20.7...rattler_index-v0.20.8) - 2025-01-23
+
+### Added
+
+- use tempfile and persist for repodata (#1031)
+
 ## [0.20.7](https://github.com/conda/rattler/compare/rattler_index-v0.20.6...rattler_index-v0.20.7) - 2025-01-09
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.20.7"
+version = "0.20.8"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.10", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.5", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.23", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.24", default-features = false }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.40](https://github.com/conda/rattler/compare/rattler_lock-v0.22.39...rattler_lock-v0.22.40) - 2025-01-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.39](https://github.com/conda/rattler/compare/rattler_lock-v0.22.38...rattler_lock-v0.22.39) - 2025-01-09
 
 ### Added

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.39"
+version = "0.22.40"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.10", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
 file_url = { path = "../file_url", version = "0.2.2" }
 pep508_rs = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/conda/rattler/compare/rattler_networking-v0.21.10...rattler_networking-v0.22.0) - 2025-01-23
+
+### Other
+
+- Improve AuthenticationStorage (#1026)
+
 ## [0.21.10](https://github.com/conda/rattler/compare/rattler_networking-v0.21.9...rattler_networking-v0.21.10) - 2025-01-08
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.21.10"
+version = "0.22.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.24](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.23...rattler_package_streaming-v0.22.24) - 2025-01-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.22.23](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.22...rattler_package_streaming-v0.22.23) - 2025-01-09
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.23"
+version = "0.22.24"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,9 +16,9 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.10", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.21.10", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.0", default-features = false }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.33](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.32...rattler_repodata_gateway-v0.21.33) - 2025-01-23
+
+### Other
+
+- Improve AuthenticationStorage (#1026)
+
 ## [0.21.32](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.31...rattler_repodata_gateway-v0.21.32) - 2025-01-09
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.32"
+version = "0.21.33"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -36,9 +36,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.10", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.21.10", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.0", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -55,7 +55,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.4", path = "../rattler_cache" }
+rattler_cache = { version = "0.3.5", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.16](https://github.com/conda/rattler/compare/rattler_shell-v0.22.15...rattler_shell-v0.22.16) - 2025-01-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.15](https://github.com/conda/rattler/compare/rattler_shell-v0.22.14...rattler_shell-v0.22.15) - 2025-01-09
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.15"
+version = "0.22.16"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.10", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.5](https://github.com/conda/rattler/compare/rattler_solve-v1.3.4...rattler_solve-v1.3.5) - 2025-01-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [1.3.4](https://github.com/conda/rattler/compare/rattler_solve-v1.3.3...rattler_solve-v1.3.4) - 2025-01-09
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.3.4"
+version = "1.3.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.29.10", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.2.0...rattler_virtual_packages-v2.0.0) - 2025-01-23
+
+### Added
+
+- align with upcoming virtual package cep (#1028)
+- add linux-ppc (PPC32 BE) platform to rattler (#1024)
+
 ## [1.2.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.1.17...rattler_virtual_packages-v1.2.0) - 2025-01-09
 
 ### Added

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "1.2.0"
+version = "2.0.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.29.10", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler`: 0.28.12 -> 0.29.0 (⚠️ API breaking changes)
* `rattler_conda_types`: 0.29.10 -> 0.30.0 (⚠️ API breaking changes)
* `rattler_networking`: 0.21.10 -> 0.22.0 (⚠️ API breaking changes)
* `rattler_repodata_gateway`: 0.21.32 -> 0.21.33 (✓ API compatible changes)
* `rattler_virtual_packages`: 1.2.0 -> 2.0.0 (⚠️ API breaking changes)
* `rattler_index`: 0.20.7 -> 0.20.8 (✓ API compatible changes)
* `rattler_cache`: 0.3.4 -> 0.3.5
* `rattler_package_streaming`: 0.22.23 -> 0.22.24
* `rattler_shell`: 0.22.15 -> 0.22.16
* `rattler_lock`: 0.22.39 -> 0.22.40
* `rattler_solve`: 1.3.4 -> 1.3.5

### ⚠️ `rattler` breaking changes

```
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type AuthenticationCLIError is no longer UnwindSafe, in /tmp/.tmpva7pia/rattler/crates/rattler/src/cli/auth.rs:54
  type AuthenticationCLIError is no longer RefUnwindSafe, in /tmp/.tmpva7pia/rattler/crates/rattler/src/cli/auth.rs:54

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_added.ron

Failed in:
  variant AuthenticationCLIError:InitializeStorageError in /tmp/.tmpva7pia/rattler/crates/rattler/src/cli/auth.rs:79
```

### ⚠️ `rattler_conda_types` breaking changes

```
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Platform::LinuxS390X 9 -> 10 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:24
  variant Platform::LinuxRiscv32 10 -> 11 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:25
  variant Platform::LinuxRiscv64 11 -> 12 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:26
  variant Platform::Osx64 12 -> 13 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:28
  variant Platform::OsxArm64 13 -> 14 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:29
  variant Platform::Win32 14 -> 15 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:31
  variant Platform::Win64 15 -> 16 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:32
  variant Platform::WinArm64 16 -> 17 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:33
  variant Platform::EmscriptenWasm32 17 -> 18 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:35
  variant Platform::WasiWasm32 18 -> 19 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:36
  variant Platform::ZosZ 19 -> 20 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:38
  variant Arch::S390X 8 -> 9 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:68
  variant Arch::Riscv32 9 -> 10 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:69
  variant Arch::Riscv64 10 -> 11 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:70
  variant Arch::Wasm32 11 -> 12 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:71
  variant Arch::Z 12 -> 13 in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:72

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_added.ron

Failed in:
  variant Arch:Ppc in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:67
  variant Platform:LinuxPpc in /tmp/.tmpva7pia/rattler/crates/rattler_conda_types/src/platform.rs:23
```

### ⚠️ `rattler_networking` breaking changes

```
--- failure enum_tuple_variant_field_missing: pub enum tuple variant's field removed ---

Description:
A field of a tuple variant in a pub enum has been removed.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_tuple_variant_field_missing.ron

Failed in:
  field 1 of variant FileStorageError::FailedToLock, previously in file /tmp/.tmpWRP75R/rattler_networking/src/authentication_storage/backends/file.rs:40

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  AuthenticationMiddleware::new, previously in file /tmp/.tmpWRP75R/rattler_networking/src/authentication_middleware.rs:52
  AuthenticationMiddleware::new, previously in file /tmp/.tmpWRP75R/rattler_networking/src/authentication_middleware.rs:52
  AuthenticationStorage::new, previously in file /tmp/.tmpWRP75R/rattler_networking/src/authentication_storage/storage.rs:47
  AuthenticationStorage::from_env, previously in file /tmp/.tmpWRP75R/rattler_networking/src/authentication_storage/storage.rs:58
  AuthenticationStorage::from_file, previously in file /tmp/.tmpWRP75R/rattler_networking/src/authentication_storage/storage.rs:74
  AuthenticationStorage::new, previously in file /tmp/.tmpWRP75R/rattler_networking/src/authentication_storage/storage.rs:47
  AuthenticationStorage::from_env, previously in file /tmp/.tmpWRP75R/rattler_networking/src/authentication_storage/storage.rs:58
  AuthenticationStorage::from_file, previously in file /tmp/.tmpWRP75R/rattler_networking/src/authentication_storage/storage.rs:74

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rattler_networking::authentication_storage::backends::file::FileStorage::new now takes 0 parameters instead of 1, in /tmp/.tmpva7pia/rattler/crates/rattler_networking/src/authentication_storage/backends/file.rs:82
```

### ⚠️ `rattler_virtual_packages` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VirtualPackageOverrides.win in /tmp/.tmpva7pia/rattler/crates/rattler_virtual_packages/src/lib.rs:309
  field VirtualPackageOverrides.linux in /tmp/.tmpva7pia/rattler/crates/rattler_virtual_packages/src/lib.rs:313
  field VirtualPackageOverrides.archspec in /tmp/.tmpva7pia/rattler/crates/rattler_virtual_packages/src/lib.rs:319

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant VirtualPackage::Win in /tmp/.tmpva7pia/rattler/crates/rattler_virtual_packages/src/lib.rs:148

--- failure struct_with_pub_fields_changed_type: struct with pub fields became an enum or union ---

Description:
A struct with pub fields became an enum or union, breaking accesses to its public fields.
        ref: https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_with_pub_fields_changed_type.ron

Failed in:
  struct rattler_virtual_packages::Archspec became enum in file /tmp/.tmpva7pia/rattler/crates/rattler_virtual_packages/src/lib.rs:506
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`
<blockquote>

## [0.29.0](https://github.com/conda/rattler/compare/rattler-v0.28.12...rattler-v0.29.0) - 2025-01-23

### Other

- Improve AuthenticationStorage (#1026)
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.30.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.10...rattler_conda_types-v0.30.0) - 2025-01-23

### Added

- add linux-ppc (PPC32 BE) platform to rattler (#1024)
</blockquote>

## `rattler_networking`
<blockquote>

## [0.22.0](https://github.com/conda/rattler/compare/rattler_networking-v0.21.10...rattler_networking-v0.22.0) - 2025-01-23

### Other

- Improve AuthenticationStorage (#1026)
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.21.33](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.32...rattler_repodata_gateway-v0.21.33) - 2025-01-23

### Other

- Improve AuthenticationStorage (#1026)
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [2.0.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.2.0...rattler_virtual_packages-v2.0.0) - 2025-01-23

### Added

- align with upcoming virtual package cep (#1028)
- add linux-ppc (PPC32 BE) platform to rattler (#1024)
</blockquote>

## `rattler_index`
<blockquote>

## [0.20.8](https://github.com/conda/rattler/compare/rattler_index-v0.20.7...rattler_index-v0.20.8) - 2025-01-23

### Added

- use tempfile and persist for repodata (#1031)
</blockquote>

## `rattler_cache`
<blockquote>

## [0.3.5](https://github.com/conda/rattler/compare/rattler_cache-v0.3.4...rattler_cache-v0.3.5) - 2025-01-23

### Other

- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.22.24](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.23...rattler_package_streaming-v0.22.24) - 2025-01-23

### Other

- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_shell`
<blockquote>

## [0.22.16](https://github.com/conda/rattler/compare/rattler_shell-v0.22.15...rattler_shell-v0.22.16) - 2025-01-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.40](https://github.com/conda/rattler/compare/rattler_lock-v0.22.39...rattler_lock-v0.22.40) - 2025-01-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_solve`
<blockquote>

## [1.3.5](https://github.com/conda/rattler/compare/rattler_solve-v1.3.4...rattler_solve-v1.3.5) - 2025-01-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).