### PR TITLE
fix: install windows start menu shortcut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4868,9 +4868,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -5863,9 +5863,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",
@@ -7454,18 +7454,16 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938cc23ac49778ac8340e366ddc422b2227ea176edb447e23fc0627608dddadd"
+checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap 2.8.0",
  "memchr",
- "thiserror 2.0.12",
  "time",
  "zopfli",
 ]

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -332,6 +332,24 @@ impl WindowsMenu {
         let args = lex::quote_args(args).join(" ");
 
         let link_name = format!("{}.lnk", self.name);
+
+        // install start menu shortcut
+        let start_menu_link_path = self.directories.start_menu.join(link_name);
+        let shortcut = Shortcut {
+            path: &self.name,
+            description: &self.command.description.resolve(&self.placeholders),
+            filename: &start_menu_link_path,
+            arguments: Some(&args),
+            workdir: Some(&workdir),
+            iconpath: icon.as_deref(),
+            iconindex: Some(0),
+            app_id: Some(&app_id),
+        };
+
+        create_shortcut::create_shortcut(shortcut)?;
+        tracker.shortcuts.push(start_menu_link_path.clone());
+
+        // install desktop shortcut
         if self.item.desktop.unwrap_or(true) {
             let desktop_link_path = self.directories.desktop.join(&link_name);
             let shortcut = Shortcut {
@@ -349,6 +367,7 @@ impl WindowsMenu {
             tracker.shortcuts.push(desktop_link_path.clone());
         }
 
+        // install quicklaunch shortcut
         if let Some(quick_launch_dir) = self.directories.quick_launch.as_ref() {
             if self.item.quicklaunch.unwrap_or(false) {
                 let quicklaunch_link_path = quick_launch_dir.join(link_name);

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -334,7 +334,7 @@ impl WindowsMenu {
         let link_name = format!("{}.lnk", self.name);
 
         // install start menu shortcut
-        let start_menu_link_path = self.directories.start_menu.join(link_name);
+        let start_menu_link_path = self.directories.start_menu.join(&link_name);
         let shortcut = Shortcut {
             path: &self.name,
             description: &self.command.description.resolve(&self.placeholders),


### PR DESCRIPTION
### Description

Add missing windows start menu shortcut installation.

In menuinst, the windows start menu shortcut is installed implicitly. This pr will match the windows installation behaveor to menuinst.

This could fix https://github.com/prefix-dev/pixi/issues/3400
