### PR TITLE
feat: add resolver options to lock-file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,6 +4414,7 @@ dependencies = [
  "pep508_rs",
  "rattler_conda_types",
  "rattler_digest",
+ "rattler_solve",
  "rstest",
  "serde",
  "serde-value",

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -17,6 +17,7 @@ indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.1.1", default-features = false }
+rattler_solve = { path = "../rattler_solve", version="1.4.4", default-features = false, features = ["serde"] }
 file_url = { path = "../file_url", version = "0.2.4" }
 pep508_rs = { workspace = true }
 pep440_rs = { workspace = true }

--- a/crates/rattler_lock/src/builder.rs
+++ b/crates/rattler_lock/src/builder.rs
@@ -6,7 +6,6 @@ use std::{
     sync::Arc,
 };
 
-use fxhash::FxHashMap;
 use indexmap::{IndexMap, IndexSet};
 use pep508_rs::ExtraName;
 use rattler_conda_types::{Platform, Version};
@@ -14,7 +13,8 @@ use rattler_conda_types::{Platform, Version};
 use crate::{
     file_format_version::FileFormatVersion, Channel, CondaBinaryData, CondaPackageData,
     CondaSourceData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
-    LockedPackageRef, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, UrlOrPath,
+    LockedPackageRef, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, ResolverOptions,
+    UrlOrPath,
 };
 
 /// Information about a single locked package in an environment.
@@ -153,20 +153,35 @@ impl LockFileBuilder {
         Self::default()
     }
 
-    /// Sets the pypi indexes for an environment.
-    pub fn set_pypi_indexes(
-        &mut self,
-        environment_data: impl Into<String>,
-        indexes: PypiIndexes,
-    ) -> &mut Self {
+    /// Helper function that returns the environment for the environment with the given name.
+    fn environment_data(&mut self, environment_data: impl Into<String>) -> &mut EnvironmentData {
         self.environments
             .entry(environment_data.into())
             .or_insert_with(|| EnvironmentData {
                 channels: vec![],
-                packages: FxHashMap::default(),
+                packages: HashMap::default(),
                 indexes: None,
+                options: ResolverOptions::default(),
             })
-            .indexes = Some(indexes);
+    }
+
+    /// Sets the pypi indexes for an environment.
+    pub fn set_pypi_indexes(
+        &mut self,
+        environment: impl Into<String>,
+        indexes: PypiIndexes,
+    ) -> &mut Self {
+        self.environment_data(environment).indexes = Some(indexes);
+        self
+    }
+
+    /// Sets the options for a particular environment.
+    pub fn set_options(
+        &mut self,
+        environment: impl Into<String>,
+        options: ResolverOptions,
+    ) -> &mut Self {
+        self.environment_data(environment).options = options;
         self
     }
 
@@ -176,14 +191,8 @@ impl LockFileBuilder {
         environment: impl Into<String>,
         channels: impl IntoIterator<Item = impl Into<Channel>>,
     ) -> &mut Self {
-        self.environments
-            .entry(environment.into())
-            .or_insert_with(|| EnvironmentData {
-                channels: vec![],
-                packages: FxHashMap::default(),
-                indexes: None,
-            })
-            .channels = channels.into_iter().map(Into::into).collect();
+        self.environment_data(environment).channels =
+            channels.into_iter().map(Into::into).collect();
         self
     }
 
@@ -198,16 +207,6 @@ impl LockFileBuilder {
         platform: Platform,
         locked_package: CondaPackageData,
     ) -> &mut Self {
-        // Get the environment
-        let environment = self
-            .environments
-            .entry(environment.into())
-            .or_insert_with(|| EnvironmentData {
-                channels: vec![],
-                packages: HashMap::default(),
-                indexes: None,
-            });
-
         let unique_identifier = UniqueCondaIdentifier::from(&locked_package);
 
         // Add the package to the list of packages.
@@ -222,7 +221,7 @@ impl LockFileBuilder {
             .or_insert(locked_package);
 
         // Add the package to the environment that it is intended for.
-        environment
+        self.environment_data(environment)
             .packages
             .entry(platform)
             .or_default()
@@ -243,16 +242,6 @@ impl LockFileBuilder {
         locked_package: PypiPackageData,
         environment_data: PypiPackageEnvironmentData,
     ) -> &mut Self {
-        // Get the environment
-        let environment = self
-            .environments
-            .entry(environment.into())
-            .or_insert_with(|| EnvironmentData {
-                channels: vec![],
-                packages: HashMap::default(),
-                indexes: None,
-            });
-
         // Add the package to the list of packages.
         let package_idx = self.pypi_packages.insert_full(locked_package).0;
         let runtime_idx = self
@@ -261,7 +250,7 @@ impl LockFileBuilder {
             .0;
 
         // Add the package to the environment that it is intended for.
-        environment
+        self.environment_data(environment)
             .packages
             .entry(platform)
             .or_default()
@@ -346,6 +335,16 @@ impl LockFileBuilder {
         indexes: PypiIndexes,
     ) -> Self {
         self.set_pypi_indexes(environment, indexes);
+        self
+    }
+
+    /// Sets the options for an environment.
+    pub fn with_options(
+        mut self,
+        environment: impl Into<String>,
+        options: ResolverOptions,
+    ) -> Self {
+        self.set_options(environment, options);
         self
     }
 

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -87,6 +87,7 @@ mod channel;
 mod conda;
 mod file_format_version;
 mod hash;
+mod options;
 mod parse;
 mod pypi;
 mod pypi_indexes;
@@ -99,6 +100,7 @@ pub use channel::Channel;
 pub use conda::{CondaBinaryData, CondaPackageData, CondaSourceData, ConversionError, InputHash};
 pub use file_format_version::FileFormatVersion;
 pub use hash::PackageHashes;
+pub use options::ResolverOptions;
 pub use parse::ParseCondaLockError;
 pub use pypi::{PypiPackageData, PypiPackageEnvironmentData, PypiSourceTreeHashable};
 pub use pypi_indexes::{FindLinksUrlOrPath, PypiIndexes};
@@ -157,6 +159,9 @@ struct EnvironmentData {
 
     /// The pypi indexes used to solve the environment.
     indexes: Option<PypiIndexes>,
+
+    /// The options that were used to solve the environment.
+    options: ResolverOptions,
 
     /// For each individual platform this environment supports we store the
     /// package identifiers associated with the environment.
@@ -547,6 +552,7 @@ mod test {
     #[case::v6_conda_source_path("v6/conda-path-lock.yml")]
     #[case::v6_derived_channel("v6/derived-channel-lock.yml")]
     #[case::v6_sources("v6/sources-lock.yml")]
+    #[case::v6_options("v6/options-lock.yml")]
     fn test_parse(#[case] file_name: &str) {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../test-data/conda-lock")

--- a/crates/rattler_lock/src/options.rs
+++ b/crates/rattler_lock/src/options.rs
@@ -1,0 +1,20 @@
+use rattler_solve::{ChannelPriority, SolveStrategy};
+
+/// Options that were used during the resolution of the packages stored in the
+/// lock-file. These options strongly influence the outcome of the solve and are
+/// therefore stored along with the locked packages.
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ResolverOptions {
+    /// The strategy that was used to solve the dependencies.
+    #[serde(default, skip_serializing_if = "crate::utils::serde::is_default")]
+    pub strategy: SolveStrategy,
+
+    /// The channel priority that was used to solve the dependencies.
+    #[serde(default, skip_serializing_if = "crate::utils::serde::is_default")]
+    pub channel_priority: ChannelPriority,
+
+    /// Packages after this date have been excluded from the lock file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+}

--- a/crates/rattler_lock/src/parse/deserialize.rs
+++ b/crates/rattler_lock/src/parse/deserialize.rs
@@ -18,7 +18,8 @@ use crate::{
     file_format_version::FileFormatVersion,
     parse::{models, models::v6, V5, V6},
     Channel, CondaPackageData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
-    ParseCondaLockError, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, UrlOrPath,
+    ParseCondaLockError, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, ResolverOptions,
+    UrlOrPath,
 };
 
 #[serde_as]
@@ -43,6 +44,8 @@ struct DeserializableEnvironment {
     channels: Vec<Channel>,
     #[serde(flatten)]
     indexes: Option<PypiIndexes>,
+    #[serde(default)]
+    options: ResolverOptions,
     packages: BTreeMap<Platform, Vec<DeserializablePackageSelector>>,
 }
 
@@ -197,6 +200,7 @@ fn parse_from_lock<P>(
                 EnvironmentData {
                     channels: env.channels,
                     indexes: env.indexes,
+                    options: env.options,
                     packages: env
                         .packages
                         .into_iter()

--- a/crates/rattler_lock/src/parse/serialize.rs
+++ b/crates/rattler_lock/src/parse/serialize.rs
@@ -15,7 +15,7 @@ use crate::{
     file_format_version::FileFormatVersion,
     parse::{models::v6, V6},
     Channel, CondaPackageData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
-    PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, UrlOrPath,
+    PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, ResolverOptions, UrlOrPath,
 };
 
 #[serde_as]
@@ -35,6 +35,8 @@ struct SerializableEnvironment<'a> {
     channels: &'a [Channel],
     #[serde(flatten)]
     indexes: Option<&'a PypiIndexes>,
+    #[serde(default, skip_serializing_if = "crate::utils::serde::is_default")]
+    options: ResolverOptions,
     packages: BTreeMap<Platform, Vec<SerializablePackageSelector<'a>>>,
 }
 
@@ -48,6 +50,7 @@ impl<'a> SerializableEnvironment<'a> {
         SerializableEnvironment {
             channels: &env_data.channels,
             indexes: env_data.indexes.as_ref(),
+            options: env_data.options.clone(),
             packages: env_data
                 .packages
                 .iter()

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -22,7 +22,7 @@ use crate::{
         LocationDerivedFields,
     },
     Channel, CondaPackageData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
-    PackageHashes, PypiPackageData, PypiPackageEnvironmentData, UrlOrPath,
+    PackageHashes, PypiPackageData, PypiPackageEnvironmentData, ResolverOptions, UrlOrPath,
     DEFAULT_ENVIRONMENT_NAME,
 };
 
@@ -258,6 +258,7 @@ pub fn parse_v3_or_lower(
         channels: lock_file.metadata.channels,
         indexes: None,
         packages: per_platform,
+        options: ResolverOptions::default(),
     };
 
     Ok(LockFile {

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v6__options-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v6__options-lock.yml.snap
@@ -1,0 +1,31 @@
+---
+source: crates/rattler_lock/src/lib.rs
+expression: conda_lock
+---
+version: 6
+environments:
+  with-channel-priority:
+    channels: []
+    options:
+      channel-priority: disabled
+    packages: {}
+  with-default-channel-priority:
+    channels: []
+    packages: {}
+  with-default-strategy:
+    channels: []
+    packages: {}
+  with-exclude-newer:
+    channels: []
+    options:
+      exclude-newer: "2025-04-15T12:15:00Z"
+    packages: {}
+  with-strategy:
+    channels: []
+    options:
+      strategy: lowest-version
+    packages: {}
+  without-options:
+    channels: []
+    packages: {}
+packages: []

--- a/crates/rattler_lock/src/utils/serde/mod.rs
+++ b/crates/rattler_lock/src/utils/serde/mod.rs
@@ -3,7 +3,13 @@ mod ordered;
 mod pep440_map_or_vec;
 mod timestamp;
 pub(crate) mod url_or_path;
+
 pub(crate) use match_spec_map_or_vec::MatchSpecMapOrVec;
 pub(crate) use ordered::Ordered;
 pub(crate) use pep440_map_or_vec::Pep440MapOrVec;
 pub(crate) use timestamp::Timestamp;
+
+/// Returns true if the given value is the default value for its type.
+pub(crate) fn is_default<T: Default + PartialEq>(value: &T) -> bool {
+    value == &T::default()
+}

--- a/test-data/conda-lock/v6/options-lock.yml
+++ b/test-data/conda-lock/v6/options-lock.yml
@@ -1,0 +1,32 @@
+version: 6
+environments:
+  without-options:
+    channels: []
+    packages: {}
+    options: {}
+  with-exclude-newer:
+    channels: []
+    packages: {}
+    options:
+      exclude-newer: "2025-04-15T12:15:00+00:00"
+  with-strategy:
+    channels: [ ]
+    packages: { }
+    options:
+      strategy: "lowest-version"
+  with-default-strategy:
+    channels: [ ]
+    packages: { }
+    options:
+      strategy: "highest"
+  with-channel-priority:
+    channels: [ ]
+    packages: { }
+    options:
+      channel-priority: "disabled"
+  with-default-channel-priority:
+    channels: [ ]
+    packages: { }
+    options:
+      channel-priority: "strict"
+packages: []


### PR DESCRIPTION
Adds resolver options to the lock file. These options strongly modify the outcome of the solver. They are stored along the locked package so programs can choose to invalidate the content if these options changed.

The options stored are:

* channel-priority: disabled or strict.
* solve strategy: whether the solver selected the highest versions or the lowest.
* exclude-newer: whether packages after a certain date were excluded.

These correspond to options used by `rattler_solve`.

These changes should both be backward- and forward-compatible. E.g. older clients will ignore the new fields, newer clients with older lock-files will use sane defaults.