### PR TITLE
feat: add support for md5 hash in direct url requests and add it to cache key

### DIFF
--- a/crates/rattler_cache/src/package_cache/cache_key.rs
+++ b/crates/rattler_cache/src/package_cache/cache_key.rs
@@ -1,6 +1,6 @@
 use rattler_conda_types::package::ArchiveIdentifier;
 use rattler_conda_types::PackageRecord;
-use rattler_digest::Sha256Hash;
+use rattler_digest::{Md5Hash, Sha256Hash};
 use std::fmt::{Display, Formatter};
 
 /// Provides a unique identifier for packages in the cache.
@@ -11,6 +11,7 @@ pub struct CacheKey {
     pub(crate) version: String,
     pub(crate) build_string: String,
     pub(crate) sha256: Option<Sha256Hash>,
+    pub(crate) md5: Option<Md5Hash>,
 }
 
 impl CacheKey {
@@ -25,12 +26,29 @@ impl CacheKey {
         self.sha256 = sha256;
         self
     }
+
+    /// Adds a md5 hash of the archive.
+    pub fn with_md5(mut self, md5: Md5Hash) -> Self {
+        self.md5 = Some(md5);
+        self
+    }
+
+    /// Potentially adds a md5 hash of the archive.
+    pub fn with_opt_md5(mut self, md5: Option<Md5Hash>) -> Self {
+        self.md5 = md5;
+        self
+    }
 }
 
 impl CacheKey {
     /// Return the sha256 hash of the package if it is known.
     pub fn sha256(&self) -> Option<Sha256Hash> {
         self.sha256
+    }
+
+    /// Return the md5 hash of the package if it is known.
+    pub fn md5(&self) -> Option<Md5Hash> {
+        self.md5
     }
 }
 
@@ -41,6 +59,7 @@ impl From<ArchiveIdentifier> for CacheKey {
             version: pkg.version,
             build_string: pkg.build_string,
             sha256: None,
+            md5: None,
         }
     }
 }
@@ -52,6 +71,7 @@ impl From<&PackageRecord> for CacheKey {
             version: record.version.to_string(),
             build_string: record.build.clone(),
             sha256: record.sha256,
+            md5: record.md5,
         }
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/direct_url_query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/direct_url_query.rs
@@ -132,26 +132,13 @@ mod test {
 
         let repodata_record = query.await.unwrap();
 
-        assert_eq!(
-            repodata_record
-                .as_ref()
-                .first()
-                .unwrap()
-                .package_record
-                .name
-                .as_normalized(),
-            "boltons"
-        );
-        assert_eq!(
-            repodata_record
-                .as_ref()
-                .first()
-                .unwrap()
-                .package_record
-                .version
-                .as_str(),
-            "24.0.0"
-        );
+        let record = repodata_record.as_ref().first().unwrap();
+
+        assert_eq!(record.package_record.name.as_normalized(), "boltons");
+        assert_eq!(record.package_record.version.as_str(), "24.0.0");
+
+        // Check that the md5 is filled in for the package record
+        assert!(record.package_record.md5.is_some());
     }
 
     #[tokio::test]
@@ -172,26 +159,10 @@ mod test {
 
         assert_eq!(query.url.clone(), url);
 
-        let repodata_record = query.await.unwrap();
-        assert_eq!(
-            repodata_record
-                .as_ref()
-                .first()
-                .unwrap()
-                .package_record
-                .name
-                .as_normalized(),
-            "zlib"
-        );
-        assert_eq!(
-            repodata_record
-                .as_ref()
-                .first()
-                .unwrap()
-                .package_record
-                .version
-                .as_str(),
-            "1.2.8"
-        );
+        let result = query.await.unwrap();
+        let record = result.as_ref().first().unwrap();
+
+        assert_eq!(record.package_record.name.as_normalized(), "zlib");
+        assert_eq!(record.package_record.version.as_str(), "1.2.8");
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/direct_url_query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/direct_url_query.rs
@@ -6,7 +6,7 @@ use rattler_conda_types::{
     package::{ArchiveIdentifier, IndexJson, PackageFile},
     ConvertSubdirError, PackageRecord, RepoDataRecord,
 };
-use rattler_digest::Sha256Hash;
+use rattler_digest::{Md5Hash, Sha256Hash};
 use url::Url;
 
 pub(crate) struct DirectUrlQuery {
@@ -14,6 +14,8 @@ pub(crate) struct DirectUrlQuery {
     url: Url,
     /// Optional Sha256 of the file
     sha256: Option<Sha256Hash>,
+    /// Optional MD5 of the file
+    md5: Option<Md5Hash>,
     /// The client to use for fetching the package
     client: reqwest_middleware::ClientWithMiddleware,
     /// The cache to use for storing the package
@@ -38,10 +40,12 @@ impl DirectUrlQuery {
         package_cache: PackageCache,
         client: reqwest_middleware::ClientWithMiddleware,
         sha256: Option<Sha256Hash>,
+        md5: Option<Md5Hash>,
     ) -> Self {
         Self {
             url,
             sha256,
+            md5,
             client,
             package_cache,
         }
@@ -80,7 +84,7 @@ impl DirectUrlQuery {
             index_json,
             None,        // Size
             self.sha256, // sha256
-            None,        // md5
+            self.md5,    // md5
         )?;
 
         tracing::debug!("Package record build from direct url: {:?}", package_record);
@@ -122,7 +126,7 @@ mod test {
         .unwrap();
         let package_cache = PackageCache::new(PathBuf::from("/tmp"));
         let client = reqwest_middleware::ClientWithMiddleware::from(reqwest::Client::new());
-        let query = DirectUrlQuery::new(url.clone(), package_cache, client, None);
+        let query = DirectUrlQuery::new(url.clone(), package_cache, client, None, None);
 
         assert_eq!(query.url.clone(), url);
 
@@ -164,7 +168,7 @@ mod test {
         let url = Url::from_file_path(package_path).unwrap();
         let package_cache = PackageCache::new(temp_dir());
         let client = reqwest_middleware::ClientWithMiddleware::from(reqwest::Client::new());
-        let query = DirectUrlQuery::new(url.clone(), package_cache, client, None);
+        let query = DirectUrlQuery::new(url.clone(), package_cache, client, None, None);
 
         assert_eq!(query.url.clone(), url);
 

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -187,6 +187,7 @@ impl RepoDataQuery {
                                 gateway.package_cache.clone(),
                                 gateway.client.clone(),
                                 spec.sha256,
+                                spec.md5,
                             );
 
                             let record = query


### PR DESCRIPTION
This would help a lot when installing explicit environments, because they usually come with `md5` hashes (from the old days...).

The environments look something like this:

```
# This file may be used to create an environment using:
# $ conda create --name <env> --file <this file>
# platform: osx-arm64
@EXPLICIT
https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.1-ha82da77_0.conda#833c4899914bf96caf64b52ef415e319
https://conda.anaconda.org/conda-forge/osx-arm64/micromamba-1.5.12-0.tar.bz2#ef854aa57525cb8d9a87cc1f1d59bd92
```

From which we can construct matchspecs like:

`libcxx[url="https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.1-ha82da77_0.conda", md5="833c4899914bf96caf64b52ef415e319"]`

Which rattler / py-rattler would then install perfectly fine.

cc @johanneskoester 