### PR TITLE
chore: Add presigned URL to debug logs

### DIFF
--- a/crates/rattler_networking/src/s3_middleware.rs
+++ b/crates/rattler_networking/src/s3_middleware.rs
@@ -174,6 +174,7 @@ impl Middleware for S3Middleware {
         if req.url().scheme() == "s3" {
             let url = req.url().clone();
             let presigned_url = self.s3.generate_presigned_s3_url(url).await?;
+            tracing::debug!("Presigned URL: {}", presigned_url);
             *req.url_mut() = presigned_url.clone();
         }
         next.run(req, extensions).await


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

In some cases you might want to debug why your pixi call to S3 didn't work.
For this, I added a debug log with the presigned URL.
Since the URL expires in a fixed amount of time (iirc 5min by default) anyway, I wouldn't consider this leaking secrets, wdyt?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
