### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.30.0", default-features = false, features = ["indicatif"] }
+rattler = { path="../rattler", version = "0.31.0", default-features = false, features = ["indicatif"] }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.30.1", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.22.1", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.34", default-features = false, features = ["gateway"] }
+rattler_networking = { path="../rattler_networking", version = "0.22.2", default-features = false, features = ["gcs", "s3"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.35", default-features = false, features = ["gateway"] }
 rattler_solve = { path="../rattler_solve", version = "1.3.6", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.1", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.6", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.7", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0](https://github.com/conda/rattler/compare/rattler-v0.30.0...rattler-v0.31.0) - 2025-02-06
+
+### Fixed
+
+- create parent directories for file storage (#1045)
+
 ## [0.30.0](https://github.com/conda/rattler/compare/rattler-v0.29.0...rattler-v0.30.0) - 2025-02-03
 
 ### Added

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.30.0"
+version = "0.31.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.6", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.7", default-features = false }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.1", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.2", default-features = false }
 rattler_shell = { path = "../rattler_shell", version = "0.22.17", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.25", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.26", default-features = false, features = ["reqwest"] }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/conda/rattler/compare/rattler_cache-v0.3.6...rattler_cache-v0.3.7) - 2025-02-06
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.3.6](https://github.com/conda/rattler/compare/rattler_cache-v0.3.5...rattler_cache-v0.3.6) - 2025-02-03
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.6"
+version = "0.3.7"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -20,8 +20,8 @@ itertools.workspace = true
 parking_lot.workspace = true
 rattler_conda_types = { version = "0.30.1", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.5", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.22.1", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.25", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_networking = { version = "0.22.2", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.26", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 fs-err = { workspace = true }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.30.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.5", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.25", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.26", default-features = false }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2](https://github.com/conda/rattler/compare/rattler_networking-v0.22.1...rattler_networking-v0.22.2) - 2025-02-06
+
+### Fixed
+
+- create parent directories for file storage (#1045)
+
 ## [0.22.1](https://github.com/conda/rattler/compare/rattler_networking-v0.22.0...rattler_networking-v0.22.1) - 2025-02-03
 
 ### Added

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.22.1"
+version = "0.22.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.26](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.25...rattler_package_streaming-v0.22.26) - 2025-02-06
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.22.25](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.24...rattler_package_streaming-v0.22.25) - 2025-02-03
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.25"
+version = "0.22.26"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -18,7 +18,7 @@ futures-util = { workspace = true }
 num_cpus = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.1", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.2", default-features = false }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.35](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.34...rattler_repodata_gateway-v0.21.35) - 2025-02-06
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.21.34](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.33...rattler_repodata_gateway-v0.21.34) - 2025-02-03
 
 ### Added

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.34"
+version = "0.21.35"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -38,7 +38,7 @@ parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.1", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.22.1", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.2", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -55,7 +55,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.6", path = "../rattler_cache" }
+rattler_cache = { version = "0.3.7", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION



## 🤖 New release

* `rattler`: 0.31.0
* `rattler_networking`: 0.22.2
* `rattler_cache`: 0.3.7
* `rattler_package_streaming`: 0.22.26
* `rattler_repodata_gateway`: 0.21.35

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`

<blockquote>

## [0.31.0](https://github.com/conda/rattler/compare/rattler-v0.30.0...rattler-v0.31.0) - 2025-02-06

### Fixed

- create parent directories for file storage (#1045)
</blockquote>

## `rattler_networking`

<blockquote>

## [0.22.2](https://github.com/conda/rattler/compare/rattler_networking-v0.22.1...rattler_networking-v0.22.2) - 2025-02-06

### Fixed

- create parent directories for file storage (#1045)
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.7](https://github.com/conda/rattler/compare/rattler_cache-v0.3.6...rattler_cache-v0.3.7) - 2025-02-06

### Other

- updated the following local packages: rattler_networking
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.26](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.25...rattler_package_streaming-v0.22.26) - 2025-02-06

### Other

- updated the following local packages: rattler_networking
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.21.35](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.34...rattler_repodata_gateway-v0.21.35) - 2025-02-06

### Other

- updated the following local packages: rattler_networking
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).