### PR TITLE
fix: allow empty info key in repodata.json (#1179)

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -71,7 +71,7 @@ pub struct RepoData {
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 pub struct ChannelInfo {
     /// The channel's subdirectory
-    pub subdir: String,
+    pub subdir: Option<String>,
 
     /// The `base_url` for all package urls. Can be an absolute or relative url.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -196,7 +196,7 @@ async fn index_subdir(
                 tracing::info!("Could not find repodata.json. Creating new one.");
                 RepoData {
                     info: Some(ChannelInfo {
-                        subdir: subdir.to_string(),
+                        subdir: Some(subdir.to_string()),
                         base_url: None,
                     }),
                     packages: HashMap::default(),
@@ -369,7 +369,7 @@ async fn index_subdir(
 
     let repodata = RepoData {
         info: Some(ChannelInfo {
-            subdir: subdir.to_string(),
+            subdir: Some(subdir.to_string()),
             base_url: None,
         }),
         packages,


### PR DESCRIPTION
### Description

A follow-up of this issue https://github.com/conda/rattler/issues/1179 to unblock myself from using `pixi` at work. I'm not really a Rust developer but it looks like this change is easy enough for me to handle, feedback is welcome.

Did some preliminary tests integrating with `pixi` seems to suggest this fixes my issue, no test was added because this is a data model change, and should be protected by any existing ones.