### PR TITLE
feat: align with upcoming virtual package cep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,5 +159,6 @@ url = { version = "2.5.4" }
 uuid = { version = "1.11.0", default-features = false }
 walkdir = "2.5.0"
 windows-sys = { version = "0.59.0", default-features = false }
+winver = { version = "1.0.0" }
 zip = { version = "2.2.2", default-features = false }
 zstd = { version = "0.13.2", default-features = false }

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -23,3 +23,6 @@ archspec = { workspace = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
 plist = { workspace = true }
+
+[target.'cfg(target_os="windows")'.dependencies]
+winver = { workspace = true }

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -770,7 +770,8 @@ mod test {
 
     #[test]
     fn doesnt_crash() {
-        let virtual_packages = VirtualPackages::detect(&VirtualPackageOverrides::default()).unwrap();
+        let virtual_packages =
+            VirtualPackages::detect(&VirtualPackageOverrides::default()).unwrap();
         println!("{virtual_packages:#?}");
     }
     #[test]

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -766,12 +766,12 @@ mod test {
 
     use rattler_conda_types::Version;
 
-    use crate::{Cuda, EnvOverride, LibC, Osx, Override, VirtualPackage, VirtualPackageOverrides};
+    use super::*;
 
     #[test]
     fn doesnt_crash() {
-        let virtual_packages = VirtualPackage::detect(&VirtualPackageOverrides::default()).unwrap();
-        println!("{virtual_packages:?}");
+        let virtual_packages = VirtualPackages::detect(&VirtualPackageOverrides::default()).unwrap();
+        println!("{virtual_packages:#?}");
     }
     #[test]
     fn parse_libc() {

--- a/crates/rattler_virtual_packages/src/linux.rs
+++ b/crates/rattler_virtual_packages/src/linux.rs
@@ -1,4 +1,4 @@
-//! Low-level functions to dect the linux version on the system. See [`linux_version`].
+//! Low-level functions to detect the linux version on the system. See [`linux_version`].
 
 use once_cell::sync::OnceCell;
 use rattler_conda_types::{ParseVersionError, Version};
@@ -122,7 +122,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
     pub fn doesnt_crash() {
         let version = super::try_detect_linux_version();
         println!("Linux {version:?}");

--- a/crates/rattler_virtual_packages/src/win.rs
+++ b/crates/rattler_virtual_packages/src/win.rs
@@ -1,5 +1,5 @@
 //! Low-level functions to detect the Windows version on the system. See
-//! [`crate::windows::windows_version`].
+//! [`windows_version`].
 
 use once_cell::sync::OnceCell;
 use rattler_conda_types::Version;

--- a/crates/rattler_virtual_packages/src/win.rs
+++ b/crates/rattler_virtual_packages/src/win.rs
@@ -1,0 +1,45 @@
+//! Low-level functions to detect the Windows version on the system. See
+//! [`crate::windows::windows_version`].
+
+use std::str::FromStr;
+
+use once_cell::sync::OnceCell;
+use rattler_conda_types::Version;
+use winver::WindowsVersion;
+
+/// Returns the Windows version of the current platform.
+///
+/// Returns an error if determining the Windows version resulted in an error.
+/// Returns `None` if the Windows version could not be determined. Note that
+/// this does not mean the current platform is not Windows.
+///
+/// Detection of the Windows version is implemented using the [`winver`] crate.
+pub fn windows_version() -> Option<Version> {
+    static DETECTED_WINDOWS_VERSION: OnceCell<Option<Version>> = OnceCell::new();
+    DETECTED_WINDOWS_VERSION
+        .get_or_init(detect_windows_version)
+        .clone()
+}
+
+#[cfg(target_os = "windows")]
+fn detect_windows_version() -> Option<Version> {
+    let windows_version = WindowsVersion::detect()?;
+    Some(
+        Version::from_str(&windows_version.to_string())
+            .expect("WindowsVersion::to_string() should always return a valid version"),
+    )
+}
+
+#[cfg(not(target_os = "windows"))]
+const fn detect_windows_version() -> Option<Version> {
+    None
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    pub fn doesnt_crash() {
+        let version = super::detect_windows_version();
+        println!("Windows {version:?}");
+    }
+}

--- a/crates/rattler_virtual_packages/src/win.rs
+++ b/crates/rattler_virtual_packages/src/win.rs
@@ -9,8 +9,6 @@ use rattler_conda_types::Version;
 /// Returns an error if determining the Windows version resulted in an error.
 /// Returns `None` if the Windows version could not be determined. Note that
 /// this does not mean the current platform is not Windows.
-///
-/// Detection of the Windows version is implemented using the [`winver`] crate.
 pub fn windows_version() -> Option<Version> {
     static DETECTED_WINDOWS_VERSION: OnceCell<Option<Version>> = OnceCell::new();
     DETECTED_WINDOWS_VERSION

--- a/crates/rattler_virtual_packages/src/win.rs
+++ b/crates/rattler_virtual_packages/src/win.rs
@@ -1,11 +1,8 @@
 //! Low-level functions to detect the Windows version on the system. See
 //! [`crate::windows::windows_version`].
 
-use std::str::FromStr;
-
 use once_cell::sync::OnceCell;
 use rattler_conda_types::Version;
-use winver::WindowsVersion;
 
 /// Returns the Windows version of the current platform.
 ///
@@ -23,9 +20,9 @@ pub fn windows_version() -> Option<Version> {
 
 #[cfg(target_os = "windows")]
 fn detect_windows_version() -> Option<Version> {
-    let windows_version = WindowsVersion::detect()?;
+    let windows_version = winver::WindowsVersion::detect()?;
     Some(
-        Version::from_str(&windows_version.to_string())
+        std::str::FromStr::from_str(&windows_version.to_string())
             .expect("WindowsVersion::to_string() should always return a valid version"),
     )
 }


### PR DESCRIPTION
This PR aligns our virtual package implementation with the upcoming [virtual package cep](https://github.com/conda/ceps/pull/103). I think most of the changes proposed in the CEP make a lot of sense so I feel we can already merge this PR before the CEP is accepted. 

In particular, I made the following changes:

* `__win` now also reports the version of Windows.
* `__win` can be overridden with `CONDA_OVERRIDE_WIN`
* `__linux` can be overridden with `CONDA_OVERRIDE_LINUX`
* `__archspec` can be overriden with `CONDA_OVERRIDE_ARCHSPEC`
* `__archspec` falls back to deriving the archspec from the platform if it could not be determined.
* `__archspec` is added as `__archspec=1=0` if the no archspec could be determined for the current platform.

Changes I explicitly did not make (also left a question in the CEP):

* `osx-arm64` should fall back to `arm64` archspec but we use `m1` instead.
* `win-arm64` should fall back to `arm64` archspec but we use `aarch64` instead.

I left this in because `arm64` is not an existing archspec and `m1` and `aarch64` are the base microarchitectures for `osx-arm64` and `win-arm64` respectively. I think this will yield better defaults.

I also added a `VirtualPackages` struct that contains all the virtual package implementations and provides handy utilities to convert it to a list of `VirtualPackage` or a list of `GenericVirtualPackage`. Detection of virtual packages is now also handled by this struct.

Tagging @jaimergp so he is aware of this!