### PR TITLE
feat: Expose FetchRepoDataOptions to py-rattler

### DIFF
--- a/py-rattler/rattler/networking/__init__.py
+++ b/py-rattler/rattler/networking/__init__.py
@@ -1,5 +1,13 @@
 from rattler.networking.client import Client
 from rattler.networking.middleware import MirrorMiddleware, AuthenticationMiddleware, GCSMiddleware
-from rattler.networking.fetch_repo_data import fetch_repo_data
+from rattler.networking.fetch_repo_data import fetch_repo_data, CacheAction, FetchRepoDataOptions
 
-__all__ = ["fetch_repo_data", "Client", "MirrorMiddleware", "AuthenticationMiddleware", "GCSMiddleware"]
+__all__ = [
+    "fetch_repo_data",
+    "CacheAction",
+    "FetchRepoDataOptions",
+    "Client",
+    "MirrorMiddleware",
+    "AuthenticationMiddleware",
+    "GCSMiddleware",
+]

--- a/py-rattler/rattler/networking/fetch_repo_data.py
+++ b/py-rattler/rattler/networking/fetch_repo_data.py
@@ -1,15 +1,68 @@
 from __future__ import annotations
-from typing import Callable, List, Optional, Union, TYPE_CHECKING
-
+from dataclasses import dataclass
+from typing import Callable, List, Literal, Optional, Union, TYPE_CHECKING
 
 from rattler.networking.client import Client
-from rattler.rattler import py_fetch_repo_data
+from rattler.rattler import py_fetch_repo_data, PyFetchRepoDataOptions
 from rattler.repo_data.sparse import SparseRepoData
 
 if TYPE_CHECKING:
     import os
     from rattler.channel import Channel
     from rattler.platform import Platform
+
+
+CacheAction = Literal["cache-or-fetch", "use-cache-only", "force-cache-only", "no-cache"]
+Variant = Literal["after-patches", "from-packages", "current"]
+
+
+@dataclass
+class FetchRepoDataOptions:
+    cache_action: CacheAction = "cache-or-fetch"
+    """How to interact with the cache.
+
+    * `'cache-or-fetch'` (default): Use the cache if its up to date or fetch from the URL if there is no valid cached value.
+    * `'use-cache-only'`: Only use the cache, but error out if the cache is not up to date
+    * `'force-cache-only'`: Only use the cache, ignore whether or not it is up to date.
+    * `'no-cache'`: Do not use the cache even if there is an up to date entry
+    """
+
+    variant: Variant = "after-patches"
+    """Which type of repodata to download
+
+    * `'after-patches'` (default): Fetch the `repodata.json` file. This `repodata.json` has repodata patches applied.
+    * `'from-packages'` Fetch the `repodata_from_packages.json` file
+    * `'current'`: Fetch `current_repodata.json` file. This file contains only the latest version of each package.
+    """
+
+    jlap_enabled: bool = True
+    """Whether the JLAP compression is enabled or not."""
+
+    zstd_enabled: bool = True
+    """Whether the ZSTD compression is enabled or not."""
+
+    bz2_enabled: bool = True
+    """Whether the BZ2 compression is enabled or not."""
+
+    def _into_py(self) -> PyFetchRepoDataOptions:
+        """
+        Converts this object into a type that can be used by the Rust code.
+
+        Examples
+        --------
+        ```python
+        >>> FetchRepoDataOptions()._into_py() # doctest: +ELLIPSIS
+        <builtins.PyFetchRepoDataOptions object at 0x...>
+        >>>
+        ```
+        """
+        return PyFetchRepoDataOptions(
+            cache_action=self.cache_action,
+            variant=self.variant,
+            jlap_enabled=self.jlap_enabled,
+            zstd_enabled=self.zstd_enabled,
+            bz2_enabled=self.bz2_enabled,
+        )
 
 
 async def fetch_repo_data(
@@ -19,6 +72,7 @@ async def fetch_repo_data(
     cache_path: Union[str, os.PathLike[str]],
     callback: Optional[Callable[[int, int], None]],
     client: Optional[Client] = None,
+    fetch_options: Optional[FetchRepoDataOptions] = None,
 ) -> List[SparseRepoData]:
     """
     Returns a list of RepoData for given channels and platform.
@@ -36,12 +90,14 @@ async def fetch_repo_data(
     Returns:
         A list of `SparseRepoData` for requested channels and platforms.
     """
+    fetch_options = fetch_options or FetchRepoDataOptions()
     repo_data_list = await py_fetch_repo_data(
         [channel._channel for channel in channels],
         [platform._inner for platform in platforms],
         cache_path,
         callback,
         client,
+        fetch_options._into_py(),
     )
 
     return [SparseRepoData._from_py_sparse_repo_data(repo_data) for repo_data in repo_data_list]

--- a/py-rattler/rattler/repo_data/gateway.py
+++ b/py-rattler/rattler/repo_data/gateway.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
 import os
-from typing import Optional, List, Literal
+from typing import Optional, List
 from dataclasses import dataclass
 
 from rattler.rattler import PyGateway, PySourceConfig, PyMatchSpec
 
 from rattler.channel import Channel
 from rattler.match_spec import MatchSpec
-from rattler.networking import Client
+from rattler.networking import Client, CacheAction
 from rattler.repo_data.record import RepoDataRecord
 from rattler.platform import Platform, PlatformLiteral
 from rattler.package.package_name import PackageName
-
-CacheAction = Literal["cache-or-fetch", "use-cache-only", "force-cache-only", "no-cache"]
 
 
 @dataclass

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -63,7 +63,7 @@ use prefix_paths::{PyPrefixPathType, PyPrefixPaths, PyPrefixPathsEntry};
 use pyo3::prelude::*;
 use record::PyRecord;
 use repo_data::{
-    gateway::{PyGateway, PySourceConfig},
+    gateway::{PyFetchRepoDataOptions, PyGateway, PySourceConfig},
     patch_instructions::PyPatchInstructions,
     sparse::PySparseRepoData,
     PyRepoData,
@@ -120,6 +120,7 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_class::<PyPatchInstructions>()?;
     m.add_class::<PyGateway>()?;
     m.add_class::<PySourceConfig>()?;
+    m.add_class::<PyFetchRepoDataOptions>()?;
 
     m.add_class::<PyRecord>()?;
 

--- a/py-rattler/tests/unit/test_fetch_repo_data.py
+++ b/py-rattler/tests/unit/test_fetch_repo_data.py
@@ -55,6 +55,7 @@ async def test_fetch_repo_data(
         platforms=[plat],
         cache_path=cache_dir,
         callback=None,
+        fetch_options=None,
     )
     assert isinstance(result, list)
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I sometimes run into zstd decoding errors when trying to fetch repodata and was wanting to be able to disable zstd from py-rattler.  This PR exposes the FetchRepoDataOptions struct in rust to python.

I originally had the python class in `gateway.py` but that was causing a circular import when trying to import it in `fetch_repo_data.py` so I moved it.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
