### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.32.0", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.3", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.22.4", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.37", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.3.8", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.3", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.9", default-features = false }
+rattler = { path="../rattler", version = "0.32.1", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.0", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.22.5", default-features = false, features = ["gcs", "s3"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.38", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.3.9", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.4", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.10", default-features = false }
 rattler_menuinst = { path="../rattler_menuinst", version = "0.1.0", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.1](https://github.com/conda/rattler/compare/rattler-v0.32.0...rattler-v0.32.1) - 2025-02-25
+
+### Added
+
+- add `rattler_menuinst` crate (#840)
+
 ## [0.32.0](https://github.com/conda/rattler/compare/rattler-v0.31.1...rattler-v0.32.0) - 2025-02-18
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.32.0"
+version = "0.32.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.9", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.10", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.4", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.19", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.28", default-features = false, features = ["reqwest"] }
+rattler_networking = { path = "../rattler_networking", version = "0.22.5", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.20", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.29", default-features = false, features = ["reqwest"] }
 rattler_menuinst = { path = "../rattler_menuinst", version = "0.1.0", default-features = false }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
@@ -45,7 +45,7 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }
 reqwest-middleware = { workspace = true }
 smallvec = { workspace = true }
-simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.0", default-features = false, features = ["tokio"] }
+simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.1", default-features = false, features = ["tokio"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "io-util", "macros"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.10](https://github.com/conda/rattler/compare/rattler_cache-v0.3.9...rattler_cache-v0.3.10) - 2025-02-25
+
+### Added
+
+- add run_exports cache (#1060)
+
+### Fixed
+
+- support file URL for run exports cache (#1081)
+
+### Other
+
+- use run-exports (#1077)
+
 ## [0.3.9](https://github.com/conda/rattler/compare/rattler_cache-v0.3.8...rattler_cache-v0.3.9) - 2025-02-18
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.9"
+version = "0.3.10"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,10 +18,10 @@ fs-err.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.30.3", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.31.0", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.6", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.22.4", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.28", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_networking = { version = "0.22.5", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.29", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros"] }
@@ -31,7 +31,7 @@ thiserror.workspace = true
 reqwest-middleware.workspace = true
 digest.workspace = true
 fs4 = { workspace = true, features = ["fs-err3-tokio", "tokio"] }
-simple_spawn_blocking = { version = "1.0.0", path = "../simple_spawn_blocking", features = ["tokio"] }
+simple_spawn_blocking = { version = "1.1.0", path = "../simple_spawn_blocking", features = ["tokio"] }
 rayon = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.30.3...rattler_conda_types-v0.31.0) - 2025-02-25
+
+### Added
+
+- add `rattler_menuinst` crate (#840)
+- initial wasm/ts/js bindings (#1079)
+
 ## [0.30.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.30.2...rattler_conda_types-v0.30.3) - 2025-02-18
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.30.3"
+version = "0.31.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.13](https://github.com/conda/rattler/compare/rattler_index-v0.20.12...rattler_index-v0.20.13) - 2025-02-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.20.12](https://github.com/conda/rattler/compare/rattler_index-v0.20.11...rattler_index-v0.20.12) - 2025-02-18
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.20.12"
+version = "0.20.13"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.6", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.28", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.29", default-features = false }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.44](https://github.com/conda/rattler/compare/rattler_lock-v0.22.43...rattler_lock-v0.22.44) - 2025-02-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.43](https://github.com/conda/rattler/compare/rattler_lock-v0.22.42...rattler_lock-v0.22.43) - 2025-02-18
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.43"
+version = "0.22.44"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
 file_url = { path = "../file_url", version = "0.2.3" }
 pep508_rs = { workspace = true }

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_menuinst-v0.1.0) - 2025-02-25
+
+### Added
+
+- add `rattler_menuinst` crate (#840)
+- better readme (#118)
+- replace zulip with discord (#116)
+- move all conda types to seperate crate
+
+### Fixed
+
+- release-plz (#1100)
+- typos (#849)
+- move more links to the conda org from conda-incubator (#816)
+- use conda-incubator
+- add python docs badge
+- typo libsolve -> libsolv (#164)
+- change urls from baszalmstra to mamba-org
+- build badge
+
+### Other
+
+- fix anchor link (#1035)
+- change links from conda-incubator to conda (#813)
+- update banner (#808)
+- update README.md
+- add pixi badge (#563)
+- update installation gif
+- update banner image
+- address issue [#282](https://github.com/conda/rattler/pull/282) ([#283](https://github.com/conda/rattler/pull/283))
+- Add an image to Readme ([#203](https://github.com/conda/rattler/pull/203))
+- Improve getting started with a micromamba environment. ([#163](https://github.com/conda/rattler/pull/163))
+- Misc/update readme ([#66](https://github.com/conda/rattler/pull/66))
+- update readme
+- layout the vision a little bit better
+- *(docs)* add build badge
+- matchspec parsing

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -15,8 +15,8 @@ dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.19", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.20", default-features = false }
 thiserror = { workspace = true }
 unicode-normalization = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.5](https://github.com/conda/rattler/compare/rattler_networking-v0.22.4...rattler_networking-v0.22.5) - 2025-02-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.4](https://github.com/conda/rattler/compare/rattler_networking-v0.22.3...rattler_networking-v0.22.4) - 2025-02-18
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.22.4"
+version = "0.22.5"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.29](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.28...rattler_package_streaming-v0.22.29) - 2025-02-25
+
+### Added
+
+- add run_exports cache (#1060)
+
 ## [0.22.28](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.27...rattler_package_streaming-v0.22.28) - 2025-02-18
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.28"
+version = "0.22.29"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,13 +16,13 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.4", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.5", default-features = false }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
-simple_spawn_blocking = { version = "1.0.0", path = "../simple_spawn_blocking", features = ["tokio"] }
+simple_spawn_blocking = { version = "1.1.0", path = "../simple_spawn_blocking", features = ["tokio"] }
 serde_json = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.38](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.37...rattler_repodata_gateway-v0.21.38) - 2025-02-25
+
+### Added
+
+- add run_exports cache (#1060)
+
+### Fixed
+
+- split matchspec on start of constraint (#1094)
+
 ## [0.21.37](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.36...rattler_repodata_gateway-v0.21.37) - 2025-02-18
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.37"
+version = "0.21.38"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -36,9 +36,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.22.4", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.5", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -46,7 +46,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 superslice = { workspace = true, optional = true }
-simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.0", features = ["tokio"] }
+simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.1", features = ["tokio"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "io-util", "macros"] }
@@ -55,7 +55,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.9", path = "../rattler_cache" }
+rattler_cache = { version = "0.3.10", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_sandbox/CHANGELOG.md
+++ b/crates/rattler_sandbox/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.3...rattler_sandbox-v0.1.4) - 2025-02-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.3](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.2...rattler_sandbox-v0.1.3) - 2025-02-18
 
 ### Other

--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_sandbox"
-version = "0.1.3"
+version = "0.1.4"
 description = "A crate to run executables in a sandbox"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.20](https://github.com/conda/rattler/compare/rattler_shell-v0.22.19...rattler_shell-v0.22.20) - 2025-02-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.19](https://github.com/conda/rattler/compare/rattler_shell-v0.22.18...rattler_shell-v0.22.19) - 2025-02-18
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.19"
+version = "0.22.20"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.9](https://github.com/conda/rattler/compare/rattler_solve-v1.3.8...rattler_solve-v1.3.9) - 2025-02-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [1.3.8](https://github.com/conda/rattler/compare/rattler_solve-v1.3.7...rattler_solve-v1.3.8) - 2025-02-18
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.3.8"
+version = "1.3.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.4](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.3...rattler_virtual_packages-v2.0.4) - 2025-02-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [2.0.3](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.2...rattler_virtual_packages-v2.0.3) - 2025-02-18
 
 ### Fixed

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.3"
+version = "2.0.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/crates/simple_spawn_blocking/CHANGELOG.md
+++ b/crates/simple_spawn_blocking/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0](https://github.com/conda/rattler/compare/simple_spawn_blocking-v1.0.0...simple_spawn_blocking-v1.1.0) - 2025-02-25
+
+### Added
+
+- add run_exports cache (#1060)

--- a/crates/simple_spawn_blocking/Cargo.toml
+++ b/crates/simple_spawn_blocking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple_spawn_blocking"
-version = "1.0.0"
+version = "1.1.0"
 description = "A simple crate to make spawning blocking tasks more ergonomic"
 categories.workspace = true
 homepage.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `rattler_conda_types`: 0.30.3 -> 0.31.0 (⚠ API breaking changes)
* `rattler_networking`: 0.22.4 -> 0.22.5 (✓ API compatible changes)
* `simple_spawn_blocking`: 1.0.0 -> 1.1.0 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.28 -> 0.22.29 (✓ API compatible changes)
* `rattler_cache`: 0.3.9 -> 0.3.10 (✓ API compatible changes)
* `rattler_shell`: 0.22.19 -> 0.22.20 (✓ API compatible changes)
* `rattler_menuinst`: 0.1.0
* `rattler`: 0.32.0 -> 0.32.1 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.21.37 -> 0.21.38 (✓ API compatible changes)
* `rattler_index`: 0.20.12 -> 0.20.13 (✓ API compatible changes)
* `rattler_sandbox`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `rattler_lock`: 0.22.43 -> 0.22.44
* `rattler_solve`: 1.3.8 -> 1.3.9
* `rattler_virtual_packages`: 2.0.3 -> 2.0.4

### ⚠ `rattler_conda_types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PrefixRecord.installed_system_menus in /tmp/.tmpchF8fv/rattler/crates/rattler_conda_types/src/prefix_record.rs:186
  field PrefixRecord.installed_system_menus in /tmp/.tmpchF8fv/rattler/crates/rattler_conda_types/src/prefix_record.rs:186
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_conda_types`

<blockquote>

## [0.31.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.30.3...rattler_conda_types-v0.31.0) - 2025-02-25

### Added

- add `rattler_menuinst` crate (#840)
- initial wasm/ts/js bindings (#1079)
</blockquote>

## `rattler_networking`

<blockquote>

## [0.22.5](https://github.com/conda/rattler/compare/rattler_networking-v0.22.4...rattler_networking-v0.22.5) - 2025-02-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `simple_spawn_blocking`

<blockquote>

## [1.1.0](https://github.com/conda/rattler/compare/simple_spawn_blocking-v1.0.0...simple_spawn_blocking-v1.1.0) - 2025-02-25

### Added

- add run_exports cache (#1060)
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.29](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.28...rattler_package_streaming-v0.22.29) - 2025-02-25

### Added

- add run_exports cache (#1060)
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.10](https://github.com/conda/rattler/compare/rattler_cache-v0.3.9...rattler_cache-v0.3.10) - 2025-02-25

### Added

- add run_exports cache (#1060)

### Fixed

- support file URL for run exports cache (#1081)

### Other

- use run-exports (#1077)
</blockquote>

## `rattler_shell`

<blockquote>

## [0.22.20](https://github.com/conda/rattler/compare/rattler_shell-v0.22.19...rattler_shell-v0.22.20) - 2025-02-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_menuinst-v0.1.0) - 2025-02-25

### Added

- add `rattler_menuinst` crate (#840)
- better readme (#118)
- replace zulip with discord (#116)
- move all conda types to seperate crate

### Fixed

- release-plz (#1100)
- typos (#849)
- move more links to the conda org from conda-incubator (#816)
- use conda-incubator
- add python docs badge
- typo libsolve -> libsolv (#164)
- change urls from baszalmstra to mamba-org
- build badge

### Other

- fix anchor link (#1035)
- change links from conda-incubator to conda (#813)
- update banner (#808)
- update README.md
- add pixi badge (#563)
- update installation gif
- update banner image
- address issue [#282](https://github.com/conda/rattler/pull/282) ([#283](https://github.com/conda/rattler/pull/283))
- Add an image to Readme ([#203](https://github.com/conda/rattler/pull/203))
- Improve getting started with a micromamba environment. ([#163](https://github.com/conda/rattler/pull/163))
- Misc/update readme ([#66](https://github.com/conda/rattler/pull/66))
- update readme
- layout the vision a little bit better
- *(docs)* add build badge
- matchspec parsing
</blockquote>

## `rattler`

<blockquote>

## [0.32.1](https://github.com/conda/rattler/compare/rattler-v0.32.0...rattler-v0.32.1) - 2025-02-25

### Added

- add `rattler_menuinst` crate (#840)
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.21.38](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.37...rattler_repodata_gateway-v0.21.38) - 2025-02-25

### Added

- add run_exports cache (#1060)

### Fixed

- split matchspec on start of constraint (#1094)
</blockquote>

## `rattler_index`

<blockquote>

## [0.20.13](https://github.com/conda/rattler/compare/rattler_index-v0.20.12...rattler_index-v0.20.13) - 2025-02-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_sandbox`

<blockquote>

## [0.1.4](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.3...rattler_sandbox-v0.1.4) - 2025-02-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_lock`

<blockquote>

## [0.22.44](https://github.com/conda/rattler/compare/rattler_lock-v0.22.43...rattler_lock-v0.22.44) - 2025-02-25

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_solve`

<blockquote>

## [1.3.9](https://github.com/conda/rattler/compare/rattler_solve-v1.3.8...rattler_solve-v1.3.9) - 2025-02-25

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.4](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.3...rattler_virtual_packages-v2.0.4) - 2025-02-25

### Other

- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).