### PR TITLE
fix: add track-features conda type

### DIFF
--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -2,9 +2,9 @@ use std::path::Path;
 
 use rattler_macros::sorted;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, skip_serializing_none, OneOrMany};
+use serde_with::{serde_as, skip_serializing_none};
 
-use super::PackageFile;
+use super::{PackageFile, TrackFeatures};
 use crate::{NoArchType, PackageName, VersionWithSource};
 
 /// A representation of the `index.json` file found in package archives.
@@ -74,9 +74,8 @@ pub struct IndexJson {
     /// them less priority). To that effect, the number of track features is
     /// counted (number of commas) and the package is downweighted
     /// by the number of track_features.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[serde_as(as = "OneOrMany<_>")]
-    pub track_features: Vec<String>,
+    #[serde(default, skip_serializing_if = "TrackFeatures::is_empty")]
+    pub track_features: TrackFeatures,
 
     /// The version of the package
     pub version: VersionWithSource,

--- a/crates/rattler_conda_types/src/package/mod.rs
+++ b/crates/rattler_conda_types/src/package/mod.rs
@@ -13,6 +13,7 @@ mod no_softlink;
 mod package_metadata;
 mod paths;
 mod run_exports;
+mod track_features;
 
 use std::io::Read;
 use std::path::Path;
@@ -31,6 +32,7 @@ pub use {
     package_metadata::PackageMetadata,
     paths::{FileMode, PathType, PathsEntry, PathsJson, PrefixPlaceholder},
     run_exports::RunExportsJson,
+    track_features::TrackFeatures,
 };
 
 /// A trait implemented for structs that represent specific files in a Conda archive.

--- a/crates/rattler_conda_types/src/package/track_features.rs
+++ b/crates/rattler_conda_types/src/package/track_features.rs
@@ -1,0 +1,56 @@
+//! Track features wrapper type
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+use std::fmt;
+use std::str::FromStr;
+
+/// Wrapper type for track features
+#[derive(SerializeDisplay, DeserializeFromStr, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TrackFeatures(Vec<String>);
+
+impl fmt::Display for TrackFeatures {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.join(","))
+    }
+}
+
+impl FromStr for TrackFeatures {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            Ok(TrackFeatures(Vec::new()))
+        } else {
+            Ok(TrackFeatures(
+                s.split(',').map(|s| s.trim().to_string()).collect(),
+            ))
+        }
+    }
+}
+
+impl Default for TrackFeatures {
+    fn default() -> Self {
+        TrackFeatures(Vec::new())
+    }
+}
+
+impl TrackFeatures {
+    /// Return true if the track features are empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Return the track features
+    pub fn features(&self) -> &[String] {
+        &self.0
+    }
+
+    /// Return the number of track features
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Create a new track features from a list of features
+    pub fn from_features(features: &[String]) -> Self {
+        TrackFeatures(features.to_vec())
+    }
+}

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -21,7 +21,7 @@ use url::Url;
 
 use crate::{
     build_spec::BuildNumber,
-    package::{IndexJson, RunExportsJson},
+    package::{IndexJson, RunExportsJson, TrackFeatures},
     utils::{
         serde::{sort_map_alphabetically, DeserializeFromStrUnchecked},
         UrlWithTrailingSlash,
@@ -194,9 +194,8 @@ pub struct PackageRecord {
     /// them less priority). To that effect, the number of track features is
     /// counted (number of commas) and the package is downweighted
     /// by the number of track_features.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[serde_as(as = "OneOrMany<_>")]
-    pub track_features: Vec<String>,
+    #[serde(default, skip_serializing_if = "TrackFeatures::is_empty")]
+    pub track_features: TrackFeatures,
 
     /// The version of the package
     pub version: VersionWithSource,
@@ -333,7 +332,7 @@ impl PackageRecord {
             size: None,
             subdir: Platform::current().to_string(),
             timestamp: None,
-            track_features: vec![],
+            track_features: TrackFeatures::default(),
             version: version.into(),
             purls: None,
             run_exports: None,

--- a/crates/rattler_conda_types/src/repo_data/patches.rs
+++ b/crates/rattler_conda_types/src/repo_data/patches.rs
@@ -2,12 +2,15 @@
 
 use fxhash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, skip_serializing_none, OneOrMany};
+use serde_with::{serde_as, skip_serializing_none};
 use std::collections::BTreeSet;
 use std::io;
 use std::path::Path;
 
-use crate::{package::ArchiveType, PackageRecord, PackageUrl, RepoData, Shard};
+use crate::{
+    package::{ArchiveType, TrackFeatures},
+    PackageRecord, PackageUrl, RepoData, Shard,
+};
 
 /// Represents a Conda repodata patch.
 ///
@@ -67,8 +70,7 @@ pub struct PackageRecordPatch {
     /// Track features are nowadays only used to downweight packages (ie. give them less priority). To
     /// that effect, the number of track features is counted (number of commas) and the package is downweighted
     /// by the number of track_features.
-    #[serde_as(as = "Option<OneOrMany<_>>")]
-    pub track_features: Option<Vec<String>>,
+    pub track_features: Option<TrackFeatures>,
 
     /// Features are a deprecated way to specify different feature sets for the conda solver. This is not
     /// supported anymore and should not be used. Instead, `mutex` packages should be used to specify

--- a/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
@@ -1,7 +1,8 @@
 use std::{borrow::Cow, collections::BTreeSet};
 
 use rattler_conda_types::{
-    BuildNumber, ChannelUrl, NoArchType, PackageName, PackageRecord, PackageUrl, VersionWithSource,
+    package::TrackFeatures, BuildNumber, ChannelUrl, NoArchType, PackageName, PackageRecord,
+    PackageUrl, VersionWithSource,
 };
 use rattler_digest::{serde::SerializableHash, Md5Hash, Sha256Hash};
 use serde::{Deserialize, Serialize};
@@ -131,7 +132,7 @@ impl<'a> From<CondaPackageDataModel<'a>> for CondaPackageData {
                 size: value.size.into_owned(),
                 subdir,
                 timestamp: value.timestamp,
-                track_features: value.track_features.into_owned(),
+                track_features: TrackFeatures::from_features(&value.track_features),
                 version: value.version.into_owned(),
                 run_exports: None,
                 // Polyfill the arch and platform fields if they are not present in the lock-file.

--- a/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use rattler_conda_types::{
-    package::ArchiveIdentifier, BuildNumber, ChannelUrl, NoArchType, PackageName, PackageRecord,
-    PackageUrl, VersionWithSource,
+    package::{ArchiveIdentifier, TrackFeatures},
+    BuildNumber, ChannelUrl, NoArchType, PackageName, PackageRecord, PackageUrl, VersionWithSource,
 };
 use rattler_digest::{serde::SerializableHash, Md5Hash, Sha256Hash};
 use serde::{Deserialize, Serialize};
@@ -182,7 +182,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaPackageData {
             size: value.size.into_owned(),
             subdir,
             timestamp: value.timestamp,
-            track_features: value.track_features.into_owned(),
+            track_features: TrackFeatures::from_features(&value.track_features),
             version: value
                 .version
                 .map(Cow::into_owned)
@@ -289,7 +289,7 @@ impl<'a> From<&'a CondaPackageData> for CondaPackageDataModel<'a> {
             legacy_bz2_size: Cow::Borrowed(&package_record.legacy_bz2_size),
             timestamp: package_record.timestamp,
             features: Cow::Borrowed(&package_record.features),
-            track_features: Cow::Borrowed(&package_record.track_features),
+            track_features: Cow::Owned(package_record.track_features.features().to_vec()),
             license: Cow::Borrowed(&package_record.license),
             license_family: Cow::Borrowed(&package_record.license_family),
             python_site_packages_path: Cow::Borrowed(&package_record.python_site_packages_path),

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -7,10 +7,11 @@ use indexmap::IndexSet;
 use pep440_rs::VersionSpecifiers;
 use pep508_rs::{ExtraName, Requirement};
 use rattler_conda_types::{
-    NoArchType, PackageName, PackageRecord, PackageUrl, Platform, VersionWithSource,
+    package::TrackFeatures, NoArchType, PackageName, PackageRecord, PackageUrl, Platform,
+    VersionWithSource,
 };
 use serde::Deserialize;
-use serde_with::{serde_as, skip_serializing_none, OneOrMany};
+use serde_with::{serde_as, skip_serializing_none};
 use url::Url;
 
 use super::ParseCondaLockError;
@@ -111,9 +112,8 @@ pub struct CondaLockedPackageV3 {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub constrains: Vec<String>,
     pub features: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    #[serde_as(as = "OneOrMany<_>")]
-    pub track_features: Vec<String>,
+    #[serde(default, skip_serializing_if = "TrackFeatures::is_empty")]
+    pub track_features: TrackFeatures,
     pub license: Option<String>,
     pub license_family: Option<String>,
     pub noarch: Option<NoArchType>,

--- a/crates/rattler_solve/src/libsolv_c/input.rs
+++ b/crates/rattler_solve/src/libsolv_c/input.rs
@@ -139,7 +139,7 @@ pub fn add_repodata_records<'a>(
         }
 
         // Track features
-        for track_features in record.track_features.iter() {
+        for track_features in record.track_features.features() {
             let track_feature = track_features.trim();
             if !track_feature.is_empty() {
                 data.add_idarray(

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -154,7 +154,7 @@ impl<'a> SolverPackageRecord<'a> {
         const EMPTY: [String; 0] = [];
         match self {
             SolverPackageRecord::Record(rec) | SolverPackageRecord::RecordWithFeature(rec, _) => {
-                &rec.package_record.track_features
+                &rec.package_record.track_features.features()
             }
             SolverPackageRecord::VirtualPackage(_rec) => &EMPTY,
         }


### PR DESCRIPTION
This adds a new `TrackFeatures` wrapper type.

Track features need to be serialized as a comma delimited string.

This still needs tests!