### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.24.0"
+version = "0.23.2"
 dependencies = [
  "chrono",
  "file_url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "chrono",
  "file_url",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "chrono",
  "criterion",

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -31,7 +31,7 @@ rattler = { path="../rattler", version = "0.33.5", default-features = false, fea
 rattler_conda_types = { path="../rattler_conda_types", version = "0.32.0", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.22.12", default-features = false, features = ["gcs", "s3"] }
 rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.22.5", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.4.4", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_solve = { path="../rattler_solve", version = "1.4.5", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.10", default-features = false }
 rattler_cache = { path="../rattler_cache", version = "0.3.17", default-features = false }
 rattler_menuinst = { path="../rattler_menuinst", version = "0.2.7", default-features = false }

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.5](https://github.com/conda/rattler/compare/rattler_index-v0.22.4...rattler_index-v0.22.5) - 2025-04-17
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.22.4](https://github.com/conda/rattler/compare/rattler_index-v0.22.3...rattler_index-v0.22.4) - 2025-04-10
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.22.4"
+version = "0.22.5"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.24.0](https://github.com/conda/rattler/compare/rattler_lock-v0.23.1...rattler_lock-v0.24.0) - 2025-04-17
+## [0.23.2](https://github.com/conda/rattler/compare/rattler_lock-v0.23.1...rattler_lock-v0.23.2) - 2025-04-17
 
 ### Fixed
 

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/conda/rattler/compare/rattler_lock-v0.23.1...rattler_lock-v0.24.0) - 2025-04-17
+
+### Fixed
+
+- rename struct and reexport ([#1262](https://github.com/conda/rattler/pull/1262))
+
 ## [0.23.1](https://github.com/conda/rattler/compare/rattler_lock-v0.23.0...rattler_lock-v0.23.1) - 2025-04-15
 
 ### Added

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.1"
+version = "0.24.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -17,7 +17,7 @@ indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.1.1", default-features = false }
-rattler_solve = { path = "../rattler_solve", version="1.4.4", default-features = false, features = ["serde"] }
+rattler_solve = { path = "../rattler_solve", version = "1.4.5", default-features = false, features = ["serde"] }
 file_url = { path = "../file_url", version = "0.2.4" }
 pep508_rs = { workspace = true }
 pep440_rs = { workspace = true }

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.24.0"
+version = "0.23.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.5](https://github.com/conda/rattler/compare/rattler_solve-v1.4.4...rattler_solve-v1.4.5) - 2025-04-17
+
+### Other
+
+- bump resolvo 0.9.0 ([#1259](https://github.com/conda/rattler/pull/1259))
+
 ## [1.4.4](https://github.com/conda/rattler/compare/rattler_solve-v1.4.3...rattler_solve-v1.4.4) - 2025-04-10
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.4.4"
+version = "1.4.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"


### PR DESCRIPTION


## 🤖 New release

* `rattler_solve`: 1.4.4 -> 1.4.5 (✓ API compatible changes)
* `rattler_lock`: 0.23.1 -> 0.23.2 
* `rattler_index`: 0.22.4 -> 0.22.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_solve`

<blockquote>

## [1.4.5](https://github.com/conda/rattler/compare/rattler_solve-v1.4.4...rattler_solve-v1.4.5) - 2025-04-17

### Other

- bump resolvo 0.9.0 ([#1259](https://github.com/conda/rattler/pull/1259))
</blockquote>

## `rattler_lock`

<blockquote>

## [0.24.0](https://github.com/conda/rattler/compare/rattler_lock-v0.23.1...rattler_lock-v0.24.0) - 2025-04-17

### Fixed

- rename struct and reexport ([#1262](https://github.com/conda/rattler/pull/1262))
</blockquote>

## `rattler_index`

<blockquote>

## [0.22.5](https://github.com/conda/rattler/compare/rattler_index-v0.22.4...rattler_index-v0.22.5) - 2025-04-17

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).