### PR TITLE
feat: Fix rattler-index name

### DIFF
--- a/crates/rattler_index/src/main.rs
+++ b/crates/rattler_index/src/main.rs
@@ -17,7 +17,7 @@ fn parse_s3_url(value: &str) -> Result<Url, String> {
 
 /// The `rattler-index` CLI.
 #[derive(Parser)]
-#[command(version, about, long_about = None)]
+#[command(name = "rattler-index", version, about, long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Now, `rattler-index --version` produces `rattler-index 0.20.13` instead of `rattler_index 0.20.13`.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
