### PR TITLE
feat: implement `flags`

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -138,6 +138,8 @@ pub struct MatchSpec {
     pub file_name: Option<String>,
     /// The selected optional features of the package
     pub extras: Option<Vec<String>>,
+    /// The selected build flags
+    pub flags: Option<Vec<String>>,
     /// The channel of the package
     pub channel: Option<Arc<Channel>>,
     /// The subdir of the channel
@@ -190,6 +192,10 @@ impl Display for MatchSpec {
             keys.push(format!("extras=[{}]", extras.iter().format(", ")));
         }
 
+        if let Some(flags) = &self.flags {
+            keys.push(format!("flags=[{}]", flags.iter().format(", ")));
+        }
+
         if let Some(md5) = &self.md5 {
             keys.push(format!("md5=\"{md5:x}\""));
         }
@@ -229,6 +235,7 @@ impl MatchSpec {
                 build_number: self.build_number,
                 file_name: self.file_name,
                 extras: self.extras,
+                flags: self.flags,
                 channel: self.channel,
                 subdir: self.subdir,
                 namespace: self.namespace,
@@ -275,6 +282,8 @@ pub struct NamelessMatchSpec {
     pub file_name: Option<String>,
     /// Optional extra dependencies to select for the package
     pub extras: Option<Vec<String>>,
+    /// Optional build time flags to select for the package
+    pub flags: Option<Vec<String>>,
     /// The channel of the package
     #[serde(deserialize_with = "deserialize_channel", default)]
     pub channel: Option<Arc<Channel>>,
@@ -329,6 +338,7 @@ impl From<MatchSpec> for NamelessMatchSpec {
             build_number: spec.build_number,
             file_name: spec.file_name,
             extras: spec.extras,
+            flags: spec.flags,
             channel: spec.channel,
             subdir: spec.subdir,
             namespace: spec.namespace,
@@ -349,6 +359,7 @@ impl MatchSpec {
             build_number: spec.build_number,
             file_name: spec.file_name,
             extras: spec.extras,
+            flags: spec.flags,
             channel: spec.channel,
             subdir: spec.subdir,
             namespace: spec.namespace,
@@ -418,6 +429,12 @@ impl Matches<PackageRecord> for NamelessMatchSpec {
 
         if let Some(sha256_spec) = self.sha256.as_ref() {
             if Some(sha256_spec) != other.sha256.as_ref() {
+                return false;
+            }
+        }
+
+        if let Some(flags) = self.flags.as_ref() {
+            if !flags.iter().all(|flag| other.flags.contains(flag)) {
                 return false;
             }
         }

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -125,6 +125,11 @@ pub struct PackageRecord {
     /// mutually exclusive features.
     pub features: Option<String>,
 
+    /// Flags are a way to define build-time features. This has been traditionally
+    /// done by changing the build string, but flags are much nicer.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub flags: BTreeSet<String>,
+
     /// A deprecated md5 hash
     #[serde_as(as = "Option<SerializableHash::<rattler_digest::Md5>>")]
     pub legacy_bz2_md5: Option<Md5Hash>,
@@ -329,6 +334,7 @@ impl PackageRecord {
             platform: None,
             python_site_packages_path: None,
             extra_depends: BTreeMap::new(),
+            flags: BTreeSet::new(),
             sha256: None,
             size: None,
             subdir: Platform::current().to_string(),
@@ -518,6 +524,7 @@ impl PackageRecord {
             platform: index.platform,
             python_site_packages_path: index.python_site_packages_path,
             extra_depends: BTreeMap::new(),
+            flags: BTreeSet::new(),
             sha256,
             size,
             subdir,

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -9,7 +9,7 @@ use rattler_conda_types::{
 };
 use rattler_package_streaming::{read, seek};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ffi::OsStr,
     io::{Read, Write},
     path::{Path, PathBuf},
@@ -40,7 +40,8 @@ pub fn package_record_from_index_json<T: Read>(
         arch: index.arch,
         platform: index.platform,
         depends: index.depends,
-        extra_depends: std::collections::BTreeMap::new(),
+        extra_depends: BTreeMap::new(),
+        flags: BTreeSet::new(),
         constrains: index.constrains,
         track_features: index.track_features,
         features: index.features,

--- a/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, collections::BTreeSet};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+};
 
 use rattler_conda_types::{
     BuildNumber, ChannelUrl, NoArchType, PackageName, PackageRecord, PackageUrl, VersionWithSource,
@@ -117,7 +120,8 @@ impl<'a> From<CondaPackageDataModel<'a>> for CondaPackageData {
                 build_number: value.build_number,
                 constrains: value.constrains.into_owned(),
                 depends: value.depends.into_owned(),
-                extra_depends: std::collections::BTreeMap::new(),
+                extra_depends: BTreeMap::new(),
+                flags: BTreeSet::new(),
                 features: value.features.into_owned(),
                 legacy_bz2_md5: value.legacy_bz2_md5,
                 legacy_bz2_size: value.legacy_bz2_size.into_owned(),

--- a/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
@@ -78,6 +78,8 @@ pub(crate) struct CondaPackageDataModel<'a> {
     pub constrains: Cow<'a, Vec<String>>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra_depends: Cow<'a, BTreeMap<String, Vec<String>>>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub flags: Cow<'a, BTreeSet<String>>,
 
     // Additional properties (in semi alphabetic order but grouped by commonality)
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -163,6 +165,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaPackageData {
             constrains: value.constrains.into_owned(),
             depends: value.depends.into_owned(),
             extra_depends: value.extra_depends.into_owned(),
+            flags: value.flags.into_owned(),
             features: value.features.into_owned(),
             legacy_bz2_md5: value.legacy_bz2_md5,
             legacy_bz2_size: value.legacy_bz2_size.into_owned(),
@@ -280,6 +283,7 @@ impl<'a> From<&'a CondaPackageData> for CondaPackageDataModel<'a> {
             depends: Cow::Borrowed(&package_record.depends),
             constrains: Cow::Borrowed(&package_record.constrains),
             extra_depends: Cow::Borrowed(&package_record.extra_depends),
+            flags: Cow::Borrowed(&package_record.flags),
             arch: (package_record.arch != arch).then_some(Cow::Owned(arch)),
             platform: (package_record.platform != platform).then_some(Cow::Owned(platform)),
             md5: package_record.md5,

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -1,6 +1,11 @@
 //! A module that enables parsing of lock files version 3 or lower.
 
-use std::{collections::BTreeSet, ops::Not, str::FromStr, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Not,
+    str::FromStr,
+    sync::Arc,
+};
 
 use fxhash::FxHashMap;
 use indexmap::IndexSet;
@@ -202,7 +207,8 @@ pub fn parse_v3_or_lower(
                             build_number,
                             constrains: value.constrains,
                             depends: value.dependencies,
-                            extra_depends: std::collections::BTreeMap::new(),
+                            extra_depends: BTreeMap::new(),
+                            flags: BTreeSet::new(),
                             features: value.features,
                             legacy_bz2_md5: None,
                             legacy_bz2_size: None,

--- a/crates/rattler_solve/src/resolvo/conda_sorting.rs
+++ b/crates/rattler_solve/src/resolvo/conda_sorting.rs
@@ -93,6 +93,13 @@ impl<'a, 'repo> SolvableSorter<'a, 'repo> {
             _ => {}
         };
 
+        // The one with more _flags_ is sorted lower
+        match a_record.flags_len().cmp(&b_record.flags_len()) {
+            Ordering::Greater => return Ordering::Less,
+            Ordering::Less => return Ordering::Greater,
+            Ordering::Equal => {}
+        }
+
         // Otherwise, select the variant with the highest version
         match (self.strategy, a_record.version().cmp(b_record.version())) {
             (CompareStrategy::Default, Ordering::Greater)

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -150,6 +150,15 @@ impl<'a> SolverPackageRecord<'a> {
         }
     }
 
+    fn flags_len(&self) -> usize {
+        match self {
+            SolverPackageRecord::Record(rec) | SolverPackageRecord::RecordWithFeature(rec, _) => {
+                rec.package_record.flags.len()
+            }
+            SolverPackageRecord::VirtualPackage(_rec) => 0,
+        }
+    }
+
     fn track_features(&self) -> &[String] {
         const EMPTY: [String; 0] = [];
         match self {


### PR DESCRIPTION
This is a new idea for Conda packages.

I imaging that for compiled packages, having flags can be quite useful. For example, a library like libarchive can be built with support for a number of different compression algorithms. It would be nice if we could express these variants with a more natural syntax vs. relying on globs on the build string. For example, for libarchive it would be nice to be able to say libarchive[flags=[zstd, bz2, zlib]] to denote the minimum enabled flags. 

For pixi build we already discussed we might want to have release and debug flags which we could express in a similar way. We might also want to be able to negate flags (e.g. libarchive[flags=[~zstd]].

Different from extras, flags would select a different variant of the package (ie. completely different repodata record). This different package might also have different requirements (for example, if zstd is enabled, the zstd package will be a dependency of libarchive).

Conceptually, this is similar to matching packages based on their build string, but just a much better syntax vs trying to do that with globs.
