### PR TITLE
refactor: change default value of  menuinst windows `quicklaunch` to `false`

### DIFF
--- a/crates/rattler_menuinst/src/schema.rs
+++ b/crates/rattler_menuinst/src/schema.rs
@@ -124,7 +124,7 @@ pub struct Windows {
 
     /// Whether to create a quick launch icon in addition to the Start Menu item.
     ///
-    /// Defaults to `true` in the original implementation.
+    /// Defaults to `false` in the original implementation.
     pub quicklaunch: Option<bool>,
 
     /// Windows Terminal profile configuration.

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -350,7 +350,7 @@ impl WindowsMenu {
         }
 
         if let Some(quick_launch_dir) = self.directories.quick_launch.as_ref() {
-            if self.item.quicklaunch.unwrap_or(true) {
+            if self.item.quicklaunch.unwrap_or(false) {
                 let quicklaunch_link_path = quick_launch_dir.join(link_name);
                 let shortcut = Shortcut {
                     path: &self.name,


### PR DESCRIPTION
### Description

Update the default value of `quicklaunch` to match menuinst schema.

- https://conda.github.io/menuinst/reference/#menuinst._schema.Windows.quicklaunch
- https://github.com/conda/menuinst/issues/244
- https://github.com/conda/menuinst/pull/272