### PR TITLE
refactor: change `InstallOptions::target_prefix` to `Option<PathBuf>`

### DIFF
--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -58,7 +58,7 @@ pub struct Installer {
     reporter: Option<Arc<dyn Reporter>>,
     target_platform: Option<Platform>,
     apple_code_sign_behavior: AppleCodeSignBehavior,
-    alternative_target_prefix: Option<Prefix>,
+    alternative_target_prefix: Option<PathBuf>,
     reinstall_packages: Option<HashSet<PackageName>>,
     // TODO: Determine upfront if these are possible.
     link_options: LinkOptions,

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -151,7 +151,7 @@ pub struct InstallOptions {
     /// However, in exceptional cases you might want to use a different prefix
     /// than the one that is being installed to. This field allows you to do
     /// that. When its set this is used instead of the target directory.
-    pub target_prefix: Option<Prefix>,
+    pub target_prefix: Option<PathBuf>,
 
     /// Instead of reading the `paths.json` file from the package directory
     /// itself, use the data specified here.


### PR DESCRIPTION
Closes #1238 
This PR changes the `InstallOptions::target_prefix` to `Option<PathBuf>`. 