### PR TITLE
feat: more helpful error when failing to persist repodata

### DIFF
--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -1,6 +1,8 @@
 //! This module provides functionality to download and cache `repodata.json`
 //! from a remote location.
 
+use std::path::PathBuf;
+
 use cfg_if::cfg_if;
 use rattler_redaction::Redact;
 use url::Url;
@@ -49,8 +51,8 @@ pub enum FetchRepoDataError {
     #[error("failed to create temporary file for repodata.json")]
     FailedToCreateTemporaryFile(#[source] std::io::Error),
 
-    #[error("failed to persist temporary repodata.json file")]
-    FailedToPersistTemporaryFile(#[from] tempfile::PersistError),
+    #[error("failed to persist temporary repodata.json file to {1:?}")]
+    FailedToPersistTemporaryFile(tempfile::PersistError, PathBuf),
 
     #[error("failed to get metadata from repodata.json file")]
     FailedToGetMetadata(#[source] std::io::Error),

--- a/crates/rattler_repodata_gateway/src/fetch/with_cache.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/with_cache.rs
@@ -490,8 +490,10 @@ pub async fn fetch_repo_data(
     let repo_data_destination_path = repo_data_json_path.clone();
     let repo_data_json_metadata = tokio::task::spawn_blocking(move || {
         let file = temp_file
-            .persist(repo_data_destination_path)
-            .map_err(FetchRepoDataError::FailedToPersistTemporaryFile)?;
+            .persist(repo_data_destination_path.clone())
+            .map_err(|e| {
+                FetchRepoDataError::FailedToPersistTemporaryFile(e, repo_data_destination_path)
+            })?;
 
         // Determine the last modified date and size of the repodata.json file. We store
         // these values in the cache to link the cache to the corresponding


### PR DESCRIPTION
Does printing the PathBuf with `{1:?}` work?