### PR TITLE
feat: allow to pass a semaphore for concurrency control

### DIFF
--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -78,7 +78,7 @@ impl Directories {
     /// Create a fake Directories struct for testing ONLY
     pub fn fake_folders(path: &Path) -> Directories {
         // Prepare the directories
-        fs::create_dir_all(&path).unwrap();
+        fs::create_dir_all(path).unwrap();
 
         let terminal_settings_json = path.join("terminal_settings.json");
         if !terminal_settings_json.exists() {
@@ -464,7 +464,7 @@ impl WindowsMenu {
         };
 
         for location in &self.directories.windows_terminal_settings_files {
-            terminal::add_windows_terminal_profile(&location, &profile)?;
+            terminal::add_windows_terminal_profile(location, &profile)?;
             tracker.terminal_profiles.push(WindowsTerminalProfile {
                 configuration_file: location.clone(),
                 identifier: profile.name.clone(),

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 pub use barrier_cell::BarrierCell;
-pub use builder::GatewayBuilder;
+pub use builder::{GatewayBuilder, MaxConcurrency};
 pub use channel_config::{ChannelConfig, SourceConfig};
 use dashmap::{mapref::entry::Entry, DashMap};
 pub use error::GatewayError;
@@ -167,7 +167,7 @@ struct GatewayInner {
     package_cache: PackageCache,
 
     /// A semaphore to limit the number of concurrent requests.
-    concurrent_requests_semaphore: Arc<tokio::sync::Semaphore>,
+    concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
 }
 
 impl GatewayInner {

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/index.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/index.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use futures::future::OptionFuture;
 use reqwest_middleware::ClientWithMiddleware;
 use url::Url;
 

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/index.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/index.rs
@@ -17,7 +17,7 @@ const REPODATA_SHARDS_FILENAME: &str = "repodata_shards.msgpack.zst";
 pub async fn fetch_index(
     client: ClientWithMiddleware,
     channel_base_url: &Url,
-    concurrent_requests_semaphore: Arc<tokio::sync::Semaphore>,
+    concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
     reporter: Option<&dyn Reporter>,
 ) -> Result<ShardedRepodata, GatewayError> {
     // Determine the actual URL to use for the request

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use futures::future::OptionFuture;
 use http::StatusCode;
 use rattler_conda_types::{Channel, PackageName, RepoDataRecord, ShardedRepodata};
 use reqwest_middleware::ClientWithMiddleware;

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
@@ -27,7 +27,7 @@ pub struct ShardedSubdir {
     shards_base_url: Url,
     package_base_url: Url,
     sharded_repodata: ShardedRepodata,
-    concurrent_requests_semaphore: Arc<tokio::sync::Semaphore>,
+    concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
 }
 
 impl ShardedSubdir {

--- a/crates/rattler_repodata_gateway/src/lib.rs
+++ b/crates/rattler_repodata_gateway/src/lib.rs
@@ -1,11 +1,12 @@
 #![deny(missing_docs)]
 
-//! `rattler_repodata_gateway` is a crate that provides functionality to interact with Conda
-//! repodata. It currently provides functionality to download and cache `repodata.json` files
-//! through the [`fetch::fetch_repo_data`] function.
+//! `rattler_repodata_gateway` is a crate that provides functionality to
+//! interact with Conda repodata. It currently provides functionality to
+//! download and cache `repodata.json` files through the
+//! [`fetch::fetch_repo_data`] function.
 //!
-//! In the future this crate will also provide more high-level functionality to query information
-//! about specific packages from different sources.
+//! In the future this crate will also provide more high-level functionality to
+//! query information about specific packages from different sources.
 //!
 //! # Install
 //! Add the following to your *Cargo.toml*:
@@ -22,8 +23,8 @@
 //! ```
 //!
 //! # Examples
-//! Below is a basic example that shows how to retrieve and cache the repodata for a conda channel
-//! using the [`fetch::fetch_repo_data`] function:
+//! Below is a basic example that shows how to retrieve and cache the repodata
+//! for a conda channel using the [`fetch::fetch_repo_data`] function:
 //!
 //! ```no_run
 //! use std::{default::Default, path::PathBuf};
@@ -72,5 +73,6 @@ mod gateway;
 
 #[cfg(feature = "gateway")]
 pub use gateway::{
-    ChannelConfig, Gateway, GatewayBuilder, GatewayError, RepoData, SourceConfig, SubdirSelection,
+    ChannelConfig, Gateway, GatewayBuilder, GatewayError, MaxConcurrency, RepoData, SourceConfig,
+    SubdirSelection,
 };


### PR DESCRIPTION
To control the maximum number of concurrent requests you can pass a number to `with_max_concurrent_requests`. This will limit the maximum number of requests that are executed concurrently. 

However, sometimes another part of the application might also be performing requests which could cause more requests to be made. This PR modifies the code to allow passing in a semaphore to control the concurrency which can be shared with other parts of the code.