### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,16 +562,14 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d21e1ba6f2cdec92044f904356a19f5ad86961acf015741106cdfafd747c0"
+checksum = "0c4e5a89d8103b8090a3f04259fb851ebd3f33abf4fb3ac13326fefaa827618b"
 dependencies = [
  "aws-smithy-http 0.62.1",
  "aws-smithy-types",
  "bytes",
- "crc32c",
- "crc32fast",
- "crc64fast-nvme",
+ "crc-fast",
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -1331,6 +1329,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add8d3a4c789d77eeb0f0e3c1035f73610d017f9047e87db94f89c02a56d8fef"
+dependencies = [
+ "cc",
+ "crc",
+ "digest",
+ "libc",
+ "rand 0.9.1",
+ "regex",
+]
+
+[[package]]
 name = "crc32c"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,15 +1358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crc64fast-nvme"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
-dependencies = [
- "crc",
 ]
 
 [[package]]
@@ -1789,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2265,11 +2268,11 @@ dependencies = [
 
 [[package]]
 name = "halfbrown"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -2284,10 +2287,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2335,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "0.4.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "hkdf"
@@ -2612,7 +2611,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core 0.61.1",
 ]
 
 [[package]]
@@ -2899,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "3.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
+checksum = "159294d661a039f7644cea7e4d844e6b25aaf71c1ffe9d73a96d768c24b0faf4"
 dependencies = [
  "jsonptr",
  "serde",
@@ -2911,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "jsonptr"
-version = "0.6.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
 dependencies = [
  "serde",
  "serde_json",
@@ -3363,6 +3362,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,9 +3403,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opendal"
-version = "0.52.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55c840b5a6ad96106d6c0612fabb8f35a5ace826e0474fc55ebda33042b8d33"
+checksum = "11ff9e9656d1cb3c58582ea18e6d9e71076a7ab2614207821d1242d7da2daed5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3399,11 +3417,11 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "http 1.3.1",
+ "http-body 1.0.1",
  "log",
  "md-5",
- "once_cell",
  "percent-encoding",
- "quick-xml 0.36.2",
+ "quick-xml 0.37.5",
  "reqsign",
  "reqwest",
  "serde",
@@ -3929,16 +3947,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
@@ -4394,7 +4402,7 @@ dependencies = [
  "unicode-normalization",
  "which",
  "windows 0.60.0",
- "windows-registry 0.5.1",
+ "windows-registry 0.5.2",
 ]
 
 [[package]]
@@ -4420,7 +4428,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "retry-policies",
+ "retry-policies 0.5.0",
  "rstest",
  "serde",
  "serde_json",
@@ -4526,7 +4534,7 @@ dependencies = [
  "rattler_redaction",
  "reqwest",
  "reqwest-middleware",
- "retry-policies",
+ "retry-policies 0.5.0",
  "rmp-serde",
  "rstest",
  "self_cell",
@@ -4892,7 +4900,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
- "retry-policies",
+ "retry-policies 0.4.0",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -4924,6 +4932,15 @@ name = "retry-policies"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503c78f59814e2664c9980b739b19e40f549233ecf39928040ee54fdd431f614"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -5512,11 +5529,11 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simd-json"
-version = "0.14.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
+checksum = "c962f626b54771990066e5435ec8331d1462576cd2d1e62f24076ae014f92112"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "halfbrown",
  "ref-cast",
  "serde",
@@ -5724,16 +5741,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "79251336d17c72d9762b8b54be4befe38d2db56fbbc0241396d70f173c39d47a"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
- "windows 0.57.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.1",
 ]
 
 [[package]]
@@ -6274,9 +6291,9 @@ dependencies = [
 
 [[package]]
 name = "typed-path"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41713888c5ccfd99979fcd1afd47b71652e331b3d4a0e19d30769e80fec76cce"
+checksum = "c462d18470a2857aa657d338af5fa67170bb48bcc80a296710ce3b0802a32566"
 
 [[package]]
 name = "typeid"
@@ -6395,8 +6412,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.3",
+ "js-sys",
  "rand 0.9.1",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6407,9 +6426,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-trait"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
+checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
 dependencies = [
  "float-cmp",
  "halfbrown",
@@ -6683,16 +6702,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
@@ -6711,8 +6720,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
 dependencies = [
  "windows-collections 0.2.0",
- "windows-core 0.61.0",
- "windows-future 0.2.0",
+ "windows-core 0.61.1",
+ "windows-future 0.2.1",
  "windows-link",
  "windows-numerics 0.2.0",
 ]
@@ -6732,19 +6741,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.0",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core 0.61.1",
 ]
 
 [[package]]
@@ -6754,23 +6751,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
 dependencies = [
  "windows-implement 0.59.0",
- "windows-interface 0.59.1",
+ "windows-interface",
  "windows-link",
- "windows-result 0.3.2",
+ "windows-result",
  "windows-strings 0.3.1",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
 dependencies = [
  "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-interface",
  "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
+ "windows-result",
+ "windows-strings 0.4.1",
 ]
 
 [[package]]
@@ -6785,23 +6782,13 @@ dependencies = [
 
 [[package]]
 name = "windows-future"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.0",
+ "windows-core 0.61.1",
  "windows-link",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "windows-threading",
 ]
 
 [[package]]
@@ -6820,17 +6807,6 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6870,7 +6846,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.0",
+ "windows-core 0.61.1",
  "windows-link",
 ]
 
@@ -6880,36 +6856,27 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.3.2",
+ "windows-result",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-registry"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1da3e436dc7653dfdf3da67332e22bff09bb0e28b0239e1624499c7830842e"
+checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
  "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
+ "windows-result",
+ "windows-strings 0.4.1",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
 dependencies = [
  "windows-link",
 ]
@@ -6925,9 +6892,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
 dependencies = [
  "windows-link",
 ]
@@ -6995,6 +6962,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ reqwest = { version = "0.12.15", default-features = false }
 reqwest-middleware = "0.4.2"
 reqwest-retry = "0.7.0"
 resolvo = { version = "0.9.1" }
-retry-policies = { version = "0.5.0", default-features = false }
+retry-policies = { version = "0.4.0", default-features = false }
 rmp-serde = { version = "1.3.0" }
 rstest = { version = "0.25.0" }
 rstest_reuse = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ tag-prefix = ""
 lto = true
 
 [workspace.dependencies]
-anyhow = "1.0.97"
+anyhow = "1.0.98"
 archspec = "0.1.3"
 assert_matches = "1.5.0"
-async-compression = { version = "0.4.19", features = [
+async-compression = { version = "0.4.23", features = [
   "gzip",
   "tokio",
   "bzip2",
@@ -35,7 +35,7 @@ async-compression = { version = "0.4.19", features = [
 async-fd-lock = "0.2.0"
 fs4 = "0.13.1"
 async-trait = "0.1.88"
-axum = { version = "0.8.1", default-features = false, features = [
+axum = { version = "0.8.4", default-features = false, features = [
   "tokio",
   "http1",
 ] }
@@ -46,13 +46,13 @@ bytes = "1.10.1"
 bzip2 = "0.5.2"
 cache_control = "0.2.0"
 cfg-if = "1.0"
-chrono = { version = "0.4.40", default-features = false, features = [
+chrono = { version = "0.4.41", default-features = false, features = [
   "std",
   "serde",
   "alloc",
 ] }
-clap = { version = "4.5.34", features = ["derive"] }
-clap-verbosity-flag = "3.0.1"
+clap = { version = "4.5.38", features = ["derive"] }
+clap-verbosity-flag = "3.0.2"
 cmake = "0.1.54"
 console = { version = "0.15.11", features = ["windows-console-colors"] }
 criterion = "0.5"
@@ -69,7 +69,7 @@ futures-util = "0.3.31"
 fxhash = "0.2.1"
 # lots of other crates are still stuck on older version which breaks `deserialize`
 generic-array = "0.14.7"
-getrandom = { version = "0.2.15", default-features = false }
+getrandom = { version = "0.2.16", default-features = false }
 glob = "0.3.2"
 google-cloud-auth = { version = "0.17.2", default-features = false }
 google-cloud-token = "0.1.2"
@@ -79,34 +79,34 @@ aws-config = { version = "=1.5.18", default-features = false, features = [
   "sso",
   "credentials-process",
 ] }
-aws-sdk-s3 = { version = "1.82.0", default-features = false, features = [
+aws-sdk-s3 = { version = "1.85.0", default-features = false, features = [
   "rt-tokio",
   "rustls",
   "sigv4a",
 ] }
 hex = "0.4.3"
-hex-literal = "0.4.1"
+hex-literal = "1.0.0"
 http = "1.3"
 http-cache-semantics = "2.1.0"
 humansize = "2.1.3"
 humantime = "2.2.0"
 indexmap = "2.9.0"
 indicatif = "0.17.11"
-insta = { version = "1.42.1" }
+insta = { version = "1.43.1" }
 itertools = "0.14.0"
-json-patch = "3.0.1"
+json-patch = "4.0.0"
 keyring = "3.6.2"
 lazy-regex = "3.4.1"
 libc = { version = "0.2" }
-libloading = "0.8.6"
-libz-sys = { version = "1.1.21", default-features = false }
+libloading = "0.8.7"
+libz-sys = { version = "1.1.22", default-features = false }
 md-5 = "0.10.6"
 memchr = "2.7.4"
 memmap2 = "0.9.5"
 netrc-rs = "0.1.2"
 nom = "7.1.3"
 num_cpus = "1.16.0"
-opendal = { version = "0.52.0", default-features = false }
+opendal = { version = "0.53.2", default-features = false }
 once_cell = "1.21.3"
 parking_lot = "0.12.3"
 pathdiff = "0.2.3"
@@ -117,7 +117,7 @@ pin-project-lite = "0.2.16"
 plist = "1"
 purl = { version = "0.1.6", features = ["serde"] }
 quote = "1.0.40"
-rand = "0.9.0"
+rand = "0.9.1"
 rayon = "1.10.0"
 reflink-copy = "0.1.26"
 regex = "1.11.1"
@@ -125,12 +125,12 @@ reqwest = { version = "0.12.15", default-features = false }
 reqwest-middleware = "0.4.2"
 reqwest-retry = "0.7.0"
 resolvo = { version = "0.9.1" }
-retry-policies = { version = "0.4.0", default-features = false }
+retry-policies = { version = "0.5.0", default-features = false }
 rmp-serde = { version = "1.3.0" }
 rstest = { version = "0.25.0" }
 rstest_reuse = "0.7.0"
-simd-json = { version = "0.14.0", features = ["serde_impl"] }
-self_cell = "1.1.0"
+simd-json = { version = "0.15.1", features = ["serde_impl"] }
+self_cell = "1.2.0"
 serde = { version = "1.0.219" }
 serde_json = { version = "1.0.140" }
 serde_repr = "0.1"
@@ -138,41 +138,41 @@ serde-value = "0.7.0"
 serde_with = "3.12.0"
 serde_yaml = "0.9.34"
 serde-untagged = "0.1.7"
-sha2 = "0.10.8"
+sha2 = "0.10.9"
 shlex = "1.3.0"
-similar-asserts = "1.6.1"
+similar-asserts = "1.7.0"
 smallvec = { version = "1.15.0", features = [
   "serde",
   "const_new",
   "const_generics",
   "union",
 ] }
-strum = { version = "0.27.0", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 superslice = "1.0.0"
-syn = "2.0.100"
-sysinfo = "0.33.1"
+syn = "2.0.101"
+sysinfo = "0.35.1"
 tar = "0.4.44"
 tempdir = "0.3.7"
-tempfile = "3.19.1"
+tempfile = "3.20.0"
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 test-log = "0.2.17"
 thiserror = "2.0"
-tokio = { version = "1.44.2", default-features = false }
+tokio = { version = "1.45.0", default-features = false }
 tokio-stream = "0.1.17"
-tokio-util = "0.7.14"
+tokio-util = "0.7.15"
 tower = { version = "0.5.2", default-features = false }
-tower-http = { version = "0.6.2", default-features = false }
+tower-http = { version = "0.6.4", default-features = false }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", default-features = false }
 tracing-test = { version = "0.2.5" }
-trybuild = { version = "1.0.103" }
-typed-path = { version = "0.10.0" }
+trybuild = { version = "1.0.105" }
+typed-path = { version = "0.11.0" }
 url = { version = "2.5.4" }
 unicode-normalization = "0.1.24"
 uuid = { version = "1.16.0", default-features = false }
 walkdir = "2.5.0"
 wasmtimer = "0.4.1"
-which = "7.0.2"
+which = "7.0.3"
 windows-sys = { version = "0.59.0", default-features = false }
 winver = { version = "1.0.0" }
 zip = { version = "3.0.0", default-features = false }

--- a/crates/file_url/Cargo.toml
+++ b/crates/file_url/Cargo.toml
@@ -13,7 +13,7 @@ url = { workspace = true }
 percent-encoding = { workspace = true }
 itertools = { workspace = true }
 typed-path = { workspace = true }
-thiserror = "2.0.11"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -17,7 +17,7 @@ libz-sys = { workspace = true, features = ["static"] }
 
 [build-dependencies]
 anyhow = { workspace = true }
-cc = "1.2.14"
+cc = "1.2.22"
 cmake = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -31,7 +31,7 @@ plist = { workspace = true }
 sha2 = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-quick-xml = "0.37.2"
+quick-xml = "0.37.5"
 configparser = { version = "3.1.0" }
 shlex = { workspace = true }
 
@@ -43,7 +43,7 @@ windows = { version = "0.60.0", features = [
     "Win32_Storage_EnhancedStorage",
     "Win32_System_Variant",
 ] }
-windows-registry = "0.5.0"
+windows-registry = "0.5.2"
 
 [dev-dependencies]
 insta = { workspace = true, features = ["json"] }

--- a/crates/rattler_pty/Cargo.toml
+++ b/crates/rattler_pty/Cargo.toml
@@ -14,4 +14,4 @@ readme.workspace = true
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 nix = { version = "0.29.0", features = ["fs", "signal", "term", "poll"] }
-signal-hook = "0.3.17"
+signal-hook = "0.3.18"


### PR DESCRIPTION
Catching us up before the dependabot does. `nom` is still breaking, as is `generic-array`.