### PR TITLE
fix: Add location to the cache key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4356,6 +4356,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -6557,13 +6558,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
-]
-
-[[package]]
-name = "wasm-bin"
-version = "0.1.0"
-dependencies = [
- "rattler_solve",
 ]
 
 [[package]]

--- a/crates/rattler_cache/src/package_cache/cache_key.rs
+++ b/crates/rattler_cache/src/package_cache/cache_key.rs
@@ -39,7 +39,7 @@ impl CacheKey {
 
     /// Adds a hash of the Path to the cache key
     pub fn with_path(mut self, path: &Path) -> Self {
-        let path_hash = compute_bytes_digest::<Sha256>(path.to_os_str().as_encoded_bytes());
+        let path_hash = compute_bytes_digest::<Sha256>(path.as_os_str().as_encoded_bytes());
         self.origin_hash = Some(format!("{path_hash:x}"));
         self
     }

--- a/crates/rattler_cache/src/package_cache/cache_key.rs
+++ b/crates/rattler_cache/src/package_cache/cache_key.rs
@@ -39,7 +39,7 @@ impl CacheKey {
 
     /// Adds a hash of the Path to the cache key
     pub fn with_path(mut self, path: &Path) -> Self {
-        let path_hash = compute_bytes_digest::<Sha256>(path.to_string_lossy().as_bytes());
+        let path_hash = compute_bytes_digest::<Sha256>(path.to_os_str().as_encoded_bytes());
         self.origin_hash = Some(format!("{path_hash:x}"));
         self
     }

--- a/crates/rattler_cache/src/package_cache/cache_key.rs
+++ b/crates/rattler_cache/src/package_cache/cache_key.rs
@@ -1,7 +1,10 @@
 use rattler_conda_types::package::ArchiveIdentifier;
 use rattler_conda_types::PackageRecord;
-use rattler_digest::Sha256Hash;
-use std::fmt::{Display, Formatter};
+use rattler_digest::{compute_bytes_digest, compute_url_digest, Sha256, Sha256Hash};
+use std::{
+    fmt::{Display, Formatter},
+    path::Path,
+};
 
 /// Provides a unique identifier for packages in the cache.
 /// TODO: This could not be unique over multiple subdir. How to handle?
@@ -11,6 +14,7 @@ pub struct CacheKey {
     pub(crate) version: String,
     pub(crate) build_string: String,
     pub(crate) sha256: Option<Sha256Hash>,
+    pub(crate) origin_hash: Option<String>,
 }
 
 impl CacheKey {
@@ -23,6 +27,20 @@ impl CacheKey {
     /// Potentially adds a sha256 hash of the archive.
     pub fn with_opt_sha256(mut self, sha256: Option<Sha256Hash>) -> Self {
         self.sha256 = sha256;
+        self
+    }
+
+    /// Adds a hash of the Url to the cache key
+    pub fn with_url(mut self, url: url::Url) -> Self {
+        let url_hash = compute_url_digest::<Sha256>(url);
+        self.origin_hash = Some(format!("{url_hash:x}"));
+        self
+    }
+
+    /// Adds a hash of the Path to the cache key
+    pub fn with_path(mut self, path: &Path) -> Self {
+        let path_hash = compute_bytes_digest::<Sha256>(path.to_string_lossy().as_bytes());
+        self.origin_hash = Some(format!("{path_hash:x}"));
         self
     }
 }
@@ -41,6 +59,7 @@ impl From<ArchiveIdentifier> for CacheKey {
             version: pkg.version,
             build_string: pkg.build_string,
             sha256: None,
+            origin_hash: None,
         }
     }
 }
@@ -52,12 +71,20 @@ impl From<&PackageRecord> for CacheKey {
             version: record.version.to_string(),
             build_string: record.build.clone(),
             sha256: record.sha256,
+            origin_hash: None,
         }
     }
 }
 
 impl Display for CacheKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}-{}-{}", &self.name, &self.version, &self.build_string)
+        match &self.origin_hash {
+            Some(url_hash) => write!(
+                f,
+                "{}-{}-{}-{}",
+                &self.name, &self.version, &self.build_string, url_hash
+            ),
+            None => write!(f, "{}-{}-{}", &self.name, &self.version, &self.build_string),
+        }
     }
 }

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["io-util"], optional = true }
+url = { workspace = true }
 generic-array = { workspace = true, optional = true }
 
 [features]

--- a/crates/rattler_digest/src/lib.rs
+++ b/crates/rattler_digest/src/lib.rs
@@ -87,6 +87,16 @@ pub fn compute_file_digest<D: Digest + Default + Write>(
     Ok(hasher.finalize())
 }
 
+/// Compute a hash of the specified Url without basic auth.
+pub fn compute_url_digest<D: Digest + Default + Write>(mut url: url::Url) -> Output<D> {
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+
+    let mut hasher = D::default();
+    hasher.update(url.to_string());
+    hasher.finalize()
+}
+
 /// Compute a hash of the specified bytes.
 pub fn compute_bytes_digest<D: Digest + Default + Write>(bytes: impl AsRef<[u8]>) -> Output<D> {
     let mut hasher = D::default();


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR is trying to solve an issue that was kind of already mentioned in this comment (cc @baszalmstra):
https://github.com/conda/rattler/blob/c7e2197d0bf8cd50a629e352e644ced7c752d9e7/crates/rattler_cache/src/package_cache/cache_key.rs#L7

Over at Palantir, users have the ability to generate custom conda packages and publish them to a private conda channel. The cache key currently consists of a `name`, `version`, and a `build_string` (and an optional `sha256` that we do not use in our custom conda packages).

Unfortunately, we set the `build_string` to a hardcoded value of `py_0`, so realistically the cache key only consists of the `name` and the `version` for those packages.

One of our forward deployed engineers ran into an issue where they tried to install a conda package with the same `name` and the same `version` of a package that they previously installed and they got a false cache hit. They installed a wrong package from a completely different customer and environment.

This is not only a problem because of the missing `sha256` or the hardcoded `build_string`, but this also opens the door for cache poison attacks if you control a conda channel.

### Offered solution

You can either install a conda package from a path ([get_or_fetch_from_path](https://github.com/conda/rattler/blob/c7e2197d0bf8cd50a629e352e644ced7c752d9e7/crates/rattler_cache/src/package_cache/mod.rs#L186)) or from an url ([get_or_fetch_from_url](https://github.com/conda/rattler/blob/c7e2197d0bf8cd50a629e352e644ced7c752d9e7/crates/rattler_cache/src/package_cache/mod.rs#L170)). This PR introduces a new property `location_hash` in the cache key, which is either a hash of the Url without the basic auth, or a hash of the path.

This way we also encode into the key where the package is coming from and therefore avoid running into cache hits with different packages with the same properties.

It might be also good to add the same logic to the

### Important notes
* This solution will invalidate all existing caches and users will need to install all the packages from the source again.
* We might want to add the same logic to the [run_exports_cache](https://github.com/conda/rattler/tree/main/crates/rattler_cache/src/run_exports_cache). As far as I can tell the `run_exports_cache` is currently not being used anywhere in the code and it is also quite new, so not sure what the plans are here - cc @nichmor 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
