### PR TITLE
feat: add source location

### DIFF
--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -1,12 +1,12 @@
-use std::{borrow::Cow, cmp::Ordering, hash::Hash};
-use std::collections::BTreeMap;
+use crate::source::SourceLocation;
+use crate::UrlOrPath;
 use rattler_conda_types::{
     ChannelUrl, MatchSpec, Matches, NamelessMatchSpec, PackageRecord, RepoDataRecord,
 };
 use rattler_digest::Sha256Hash;
+use std::collections::BTreeMap;
+use std::{borrow::Cow, cmp::Ordering, hash::Hash};
 use url::Url;
-use crate::source::SourceLocation;
-use crate::UrlOrPath;
 
 /// A locked conda dependency can be either a binary package or a source
 /// package.

--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -1,11 +1,11 @@
 use std::{borrow::Cow, cmp::Ordering, hash::Hash};
-
+use std::collections::BTreeMap;
 use rattler_conda_types::{
     ChannelUrl, MatchSpec, Matches, NamelessMatchSpec, PackageRecord, RepoDataRecord,
 };
 use rattler_digest::Sha256Hash;
 use url::Url;
-
+use crate::source::SourceLocation;
 use crate::UrlOrPath;
 
 /// A locked conda dependency can be either a binary package or a source
@@ -151,6 +151,10 @@ pub struct CondaSourceData {
 
     /// The input hash of the package
     pub input: Option<InputHash>,
+
+    /// Information about packages that should be built from source instead of binary.
+    /// This maps from a normalized package name to location of the source.
+    pub sources: BTreeMap<String, SourceLocation>,
 }
 
 impl From<CondaSourceData> for CondaPackageData {

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -92,6 +92,7 @@ mod pypi;
 mod pypi_indexes;
 mod url_or_path;
 mod utils;
+pub mod source;
 
 pub use builder::{LockFileBuilder, LockedPackage};
 pub use channel::Channel;

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -90,9 +90,9 @@ mod hash;
 mod parse;
 mod pypi;
 mod pypi_indexes;
+pub mod source;
 mod url_or_path;
 mod utils;
-pub mod source;
 
 pub use builder::{LockFileBuilder, LockedPackage};
 pub use channel::Channel;

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -548,6 +548,7 @@ mod test {
     #[case::v5_with_and_without_purl("v5/similar-with-and-without-purl.yml")]
     #[case::v6_conda_source_path("v6/conda-path-lock.yml")]
     #[case::v6_derived_channel("v6/derived-channel-lock.yml")]
+    #[case::v6_sources("v6/sources-lock.yml")]
     fn test_parse(#[case] file_name: &str) {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../test-data/conda-lock")

--- a/crates/rattler_lock/src/parse/models/v6/mod.rs
+++ b/crates/rattler_lock/src/parse/models/v6/mod.rs
@@ -1,5 +1,6 @@
 mod conda_package_data;
 mod pypi_package_data;
+mod source_data;
 
 pub(crate) use conda_package_data::CondaPackageDataModel;
 pub(crate) use pypi_package_data::PypiPackageDataModel;

--- a/crates/rattler_lock/src/parse/models/v6/source_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/source_data.rs
@@ -1,0 +1,186 @@
+use std::borrow::Cow;
+
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_with::{serde_as, DeserializeAs, SerializeAs};
+use url::Url;
+
+use crate::source::{
+    GitReference, GitSourceLocation, PathSourceLocation, SourceLocation, UrlSourceLocation,
+};
+
+#[serde_as]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Clone)]
+struct SourceLocationData<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<Cow<'a, Url>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<rattler_digest::serde::SerializableHash::<rattler_digest::Md5>>")]
+    pub md5: Option<rattler_digest::Md5Hash>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<rattler_digest::serde::SerializableHash::<rattler_digest::Sha256>>")]
+    pub sha256: Option<rattler_digest::Sha256Hash>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git: Option<Cow<'a, Url>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rev: Option<Cow<'a, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<Cow<'a, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<Cow<'a, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subdirectory: Option<Cow<'a, String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<Cow<'a, str>>,
+}
+
+impl<'a> From<&'a SourceLocation> for SourceLocationData<'a> {
+    fn from(value: &'a SourceLocation) -> Self {
+        match value {
+            SourceLocation::Url(location) => location.into(),
+            SourceLocation::Git(location) => location.into(),
+            SourceLocation::Path(location) => location.into(),
+        }
+    }
+}
+
+impl<'a> From<&'a UrlSourceLocation> for SourceLocationData<'a> {
+    fn from(value: &'a UrlSourceLocation) -> Self {
+        Self {
+            url: Some(Cow::Borrowed(&value.url)),
+            md5: value.md5.clone(),
+            sha256: value.sha256.clone(),
+            git: None,
+            rev: None,
+            branch: None,
+            tag: None,
+            subdirectory: None,
+            path: None,
+        }
+    }
+}
+
+impl<'a> From<&'a GitSourceLocation> for SourceLocationData<'a> {
+    fn from(value: &'a GitSourceLocation) -> Self {
+        Self {
+            url: None,
+            md5: None,
+            sha256: None,
+            git: Some(Cow::Borrowed(&value.git)),
+            rev: if let Some(GitReference::Rev(rev)) = value.rev.as_ref() {
+                Some(Cow::Borrowed(rev))
+            } else {
+                None
+            },
+            branch: if let Some(GitReference::Branch(branch)) = value.rev.as_ref() {
+                Some(Cow::Borrowed(branch))
+            } else {
+                None
+            },
+            tag: if let Some(GitReference::Tag(tag)) = value.rev.as_ref() {
+                Some(Cow::Borrowed(tag))
+            } else {
+                None
+            },
+            subdirectory: value.subdirectory.as_ref().map(Cow::Borrowed),
+            path: None,
+        }
+    }
+}
+
+impl<'a> From<&'a PathSourceLocation> for SourceLocationData<'a> {
+    fn from(value: &'a PathSourceLocation) -> Self {
+        Self {
+            url: None,
+            md5: None,
+            sha256: None,
+            git: None,
+            rev: None,
+            branch: None,
+            tag: None,
+            subdirectory: None,
+            path: Some(Cow::Borrowed(value.path.as_str())),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SourceLocationError {
+    #[error("must specify exactly one of `url`, `path` or `git`")]
+    MissingOrMultipleSourceRoots,
+
+    #[error("must specify none or exactly one of `branch`, `tag` or `rev`")]
+    MultipleGitReferences,
+}
+
+impl<'a> TryFrom<SourceLocationData<'a>> for SourceLocation {
+    type Error = SourceLocationError;
+
+    fn try_from(value: SourceLocationData<'a>) -> Result<Self, Self::Error> {
+        let SourceLocationData {
+            url,
+            md5,
+            sha256,
+            path,
+            git,
+            rev,
+            branch,
+            tag,
+            subdirectory,
+        } = value;
+
+        let count = url.is_some() as u8 + path.is_some() as u8 + git.is_some() as u8;
+        if count != 1 {
+            return Err(SourceLocationError::MissingOrMultipleSourceRoots);
+        }
+
+        if let Some(url) = url {
+            let url = url.into_owned();
+            Ok(SourceLocation::Url(UrlSourceLocation { url, md5, sha256 }))
+        } else if let Some(path) = path {
+            let path = path.into_owned().into();
+            Ok(SourceLocation::Path(PathSourceLocation { path }))
+        } else if let Some(git) = git {
+            let git = git.into_owned();
+            let rev = match (rev, branch, tag) {
+                (Some(rev), None, None) => Some(GitReference::Rev(rev.into_owned())),
+                (None, Some(branch), None) => Some(GitReference::Branch(branch.into_owned())),
+                (None, None, Some(tag)) => Some(GitReference::Tag(tag.into_owned())),
+                (None, None, None) => None,
+                _ => return Err(SourceLocationError::MultipleGitReferences),
+            };
+
+            Ok(SourceLocation::Git(GitSourceLocation {
+                git,
+                rev,
+                subdirectory: subdirectory.map(|subdirectory| subdirectory.into_owned()),
+            }))
+        } else {
+            unreachable!("we already checked that exactly one of url, path or git is set")
+        }
+    }
+}
+
+pub struct SourceLocationSerializer;
+
+impl SerializeAs<SourceLocation> for SourceLocationSerializer {
+    fn serialize_as<S>(source: &SourceLocation, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let data = SourceLocationData::from(source);
+        data.serialize(serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, SourceLocation> for SourceLocationSerializer {
+    fn deserialize_as<D>(deserializer: D) -> Result<SourceLocation, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        SourceLocationData::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v6__sources-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v6__sources-lock.yml.snap
@@ -1,0 +1,39 @@
+---
+source: crates/rattler_lock/src/lib.rs
+expression: conda_lock
+---
+version: 6
+environments:
+  default:
+    channels:
+      - url: "https://conda.anaconda.org/conda-forge/"
+    packages:
+      win-64:
+        - conda: child-package
+packages:
+  - conda: child-package
+    name: child-package
+    version: 0.1.0
+    build: pyhbf21a9e_0
+    subdir: noarch
+    depends:
+      - path
+      - git_tag
+      - git_rev
+      - git_branch
+    sources:
+      git_branch:
+        git: "https://github.com/example/baz.git"
+        branch: foobar
+      git_rev:
+        git: "https://github.com/example/baz.git"
+        rev: deadbeaf
+      git_tag:
+        git: "https://github.com/example/baz.git"
+        tag: v0.1.0
+      path:
+        path: foobar
+      url:
+        url: "https://example.com/foobar.tar.gz"
+        md5: 1234567890abcdef1234567890abcdef
+        sha256: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef

--- a/crates/rattler_lock/src/source.rs
+++ b/crates/rattler_lock/src/source.rs
@@ -1,0 +1,65 @@
+//! Provides data types that are used to describe the location of a source
+//! package.
+
+use rattler_digest::{Md5Hash, Sha256Hash};
+use typed_path::Utf8TypedPathBuf;
+use url::Url;
+
+/// Describes the source location of a package.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum SourceLocation {
+    /// The source is stored as a downloadable archive
+    Url(UrlSourceLocation),
+
+    /// The source is stored in a git repository
+    Git(GitSourceLocation),
+
+    /// The source is stored on the local filesystem
+    Path(PathSourceLocation),
+}
+
+/// A specification of a source archive from a URL.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct UrlSourceLocation {
+    /// The URL of the package contents
+    pub url: Url,
+
+    /// The md5 hash of the archive
+    pub md5: Option<Md5Hash>,
+
+    /// The sha256 hash of the archive
+    pub sha256: Option<Sha256Hash>,
+}
+
+/// A specification of source from a git repository.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GitSourceLocation {
+    /// The git url of the package which can contain git+ prefixes.
+    pub git: Url,
+
+    /// The git revision of the package
+    pub rev: Option<GitReference>,
+
+    /// The git subdirectory of the package
+    pub subdirectory: Option<String>,
+}
+
+/// A reference to a specific commit in a git repository.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GitReference {
+    /// The HEAD commit of a branch.
+    Branch(String),
+
+    /// A specific tag.
+    Tag(String),
+
+    /// A specific commit.
+    Rev(String),
+}
+
+/// Source located somewhere on the filesystem.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PathSourceLocation {
+    /// The path to the package. Either a directory or an archive.
+    pub path: Utf8TypedPathBuf,
+}

--- a/test-data/conda-lock/v6/sources-lock.yml
+++ b/test-data/conda-lock/v6/sources-lock.yml
@@ -17,8 +17,6 @@ packages:
       - git_tag
       - git_rev
       - git_branch
-    # This should cause the lock-file to be invalid because `foobar` should be a source package,
-    # but it is installed in the environment as a binary package.
     sources:
       path:
         path: "foobar"

--- a/test-data/conda-lock/v6/sources-lock.yml
+++ b/test-data/conda-lock/v6/sources-lock.yml
@@ -1,0 +1,37 @@
+version: 6
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      win-64:
+        - conda: child-package
+packages:
+  - conda: child-package
+    name: child-package
+    version: 0.1.0
+    build: pyhbf21a9e_0
+    subdir: noarch
+    depends:
+      - path
+      - git_tag
+      - git_rev
+      - git_branch
+    # This should cause the lock-file to be invalid because `foobar` should be a source package,
+    # but it is installed in the environment as a binary package.
+    sources:
+      path:
+        path: "foobar"
+      git_tag:
+        git: https://github.com/example/baz.git
+        tag: v0.1.0
+      git_rev:
+        git: https://github.com/example/baz.git
+        rev: deadbeaf
+      git_branch:
+        git: https://github.com/example/baz.git
+        branch: foobar
+      url:
+        url: https://example.com/foobar.tar.gz
+        sha256: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+        md5: 1234567890abcdef1234567890abcdef


### PR DESCRIPTION
This PR adds the `sources` field to source dependencies to allow specifying that a given dependency should come from a specific source location. This will enable us to lock where dependencies should come from.

This is WIP for now because I need to add way more tests.