### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,14 +27,14 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.32.1", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.0", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.22.5", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.38", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.3.9", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.4", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.10", default-features = false }
-rattler_menuinst = { path="../rattler_menuinst", version = "0.1.0", default-features = false }
+rattler = { path="../rattler", version = "0.32.2", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.1", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.22.6", default-features = false, features = ["gcs", "s3"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.39", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.3.10", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.5", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.11", default-features = false }
+rattler_menuinst = { path="../rattler_menuinst", version = "0.2.0", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.2](https://github.com/conda/rattler/compare/rattler-v0.32.1...rattler-v0.32.2) - 2025-02-27
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming, rattler_shell, rattler_menuinst
+
 ## [0.32.1](https://github.com/conda/rattler/compare/rattler-v0.32.0...rattler-v0.32.1) - 2025-02-25
 
 ### Added

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.32.1"
+version = "0.32.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,13 +32,13 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.10", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.11", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.5", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.20", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.29", default-features = false, features = ["reqwest"] }
-rattler_menuinst = { path = "../rattler_menuinst", version = "0.1.0", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.21", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.30", default-features = false, features = ["reqwest"] }
+rattler_menuinst = { path = "../rattler_menuinst", version = "0.2.0", default-features = false }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.11](https://github.com/conda/rattler/compare/rattler_cache-v0.3.10...rattler_cache-v0.3.11) - 2025-02-27
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming
+
 ## [0.3.10](https://github.com/conda/rattler/compare/rattler_cache-v0.3.9...rattler_cache-v0.3.10) - 2025-02-25
 
 ### Added

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.10"
+version = "0.3.11"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,10 +18,10 @@ fs-err.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.31.0", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.31.1", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.6", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.22.5", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.29", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_networking = { version = "0.22.6", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.30", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.0...rattler_conda_types-v0.31.1) - 2025-02-27
+
+### Added
+
+- Use `opendal` in `rattler-index` and add executable (#1076)
+
 ## [0.31.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.30.3...rattler_conda_types-v0.31.0) - 2025-02-25
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.31.0"
+version = "0.31.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -28,7 +28,7 @@ rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-featur
   "serde",
 ] }
 rattler_macros = { path = "../rattler_macros", version = "1.0.6", default-features = false }
-rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", default-features = false }
+rattler_redaction = { version = "0.1.7", path = "../rattler_redaction", default-features = false }
 regex = { workspace = true }
 simd-json = { workspace = true, features = ["serde_impl"] }
 serde = { workspace = true, features = ["derive", "rc"] }

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/conda/rattler/compare/rattler_index-v0.20.13...rattler_index-v0.21.0) - 2025-02-27
+
+### Added
+
+- fix rattler-index name (#1114)
+- Use `opendal` in `rattler-index` and add executable (#1076)
+
+### Fixed
+
+- make `menuinst` schema pub, hide utils, fix indexing for rattler-build (#1111)
+- code review in rattler-index and test fix (#1109)
+
+### Other
+
+- remove tools/* features for rattler-index (#1112)
+
 ## [0.20.13](https://github.com/conda/rattler/compare/rattler_index-v0.20.12...rattler_index-v0.20.13) - 2025-02-25
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.20.13"
+version = "0.21.0"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."
@@ -43,10 +43,10 @@ opendal = { workspace = true, features = [
   "services-s3",
   "services-fs",
 ], default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.4", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0" }
+rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1" }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.29", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.30", default-features = false }
 reqwest = { workspace = true, default-features = false, features = [
   "http2",
   "macos-system-configuration",

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.45](https://github.com/conda/rattler/compare/rattler_lock-v0.22.44...rattler_lock-v0.22.45) - 2025-02-27
+
+### Fixed
+
+- clippy lint (#1105)
+
 ## [0.22.44](https://github.com/conda/rattler/compare/rattler_lock-v0.22.43...rattler_lock-v0.22.44) - 2025-02-25
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.44"
+version = "0.22.45"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
 file_url = { path = "../file_url", version = "0.2.3" }
 pep508_rs = { workspace = true }

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/conda/rattler/compare/rattler_menuinst-v0.1.0...rattler_menuinst-v0.2.0) - 2025-02-27
+
+### Added
+
+- Use `opendal` in `rattler-index` and add executable (#1076)
+
+### Fixed
+
+- make `menuinst` schema pub, hide utils, fix indexing for rattler-build (#1111)
+- clippy lint (#1105)
+
 ## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_menuinst-v0.1.0) - 2025-02-25
 
 ### Added

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"
@@ -15,8 +15,8 @@ dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.20", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.21", default-features = false }
 thiserror = { workspace = true }
 unicode-normalization = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.6](https://github.com/conda/rattler/compare/rattler_networking-v0.22.5...rattler_networking-v0.22.6) - 2025-02-27
+
+### Fixed
+
+- clippy lint (#1105)
+
 ## [0.22.5](https://github.com/conda/rattler/compare/rattler_networking-v0.22.4...rattler_networking-v0.22.5) - 2025-02-25
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.22.5"
+version = "0.22.6"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.30](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.29...rattler_package_streaming-v0.22.30) - 2025-02-27
+
+### Added
+
+- Use `opendal` in `rattler-index` and add executable (#1076)
+
 ## [0.22.29](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.28...rattler_package_streaming-v0.22.29) - 2025-02-25
 
 ### Added

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.29"
+version = "0.22.30"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,10 +16,10 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.5", default-features = false }
-rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = [
+rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
+rattler_redaction = { version = "0.1.7", path = "../rattler_redaction", features = [
   "reqwest",
   "reqwest-middleware",
 ], default-features = false }

--- a/crates/rattler_redaction/CHANGELOG.md
+++ b/crates/rattler_redaction/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.6...rattler_redaction-v0.1.7) - 2025-02-27
+
+### Added
+
+- Use `opendal` in `rattler-index` and add executable (#1076)
+
 ## [0.1.6](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.5...rattler_redaction-v0.1.6) - 2025-01-08
 
 ### Other

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_redaction"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Redact sensitive information from URLs (ie. conda tokens)"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.39](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.38...rattler_repodata_gateway-v0.21.39) - 2025-02-27
+
+### Other
+
+- updated the following local packages: rattler_redaction, rattler_conda_types, rattler_networking
+
 ## [0.21.38](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.37...rattler_repodata_gateway-v0.21.38) - 2025-02-25
 
 ### Added

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.38"
+version = "0.21.39"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -36,9 +36,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.22.5", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -55,8 +55,8 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.10", path = "../rattler_cache" }
-rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+rattler_cache = { version = "0.3.11", path = "../rattler_cache" }
+rattler_redaction = { version = "0.1.7", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.21](https://github.com/conda/rattler/compare/rattler_shell-v0.22.20...rattler_shell-v0.22.21) - 2025-02-27
+
+### Added
+
+- implement shell completion helpers (#1075)
+
 ## [0.22.20](https://github.com/conda/rattler/compare/rattler_shell-v0.22.19...rattler_shell-v0.22.20) - 2025-02-25
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.20"
+version = "0.22.21"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.1", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.10](https://github.com/conda/rattler/compare/rattler_solve-v1.3.9...rattler_solve-v1.3.10) - 2025-02-27
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [1.3.9](https://github.com/conda/rattler/compare/rattler_solve-v1.3.8...rattler_solve-v1.3.9) - 2025-02-25
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.3.9"
+version = "1.3.10"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.4...rattler_virtual_packages-v2.0.5) - 2025-02-27
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [2.0.4](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.3...rattler_virtual_packages-v2.0.4) - 2025-02-25
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.4"
+version = "2.0.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.1", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `rattler_redaction`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `rattler_conda_types`: 0.31.0 -> 0.31.1 (✓ API compatible changes)
* `rattler_networking`: 0.22.5 -> 0.22.6 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.29 -> 0.22.30 (✓ API compatible changes)
* `rattler_shell`: 0.22.20 -> 0.22.21 (✓ API compatible changes)
* `rattler_menuinst`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `rattler_lock`: 0.22.44 -> 0.22.45 (✓ API compatible changes)
* `rattler_index`: 0.20.13 -> 0.21.0 (⚠ API breaking changes)
* `rattler_cache`: 0.3.10 -> 0.3.11
* `rattler`: 0.32.1 -> 0.32.2
* `rattler_repodata_gateway`: 0.21.38 -> 0.21.39
* `rattler_solve`: 1.3.9 -> 1.3.10
* `rattler_virtual_packages`: 2.0.4 -> 2.0.5

### ⚠ `rattler_menuinst` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_missing.ron

Failed in:
  function rattler_menuinst::utils::slugify::slugify, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/slugify.rs:19
  function rattler_menuinst::utils::slugify, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/slugify.rs:19
  function rattler_menuinst::utils::terminal::run_pre_create_command, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/terminal.rs:14
  function rattler_menuinst::utils::run_pre_create_command, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/terminal.rs:14
  function rattler_menuinst::utils::quote_args, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/mod.rs:9
  function rattler_menuinst::utils::terminal::log_output, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/terminal.rs:4
  function rattler_menuinst::utils::log_output, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/terminal.rs:4

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/module_missing.ron

Failed in:
  mod rattler_menuinst::utils::terminal, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/terminal.rs:1
  mod rattler_menuinst::utils::slugify, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/slugify.rs:1
  mod rattler_menuinst::utils, previously in file /tmp/.tmpJ0rx9v/rattler_menuinst/src/utils/mod.rs:1
```

### ⚠ `rattler_index` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rattler_index::index now takes 5 parameters instead of 2, in /tmp/.tmpJYrB4Y/rattler/crates/rattler_index/src/lib.rs:398

--- failure function_requires_different_generic_type_params: function now requires a different number of generic type parameters ---

Description:
A function now requires a different number of generic type parameters than it used to. Uses of this function that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_requires_different_generic_type_params.ron

Failed in:
  function index (0 -> 1 generic types) in /tmp/.tmpJYrB4Y/rattler/crates/rattler_index/src/lib.rs:398
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_redaction`

<blockquote>

## [0.1.7](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.6...rattler_redaction-v0.1.7) - 2025-02-27

### Added

- Use `opendal` in `rattler-index` and add executable (#1076)
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.31.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.0...rattler_conda_types-v0.31.1) - 2025-02-27

### Added

- Use `opendal` in `rattler-index` and add executable (#1076)
</blockquote>

## `rattler_networking`

<blockquote>

## [0.22.6](https://github.com/conda/rattler/compare/rattler_networking-v0.22.5...rattler_networking-v0.22.6) - 2025-02-27

### Fixed

- clippy lint (#1105)
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.30](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.29...rattler_package_streaming-v0.22.30) - 2025-02-27

### Added

- Use `opendal` in `rattler-index` and add executable (#1076)
</blockquote>

## `rattler_shell`

<blockquote>

## [0.22.21](https://github.com/conda/rattler/compare/rattler_shell-v0.22.20...rattler_shell-v0.22.21) - 2025-02-27

### Added

- implement shell completion helpers (#1075)
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.0](https://github.com/conda/rattler/compare/rattler_menuinst-v0.1.0...rattler_menuinst-v0.2.0) - 2025-02-27

### Added

- Use `opendal` in `rattler-index` and add executable (#1076)

### Fixed

- make `menuinst` schema pub, hide utils, fix indexing for rattler-build (#1111)
- clippy lint (#1105)
</blockquote>

## `rattler_lock`

<blockquote>

## [0.22.45](https://github.com/conda/rattler/compare/rattler_lock-v0.22.44...rattler_lock-v0.22.45) - 2025-02-27

### Fixed

- clippy lint (#1105)
</blockquote>

## `rattler_index`

<blockquote>

## [0.21.0](https://github.com/conda/rattler/compare/rattler_index-v0.20.13...rattler_index-v0.21.0) - 2025-02-27

### Added

- fix rattler-index name (#1114)
- Use `opendal` in `rattler-index` and add executable (#1076)

### Fixed

- make `menuinst` schema pub, hide utils, fix indexing for rattler-build (#1111)
- code review in rattler-index and test fix (#1109)

### Other

- remove tools/* features for rattler-index (#1112)
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.11](https://github.com/conda/rattler/compare/rattler_cache-v0.3.10...rattler_cache-v0.3.11) - 2025-02-27

### Other

- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming
</blockquote>

## `rattler`

<blockquote>

## [0.32.2](https://github.com/conda/rattler/compare/rattler-v0.32.1...rattler-v0.32.2) - 2025-02-27

### Other

- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming, rattler_shell, rattler_menuinst
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.21.39](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.38...rattler_repodata_gateway-v0.21.39) - 2025-02-27

### Other

- updated the following local packages: rattler_redaction, rattler_conda_types, rattler_networking
</blockquote>

## `rattler_solve`

<blockquote>

## [1.3.10](https://github.com/conda/rattler/compare/rattler_solve-v1.3.9...rattler_solve-v1.3.10) - 2025-02-27

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.5](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.4...rattler_virtual_packages-v2.0.5) - 2025-02-27

### Other

- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).