### PR TITLE
fix: Don't clone package bytes in rattler-index

### DIFF
--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -155,8 +155,8 @@ pub fn package_record_from_conda(file: &Path) -> std::io::Result<PackageRecord> 
 /// and extract the package record from it.
 pub fn package_record_from_conda_reader(reader: impl Read) -> std::io::Result<PackageRecord> {
     let bytes = reader.bytes().collect::<Result<Vec<u8>, _>>()?;
-    let mut reader = Cursor::new(&bytes);
-    let mut archive = seek::stream_conda_info(&mut reader).expect("Could not open conda file");
+    let reader = Cursor::new(&bytes);
+    let mut archive = seek::stream_conda_info(reader).expect("Could not open conda file");
 
     for entry in archive.entries()?.flatten() {
         let mut entry = entry;

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -127,13 +127,13 @@ pub fn package_record_from_tar_bz2(file: &Path) -> std::io::Result<PackageRecord
 /// and extract the package record from it.
 pub fn package_record_from_tar_bz2_reader(reader: impl Read) -> std::io::Result<PackageRecord> {
     let bytes = reader.bytes().collect::<Result<Vec<u8>, _>>()?;
-    let reader = Cursor::new(bytes.clone());
+    let reader = Cursor::new(&bytes);
     let mut archive = read::stream_tar_bz2(reader);
     for entry in archive.entries()?.flatten() {
         let mut entry = entry;
         let path = entry.path()?;
         if path.as_os_str().eq("info/index.json") {
-            return package_record_from_index_json(bytes, &mut entry);
+            return package_record_from_index_json(&bytes, &mut entry);
         }
     }
     Err(std::io::Error::new(
@@ -155,14 +155,14 @@ pub fn package_record_from_conda(file: &Path) -> std::io::Result<PackageRecord> 
 /// and extract the package record from it.
 pub fn package_record_from_conda_reader(reader: impl Read) -> std::io::Result<PackageRecord> {
     let bytes = reader.bytes().collect::<Result<Vec<u8>, _>>()?;
-    let reader = Cursor::new(bytes.clone());
-    let mut archive = seek::stream_conda_info(reader).expect("Could not open conda file");
+    let mut reader = Cursor::new(&bytes);
+    let mut archive = seek::stream_conda_info(&mut reader).expect("Could not open conda file");
 
     for entry in archive.entries()?.flatten() {
         let mut entry = entry;
         let path = entry.path()?;
         if path.as_os_str().eq("info/index.json") {
-            return package_record_from_index_json(bytes, &mut entry);
+            return package_record_from_index_json(&bytes, &mut entry);
         }
     }
     Err(std::io::Error::new(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

cloning package bytes could get out of hand quickly if you have large packages

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
