### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.32.2"
+version = "0.32.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.31.1"
+version = "0.31.2"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "blake2",
  "digest",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4384,7 +4384,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.45"
+version = "0.22.46"
 dependencies = [
  "chrono",
  "file_url",
@@ -4399,6 +4399,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde-value",
+ "serde_json",
  "serde_repr",
  "serde_with",
  "serde_yaml",
@@ -4419,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "configparser",
@@ -4448,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4484,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.30"
+version = "0.22.31"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4527,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.39"
+version = "0.21.40"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4602,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.21"
+version = "0.22.22"
 dependencies = [
  "enum_dispatch",
  "fs-err",
@@ -4621,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.3.10"
+version = "1.3.11"
 dependencies = [
  "chrono",
  "criterion",
@@ -4650,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "archspec",
  "libloading",

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,14 +27,14 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.32.2", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.1", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.22.6", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.39", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.3.10", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.5", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.11", default-features = false }
-rattler_menuinst = { path="../rattler_menuinst", version = "0.2.0", default-features = false }
+rattler = { path="../rattler", version = "0.32.3", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.2", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.22.7", default-features = false, features = ["gcs", "s3"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.40", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.3.11", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.6", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.12", default-features = false }
+rattler_menuinst = { path="../rattler_menuinst", version = "0.2.1", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.3](https://github.com/conda/rattler/compare/rattler-v0.32.2...rattler-v0.32.3) - 2025-02-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.32.2](https://github.com/conda/rattler/compare/rattler-v0.32.1...rattler-v0.32.2) - 2025-02-27
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.32.2"
+version = "0.32.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,13 +32,13 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.11", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.21", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.30", default-features = false, features = ["reqwest"] }
-rattler_menuinst = { path = "../rattler_menuinst", version = "0.2.0", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.12", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.2", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.7", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.22", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.31", default-features = false, features = ["reqwest"] }
+rattler_menuinst = { path = "../rattler_menuinst", version = "0.2.1", default-features = false }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12](https://github.com/conda/rattler/compare/rattler_cache-v0.3.11...rattler_cache-v0.3.12) - 2025-02-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.11](https://github.com/conda/rattler/compare/rattler_cache-v0.3.10...rattler_cache-v0.3.11) - 2025-02-27
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.11"
+version = "0.3.12"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,10 +18,10 @@ fs-err.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.31.1", path = "../rattler_conda_types", default-features = false }
-rattler_digest = { version = "1.0.6", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.22.6", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.30", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { version = "0.31.2", path = "../rattler_conda_types", default-features = false }
+rattler_digest = { version = "1.0.7", path = "../rattler_digest", default-features = false }
+rattler_networking = { version = "0.22.7", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.31", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.1...rattler_conda_types-v0.31.2) - 2025-02-28
+
+### Fixed
+
+- roundtrip of arch/platform in lock files (#1124)
+
 ## [0.31.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.0...rattler_conda_types-v0.31.1) - 2025-02-27
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.31.1"
+version = "0.31.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -24,7 +24,7 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false, features = [
+rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false, features = [
   "serde",
 ] }
 rattler_macros = { path = "../rattler_macros", version = "1.0.6", default-features = false }

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7](https://github.com/conda/rattler/compare/rattler_digest-v1.0.6...rattler_digest-v1.0.7) - 2025-02-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.6](https://github.com/conda/rattler/compare/rattler_digest-v1.0.5...rattler_digest-v1.0.6) - 2025-02-18
 
 ### Other

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "1.0.6"
+version = "1.0.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1](https://github.com/conda/rattler/compare/rattler_index-v0.21.0...rattler_index-v0.21.1) - 2025-02-28
+
+### Other
+
+- create reader from opendal buffer (#1123)
+
 ## [0.21.0](https://github.com/conda/rattler/compare/rattler_index-v0.20.13...rattler_index-v0.21.0) - 2025-02-27
 
 ### Added

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.21.0"
+version = "0.21.1"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."
@@ -44,10 +44,10 @@ opendal = { workspace = true, features = [
   "services-s3",
   "services-fs",
 ], default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1" }
-rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.30", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.7", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.2" }
+rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.31", default-features = false }
 reqwest = { workspace = true, default-features = false, features = [
   "http2",
   "macos-system-configuration",

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.46](https://github.com/conda/rattler/compare/rattler_lock-v0.22.45...rattler_lock-v0.22.46) - 2025-02-28
+
+### Fixed
+
+- roundtrip of arch/platform in lock files (#1124)
+
 ## [0.22.45](https://github.com/conda/rattler/compare/rattler_lock-v0.22.44...rattler_lock-v0.22.45) - 2025-02-27
 
 ### Fixed

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.45"
+version = "0.22.46"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,8 +15,8 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.2", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
 file_url = { path = "../file_url", version = "0.2.3" }
 pep508_rs = { workspace = true }
 pep440_rs = { workspace = true }

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.0...rattler_menuinst-v0.2.1) - 2025-02-28
+
+### Added
+
+- add fake folders method on win for easier testing (#1125)
+
 ## [0.2.0](https://github.com/conda/rattler/compare/rattler_menuinst-v0.1.0...rattler_menuinst-v0.2.0) - 2025-02-27
 
 ### Added

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"
@@ -15,8 +15,8 @@ dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.21", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.2", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.22", default-features = false }
 thiserror = { workspace = true }
 unicode-normalization = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.7](https://github.com/conda/rattler/compare/rattler_networking-v0.22.6...rattler_networking-v0.22.7) - 2025-02-28
+
+### Fixed
+
+- R2 key names in tests (#1115)
+
 ## [0.22.6](https://github.com/conda/rattler/compare/rattler_networking-v0.22.5...rattler_networking-v0.22.6) - 2025-02-27
 
 ### Fixed

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.22.6"
+version = "0.22.7"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.31](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.30...rattler_package_streaming-v0.22.31) - 2025-02-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.30](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.29...rattler_package_streaming-v0.22.30) - 2025-02-27
 
 ### Added

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.30"
+version = "0.22.31"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,9 +16,9 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.2", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.7", default-features = false }
 rattler_redaction = { version = "0.1.7", path = "../rattler_redaction", features = [
   "reqwest",
   "reqwest-middleware",

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.40](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.39...rattler_repodata_gateway-v0.21.40) - 2025-02-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.21.39](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.38...rattler_repodata_gateway-v0.21.39) - 2025-02-27
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.39"
+version = "0.21.40"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -36,9 +36,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false, optional = true }
-rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.2", default-features = false, optional = true }
+rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false, features = ["tokio", "serde"] }
+rattler_networking = { path = "../rattler_networking", version = "0.22.7", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -55,7 +55,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.11", path = "../rattler_cache" }
+rattler_cache = { version = "0.3.12", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.7", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.22](https://github.com/conda/rattler/compare/rattler_shell-v0.22.21...rattler_shell-v0.22.22) - 2025-02-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.21](https://github.com/conda/rattler/compare/rattler_shell-v0.22.20...rattler_shell-v0.22.21) - 2025-02-27
 
 ### Added

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.21"
+version = "0.22.22"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.2", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.11](https://github.com/conda/rattler/compare/rattler_solve-v1.3.10...rattler_solve-v1.3.11) - 2025-02-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.3.10](https://github.com/conda/rattler/compare/rattler_solve-v1.3.9...rattler_solve-v1.3.10) - 2025-02-27
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.3.10"
+version = "1.3.11"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.2", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.6](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.5...rattler_virtual_packages-v2.0.6) - 2025-02-28
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [2.0.5](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.4...rattler_virtual_packages-v2.0.5) - 2025-02-27
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.5"
+version = "2.0.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.2", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `rattler_digest`: 1.0.6 -> 1.0.7 (✓ API compatible changes)
* `rattler_conda_types`: 0.31.1 -> 0.31.2 (✓ API compatible changes)
* `rattler_networking`: 0.22.6 -> 0.22.7 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.30 -> 0.22.31 (✓ API compatible changes)
* `rattler_cache`: 0.3.11 -> 0.3.12 (✓ API compatible changes)
* `rattler_shell`: 0.22.21 -> 0.22.22 (✓ API compatible changes)
* `rattler_menuinst`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `rattler`: 0.32.2 -> 0.32.3 (✓ API compatible changes)
* `rattler_lock`: 0.22.45 -> 0.22.46 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.21.39 -> 0.21.40 (✓ API compatible changes)
* `rattler_solve`: 1.3.10 -> 1.3.11 (✓ API compatible changes)
* `rattler_virtual_packages`: 2.0.5 -> 2.0.6 (✓ API compatible changes)
* `rattler_index`: 0.21.0 -> 0.21.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_digest`

<blockquote>

## [1.0.7](https://github.com/conda/rattler/compare/rattler_digest-v1.0.6...rattler_digest-v1.0.7) - 2025-02-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.31.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.1...rattler_conda_types-v0.31.2) - 2025-02-28

### Fixed

- roundtrip of arch/platform in lock files (#1124)
</blockquote>

## `rattler_networking`

<blockquote>

## [0.22.7](https://github.com/conda/rattler/compare/rattler_networking-v0.22.6...rattler_networking-v0.22.7) - 2025-02-28

### Fixed

- R2 key names in tests (#1115)
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.31](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.30...rattler_package_streaming-v0.22.31) - 2025-02-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.12](https://github.com/conda/rattler/compare/rattler_cache-v0.3.11...rattler_cache-v0.3.12) - 2025-02-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_shell`

<blockquote>

## [0.22.22](https://github.com/conda/rattler/compare/rattler_shell-v0.22.21...rattler_shell-v0.22.22) - 2025-02-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.1](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.0...rattler_menuinst-v0.2.1) - 2025-02-28

### Added

- add fake folders method on win for easier testing (#1125)
</blockquote>

## `rattler`

<blockquote>

## [0.32.3](https://github.com/conda/rattler/compare/rattler-v0.32.2...rattler-v0.32.3) - 2025-02-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_lock`

<blockquote>

## [0.22.46](https://github.com/conda/rattler/compare/rattler_lock-v0.22.45...rattler_lock-v0.22.46) - 2025-02-28

### Fixed

- roundtrip of arch/platform in lock files (#1124)
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.21.40](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.39...rattler_repodata_gateway-v0.21.40) - 2025-02-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_solve`

<blockquote>

## [1.3.11](https://github.com/conda/rattler/compare/rattler_solve-v1.3.10...rattler_solve-v1.3.11) - 2025-02-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.6](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.5...rattler_virtual_packages-v2.0.6) - 2025-02-28

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_index`

<blockquote>

## [0.21.1](https://github.com/conda/rattler/compare/rattler_index-v0.21.0...rattler_index-v0.21.1) - 2025-02-28

### Other

- create reader from opendal buffer (#1123)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).