### PR TITLE
fix: Use new PackageRecord when issuing reinstallation in Transaction::from_current_and_desired

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -376,11 +376,11 @@ fn print_transaction(
                     format_record(new)
                 );
             }
-            TransactionOperation::Reinstall(r) => {
+            TransactionOperation::Reinstall { old, .. } => {
                 println!(
                     "{} {}",
                     console::style("~").yellow(),
-                    format_record(&r.repodata_record)
+                    format_record(&old.repodata_record)
                 );
             }
             TransactionOperation::Remove(r) => {

--- a/crates/rattler/src/install/installer/indicatif.rs
+++ b/crates/rattler/src/install/installer/indicatif.rs
@@ -446,12 +446,10 @@ impl<F: ProgressFormatter + Send> Reporter for IndicatifReporter<F> {
         inner.package_sizes.reserve(transaction.operations.len());
         for operation in &transaction.operations {
             let record = match operation {
-                TransactionOperation::Install(new) | TransactionOperation::Change { new, .. } => {
-                    &new.package_record
-                }
-                TransactionOperation::Reinstall(old) | TransactionOperation::Remove(old) => {
-                    &old.repodata_record.package_record
-                }
+                TransactionOperation::Install(new)
+                | TransactionOperation::Change { new, .. }
+                | TransactionOperation::Reinstall { new, .. } => &new.package_record,
+                TransactionOperation::Remove(old) => &old.repodata_record.package_record,
             };
             inner
                 .package_names

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -34,6 +34,7 @@ pub enum TransactionOperation<Old, New> {
     /// Reinstall a package. This can happen if the Python version changed in
     /// the environment, we need to relink all noarch python packages in
     /// that case.
+    /// Includes old and new as fields like the channel may have changed between installations
     Reinstall {
         /// The old record to remove
         old: Old,

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -34,7 +34,12 @@ pub enum TransactionOperation<Old, New> {
     /// Reinstall a package. This can happen if the Python version changed in
     /// the environment, we need to relink all noarch python packages in
     /// that case.
-    Reinstall(Old),
+    Reinstall {
+        /// The old record to remove
+        old: Old,
+        /// The new record to install
+        new: New,
+    },
 
     /// Completely remove a package
     Remove(Old),
@@ -48,7 +53,7 @@ impl<Old: AsRef<New>, New> TransactionOperation<Old, New> {
         match self {
             TransactionOperation::Install(record) => Some(record),
             TransactionOperation::Change { new, .. } => Some(new),
-            TransactionOperation::Reinstall(old) => Some(old.as_ref()),
+            TransactionOperation::Reinstall { old: _, new } => Some(new),
             TransactionOperation::Remove(_) => None,
         }
     }
@@ -62,7 +67,7 @@ impl<Old, New> TransactionOperation<Old, New> {
         match self {
             TransactionOperation::Install(_) => None,
             TransactionOperation::Change { old, .. }
-            | TransactionOperation::Reinstall(old)
+            | TransactionOperation::Reinstall { old, new: _ }
             | TransactionOperation::Remove(old) => Some(old),
         }
     }
@@ -182,7 +187,10 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
                 } else if needs_python_relink && old_record.as_ref().noarch.is_python() {
                     // when the python version changed, we need to relink all noarch packages
                     // to recompile the bytecode
-                    operations.push(TransactionOperation::Reinstall(old_record));
+                    operations.push(TransactionOperation::Reinstall {
+                        old: old_record,
+                        new: record,
+                    });
                 }
                 // if the content is the same, we dont need to do anything
             } else {

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -34,7 +34,7 @@ pub enum TransactionOperation<Old, New> {
     /// Reinstall a package. This can happen if the Python version changed in
     /// the environment, we need to relink all noarch python packages in
     /// that case.
-    /// Includes old and new as fields like the channel may have changed between installations
+    /// Includes old and new because certains fields like the channel/url may have changed between installations
     Reinstall {
         /// The old record to remove
         old: Old,
@@ -53,8 +53,8 @@ impl<Old: AsRef<New>, New> TransactionOperation<Old, New> {
     pub fn record_to_install(&self) -> Option<&New> {
         match self {
             TransactionOperation::Install(record) => Some(record),
-            TransactionOperation::Change { new, .. } => Some(new),
-            TransactionOperation::Reinstall { old: _, new } => Some(new),
+            TransactionOperation::Change { new, .. }
+            | TransactionOperation::Reinstall { new, .. } => Some(new),
             TransactionOperation::Remove(_) => None,
         }
     }


### PR DESCRIPTION
Hey there, I'm back with another super edge case!

While using rattler I started seeing that installing new packages on top of my existing environment was leading me to get invalid authentication errors when downloading packages, which lead me to find the edge case that follows.

# The scenario
- Let's say a user uses basic authentication to authenticate requests for packages to their onw private conda repository. Which means the channel URL will look like `https://user:password@[their own repo url]` 
- Let's say that these tokens are invalidates and rolled in a short time range -> in this case tokens are rolled every 1 hour 

- Let's say at 1PM I create an env containing `packageA-1.1.1` and `python-3.11.8`. -> **succeeds**
- Let's say at 2:30PM I want to install a packageB on top of this environment. -> I will provide a channel url that contains **A NEW VALID TOKEN** -> and rattler will be able to download a version of packageB, but the installation will fail with an error meaning: failed to download packageA from `https://user:OLD INVALID TOKEN@[their own repo url]`.  


# What we must answer
So now we have two strange things in the issue to try to understand:
1) why is it that we're trying to fetch packageA which is a package that already exists in the env?
2) Why is it that even if we wanted to fetch again packageA, the request was invalid?

# Answers
When we reissue the new solve to rattler, because we want to install packageB, we will request `packageA, packageB, python`. Rattler will return `packageA-1.1.1, packageB-1, python-3.11.9` -> **NOTE THAT PYTHON IN THE EXISTING ENV IS 3.11.8 BUT THE NEW SOLVE RETURNED PYTHON3 .11.9**, this will be very important in a bit  

Notice: PackageA hasn't changed versions, packageB is new and python has changed version (3.11.8 -> 3.11.9). 

## So, why is it that we're trying to refetch packageA?
When attempting to install the env using the [CondaInstaller](https://github.com/conda/rattler/blob/main/crates/rattler/src/install/installer/mod.rs#L43)  
Rattler takes the existing packages in the env and the solved group of packages and computes a transaction saying, which packages can be:
- kept
- removed
- installed
- **REINSTALLED**!!!

There is a reinstallation edge condition for existing packages:
- if the package exists in the env and it's also in the newly solved group of specs, but the python version changed between the existing env and the newly resolved set of specs, we must reinstall (aka redownload) it because of python relinking logic: https://github.com/conda/rattler/blob/6c288beea6b18656b515d17e84aa2ae38a547934/crates/rattler/src/install/transaction.rs#L182-L187

- In our case above, it means that packageA will have to be redownloaded because the python version changed, even though the package itself didn't.

- **Where does this become a problem?** Notice in the rattler code how we do operations.push(TransactionOperation::Reinstall(old_record)); ([src](https://github.com/conda/rattler/blob/6c288beea6b18656b515d17e84aa2ae38a547934/crates/rattler/src/install/transaction.rs#L182-L187)) 
We're telling our transaction redownload this package using the old record we have on it. This assumes that the old and new record (which comes from a new solve) for the package are the same -> **except they aren't!** 

The new rercord, resulting from the rattler solve will say
[name: packageA-1.1.1, url: https:[NEW VALID TOKEN]...]

While the old metadata will contain a URL which uses the old invalid token, present there because when the environment was created, that was the valid URL.


# Can we fix this?
Yup! If we simply issue the reinstallation using the new packageRecord instead of the old one then we guarantee that the download URL will be the fresh version resulting from a recent solve! 
