### PR TITLE
fix: downgrade `async-compression`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lto = true
 anyhow = "1.0.97"
 archspec = "0.1.3"
 assert_matches = "1.5.0"
-async-compression = { version = "0.4.22", features = [
+async-compression = { version = "0.4.19", features = [
   "gzip",
   "tokio",
   "bzip2",


### PR DESCRIPTION
This downgrades `async-compression` since we otherwise encounter a dependency conflict on the pixi side:

```
error: failed to select a version for `async-compression`.
    ... required by package `uv-extract v0.0.1 (https://github.com/astral-sh/uv?tag=0.6.9#3d946027)`
    ... which satisfies git dependency `uv-extract` of package `uv-distribution v0.0.1 (https://github.com/astral-sh/uv?tag=0.6.9#3d946027)`
    ... which satisfies git dependency `uv-distribution` of package `pixi v0.44.0 (/var/home/julian/Projekte/github.com/prefix-dev/pixi-1)`
versions that meet the requirements `^0.4.12` are: 0.4.22, 0.4.21, 0.4.20, 0.4.19, 0.4.18, 0.4.17, 0.4.16, 0.4.15, 0.4.14, 0.4.13, 0.4.12

the package `async-compression` links to the native library `lzma`, but it conflicts with a previous package which links to `lzma` as well:
package `uv-extract v0.0.1 (https://github.com/astral-sh/uv?tag=0.6.9#3d946027)`
    ... which satisfies git dependency `uv-extract` of package `uv-distribution v0.0.1 (https://github.com/astral-sh/uv?tag=0.6.9#3d946027)`
    ... which satisfies git dependency `uv-distribution` of package `pixi v0.44.0 (/var/home/julian/Projekte/github.com/prefix-dev/pixi-1)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "lzma"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

all possible versions conflict with previously selected packages.

  previously selected package `async-compression v0.4.22`
    ... which satisfies dependency `async-compression = "^0.4.20"` of package `rattler_repodata_gateway v0.22.3 (/var/home/julian/Projekte/github.com/prefix-dev/rattler/crates/rattler_repodata_gateway)`
    ... which satisfies path dependency `rattler_repodata_gateway` of package `pixi v0.44.0 (/var/home/julian/Projekte/github.com/prefix-dev/pixi-1)`

failed to select a version for `async-compression` which could resolve this conflict
```

