### PR TITLE
feat: derive `Debug` and `Clone` for `SerializableHash`

### DIFF
--- a/crates/rattler_digest/src/serde.rs
+++ b/crates/rattler_digest/src/serde.rs
@@ -58,6 +58,7 @@ where
 }
 
 /// Wrapper type for easily serializing a Hash
+#[derive(Debug, Clone)]
 pub struct SerializableHash<T: Digest>(pub Output<T>);
 
 impl<T: Digest> Serialize for SerializableHash<T>


### PR DESCRIPTION
This allows us to derive `Clone` for more types on the pixi side
