### PR TITLE
fix(JS): Remove non-needed top-level awaits

### DIFF
--- a/js-rattler/src/esm.ts
+++ b/js-rattler/src/esm.ts
@@ -6,4 +6,4 @@ import mod from "../pkg/js_rattler_bg.wasm";
 import { initSync } from "../pkg/js_rattler";
 
 //@ts-ignore
-await initSync({ module: await mod() });
+initSync({ module: mod() });


### PR DESCRIPTION
### Description

Rattler was using a top-level await (actually not even needed as it was awaiting a synchronous function), which is not allowed in some contexts like service workers.