### PR TITLE
fix: use run-exports

### DIFF
--- a/crates/rattler_cache/src/consts.rs
+++ b/crates/rattler_cache/src/consts.rs
@@ -1,5 +1,5 @@
 /// The location in the main cache folder where the conda package cache is stored.
 pub const PACKAGE_CACHE_DIR: &str = "pkgs";
-pub const RUN_EXPORTS_CACHE_DIR: &str = "run_exports";
+pub const RUN_EXPORTS_CACHE_DIR: &str = "run-exports";
 /// The location in the main cache folder where the repodata cache is stored.
 pub const REPODATA_CACHE_DIR: &str = "repodata";


### PR DESCRIPTION
## Overview

everywhere we use dash for folder names instead of underscore.
I think it would be good to use the same approach for run-exports cache