### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.29.0", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.0", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.22.0", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.33", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.3.5", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.0", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.5", default-features = false }
+rattler = { path="../rattler", version = "0.30.0", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.1", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.22.1", default-features = false, features = ["gcs", "s3"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.34", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.3.6", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.1", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.6", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0](https://github.com/conda/rattler/compare/rattler-v0.29.0...rattler-v0.30.0) - 2025-02-03
+
+### Added
+
+- add S3 support (#1008)
+
 ## [0.29.0](https://github.com/conda/rattler/compare/rattler-v0.28.12...rattler-v0.29.0) - 2025-01-23
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.29.0"
+version = "0.30.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.5", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.6", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.0", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.16", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.24", default-features = false, features = ["reqwest"] }
+rattler_networking = { path = "../rattler_networking", version = "0.22.1", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.17", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.25", default-features = false, features = ["reqwest"] }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/conda/rattler/compare/rattler_cache-v0.3.5...rattler_cache-v0.3.6) - 2025-02-03
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.3.5](https://github.com/conda/rattler/compare/rattler_cache-v0.3.4...rattler_cache-v0.3.5) - 2025-01-23
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.5"
+version = "0.3.6"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,10 +18,10 @@ fs-err.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.30.0", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.30.1", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.5", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.22.0", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.24", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_networking = { version = "0.22.1", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.25", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.30.0...rattler_conda_types-v0.30.1) - 2025-02-03
+
+### Fixed
+
+- track feature serialization and deserialization (#1039)
+
 ## [0.30.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.29.10...rattler_conda_types-v0.30.0) - 2025-01-23
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.30.0"
+version = "0.30.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.9](https://github.com/conda/rattler/compare/rattler_index-v0.20.8...rattler_index-v0.20.9) - 2025-02-03
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.20.8](https://github.com/conda/rattler/compare/rattler_index-v0.20.7...rattler_index-v0.20.8) - 2025-01-23
 
 ### Added

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.20.8"
+version = "0.20.9"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.5", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.24", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.25", default-features = false }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.41](https://github.com/conda/rattler/compare/rattler_lock-v0.22.40...rattler_lock-v0.22.41) - 2025-02-03
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.40](https://github.com/conda/rattler/compare/rattler_lock-v0.22.39...rattler_lock-v0.22.40) - 2025-01-23
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.40"
+version = "0.22.41"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
 file_url = { path = "../file_url", version = "0.2.2" }
 pep508_rs = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1](https://github.com/conda/rattler/compare/rattler_networking-v0.22.0...rattler_networking-v0.22.1) - 2025-02-03
+
+### Added
+
+- add S3 support (#1008)
+
 ## [0.22.0](https://github.com/conda/rattler/compare/rattler_networking-v0.21.10...rattler_networking-v0.22.0) - 2025-01-23
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.22.0"
+version = "0.22.1"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.25](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.24...rattler_package_streaming-v0.22.25) - 2025-02-03
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.22.24](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.23...rattler_package_streaming-v0.22.24) - 2025-01-23
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.24"
+version = "0.22.25"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,9 +16,9 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.0", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.1", default-features = false }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.34](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.33...rattler_repodata_gateway-v0.21.34) - 2025-02-03
+
+### Added
+
+- add S3 support (#1008)
+
 ## [0.21.33](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.32...rattler_repodata_gateway-v0.21.33) - 2025-01-23
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.33"
+version = "0.21.34"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -36,9 +36,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.1", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.22.0", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.1", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -55,7 +55,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.5", path = "../rattler_cache" }
+rattler_cache = { version = "0.3.6", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.17](https://github.com/conda/rattler/compare/rattler_shell-v0.22.16...rattler_shell-v0.22.17) - 2025-02-03
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.16](https://github.com/conda/rattler/compare/rattler_shell-v0.22.15...rattler_shell-v0.22.16) - 2025-01-23
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.16"
+version = "0.22.17"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.1", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.6](https://github.com/conda/rattler/compare/rattler_solve-v1.3.5...rattler_solve-v1.3.6) - 2025-02-03
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [1.3.5](https://github.com/conda/rattler/compare/rattler_solve-v1.3.4...rattler_solve-v1.3.5) - 2025-01-23
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.3.5"
+version = "1.3.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.0...rattler_virtual_packages-v2.0.1) - 2025-02-03
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [2.0.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v1.2.0...rattler_virtual_packages-v2.0.0) - 2025-01-23
 
 ### Added

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.0"
+version = "2.0.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.1", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `rattler`: 0.30.0
* `rattler_conda_types`: 0.30.1
* `rattler_networking`: 0.22.1
* `rattler_repodata_gateway`: 0.21.34
* `rattler_cache`: 0.3.6
* `rattler_package_streaming`: 0.22.25
* `rattler_shell`: 0.22.17
* `rattler_lock`: 0.22.41
* `rattler_solve`: 1.3.6
* `rattler_virtual_packages`: 2.0.1
* `rattler_index`: 0.20.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`

<blockquote>

## [0.30.0](https://github.com/conda/rattler/compare/rattler-v0.29.0...rattler-v0.30.0) - 2025-02-03

### Added

- add S3 support (#1008)
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.30.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.30.0...rattler_conda_types-v0.30.1) - 2025-02-03

### Fixed

- track feature serialization and deserialization (#1039)
</blockquote>

## `rattler_networking`

<blockquote>

## [0.22.1](https://github.com/conda/rattler/compare/rattler_networking-v0.22.0...rattler_networking-v0.22.1) - 2025-02-03

### Added

- add S3 support (#1008)
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.21.34](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.33...rattler_repodata_gateway-v0.21.34) - 2025-02-03

### Added

- add S3 support (#1008)
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.6](https://github.com/conda/rattler/compare/rattler_cache-v0.3.5...rattler_cache-v0.3.6) - 2025-02-03

### Other

- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.25](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.24...rattler_package_streaming-v0.22.25) - 2025-02-03

### Other

- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_shell`

<blockquote>

## [0.22.17](https://github.com/conda/rattler/compare/rattler_shell-v0.22.16...rattler_shell-v0.22.17) - 2025-02-03

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`

<blockquote>

## [0.22.41](https://github.com/conda/rattler/compare/rattler_lock-v0.22.40...rattler_lock-v0.22.41) - 2025-02-03

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_solve`

<blockquote>

## [1.3.6](https://github.com/conda/rattler/compare/rattler_solve-v1.3.5...rattler_solve-v1.3.6) - 2025-02-03

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.1](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.0...rattler_virtual_packages-v2.0.1) - 2025-02-03

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`

<blockquote>

## [0.20.9](https://github.com/conda/rattler/compare/rattler_index-v0.20.8...rattler_index-v0.20.9) - 2025-02-03

### Other

- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).