### PR TITLE
fix: use `create_dir_all` for `.trash` directory on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6550,6 +6550,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bin"
+version = "0.1.0"
+dependencies = [
+ "rattler_solve",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/rattler/src/install/unlink.rs
+++ b/crates/rattler/src/install/unlink.rs
@@ -156,18 +156,10 @@ pub async fn empty_trash(target_prefix: &Path) -> Result<(), UnlinkError> {
 
 async fn move_to_trash(target_prefix: &Path, path: &Path) -> Result<(), UnlinkError> {
     let mut trash_dest = target_prefix.join(".trash");
-    match tokio::fs::try_exists(&trash_dest).await {
-        Ok(true) => {}
-        Ok(false) => tokio_fs::create_dir(&trash_dest).await.map_err(|e| {
-            UnlinkError::FailedToCreateDirectory(trash_dest.to_string_lossy().to_string(), e)
-        })?,
-        Err(e) => {
-            return Err(UnlinkError::FailedToTestExistence(
-                trash_dest.to_string_lossy().to_string(),
-                e,
-            ))
-        }
-    }
+    tokio_fs::create_dir_all(&trash_dest).await.map_err(|e| {
+        UnlinkError::FailedToCreateDirectory(trash_dest.to_string_lossy().to_string(), e)
+    })?;
+
     let mut new_filename = OsString::new();
     if let Some(file_name) = path.file_name() {
         new_filename.push(file_name);


### PR DESCRIPTION
This might fix issues in the `pixi` CI.