### PR TITLE
fix: upgrade simd-json and downgrade zip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,11 +2302,11 @@ dependencies = [
 
 [[package]]
 name = "halfbrown"
-version = "0.3.0"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -2321,6 +2321,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -5582,11 +5586,11 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simd-json"
-version = "0.15.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b5602e4f1f7d358956f94cac1eff59220f34cf9e26d49f5fde5acef851cbed"
+checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.2.15",
  "halfbrown",
  "ref-cast",
  "serde",
@@ -6489,9 +6493,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-trait"
-version = "0.11.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
+checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
 dependencies = [
  "float-cmp",
  "halfbrown",
@@ -7538,9 +7542,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
+checksum = "febbe83a485467affa75a75d28dc7494acd2f819e549536c47d46b3089b56164"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ retry-policies = { version = "0.4.0", default-features = false }
 rmp-serde = { version = "1.3.0" }
 rstest = { version = "0.25.0" }
 rstest_reuse = "0.7.0"
-simd-json = { version = "0.15.0", features = ["serde_impl"] }
+simd-json = { version = "0.14.0", features = ["serde_impl"] }
 self_cell = "1.1.0"
 serde = { version = "1.0.219" }
 serde_json = { version = "1.0.140" }
@@ -175,5 +175,5 @@ wasmtimer = "0.4.1"
 which = "7.0.2"
 windows-sys = { version = "0.59.0", default-features = false }
 winver = { version = "1.0.0" }
-zip = { version = "2.5.0", default-features = false }
+zip = { version = "2.6.0", default-features = false }
 zstd = { version = "0.13.3", default-features = false }

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -98,7 +98,10 @@ pub fn extract_conda_via_buffering(
     compute_hashes(md5_reader)
 }
 
-fn extract_zipfile(zip_file: ZipFile<'_>, destination: &Path) -> Result<(), ExtractError> {
+fn extract_zipfile<R: std::io::Read>(
+    zip_file: ZipFile<'_, R>,
+    destination: &Path,
+) -> Result<(), ExtractError> {
     // If an error occurs while we are reading the contents of the zip we don't want to
     // seek to the end of the file. Using [`ManuallyDrop`] we prevent `drop` to be called on
     // the `file` in case the stack unwinds.


### PR DESCRIPTION
## Downgrade simd-json

With newer simd-json, you also need a newer version of a transient dependency which needs edition2024, which requires a Rust 1.85, which in turn fails to compile with uv on the pixi side

## Upgrade zip

zip 2.6.0 introduced a breaking change without bumping the version number accordingly. This makes it very easy to get to a situation where rattler refuses to compile
