### PR TITLE
chore: bump resolvo 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,31 +1773,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -4658,7 +4637,6 @@ dependencies = [
  "chrono",
  "criterion",
  "futures",
- "indexmap 2.9.0",
  "insta",
  "itertools 0.14.0",
  "libc",
@@ -4673,10 +4651,8 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "tempfile",
- "test-log",
  "thiserror 2.0.12",
  "tracing",
- "tracing-subscriber",
  "url",
 ]
 
@@ -4973,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5314eb4b865d39acd1b3cd05eb91b87031bb49fd1278a1bdf8d6680f1389ec29"
+checksum = "996e40b356864ad72942a9ef6815df7f219b7b42ccc791906d3e0a17df5d66ab"
 dependencies = [
  "ahash",
  "bitvec",
@@ -5895,28 +5871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "test-log"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
-dependencies = [
- "env_logger",
- "test-log-macros",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "test-log-macros"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ regex = "1.11.1"
 reqwest = { version = "0.12.15", default-features = false }
 reqwest-middleware = "0.4.2"
 reqwest-retry = "0.7.0"
-resolvo = { version = "0.8.6" }
+resolvo = { version = "0.9.0" }
 retry-policies = { version = "0.4.0", default-features = false }
 rmp-serde = { version = "1.3.0" }
 rstest = { version = "0.25.0" }

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -18,13 +18,11 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 itertools = { workspace = true }
-url = { workspace = true }
 tempfile = { workspace = true }
 rattler_libsolv_c = { path = "../rattler_libsolv_c", version = "1.1.3", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-indexmap = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -36,8 +34,6 @@ rattler_repodata_gateway = { path = "../rattler_repodata_gateway", default-featu
 rstest = { workspace = true }
 serde_json = { workspace = true }
 similar-asserts = { workspace = true }
-test-log = { workspace = true, features = ["trace"] }
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 url = { workspace = true }
 
 [features]

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -19,9 +19,9 @@ use rattler_conda_types::{
 };
 use resolvo::{
     utils::{Pool, VersionSet},
-    Candidates, Dependencies, DependencyProvider, Interner, KnownDependencies, NameId, Problem,
-    Requirement, SolvableId, Solver as LibSolvRsSolver, SolverCache, StringId,
-    UnsolvableOrCancelled, VersionSetId, VersionSetUnionId,
+    Candidates, Dependencies, DependencyProvider, HintDependenciesAvailable, Interner,
+    KnownDependencies, NameId, Problem, Requirement, SolvableId, Solver as LibSolvRsSolver,
+    SolverCache, StringId, UnsolvableOrCancelled, VersionSetId, VersionSetUnionId,
 };
 
 use crate::{
@@ -67,7 +67,8 @@ impl<'a> SolverMatchSpec<'a> {
         }
     }
 
-    /// Returns a mutable reference to this match spec after enabling the given feature
+    /// Returns a mutable reference to this match spec after enabling the given
+    /// feature
     pub fn set_feature(&mut self, feature: String) -> &SolverMatchSpec<'a> {
         self.feature = Some(feature);
         self
@@ -429,7 +430,8 @@ impl<'a> CondaDependencyProvider<'a> {
                                 .as_normalized()
                                 == record.package_record.name.as_normalized()
                         }) {
-                            // Check if the spec has a channel, and compare it to the repodata channel
+                            // Check if the spec has a channel, and compare it to the repodata
+                            // channel
                             if let Some(spec_channel) = &spec.channel {
                                 if record.channel.as_ref() != Some(&spec_channel.canonical_name()) {
                                     tracing::debug!("Ignoring {} {} because it was not requested from that channel.", &record.package_record.name.as_normalized(), match &record.channel {
@@ -515,7 +517,7 @@ impl<'a> CondaDependencyProvider<'a> {
 
         // The dependencies for all candidates are always available.
         for candidates in records.values_mut() {
-            candidates.hint_dependencies_available = candidates.candidates.clone();
+            candidates.hint_dependencies_available = HintDependenciesAvailable::All;
         }
 
         Ok(Self {


### PR DESCRIPTION
### Description

This bumps `resolvo` to `0.9.0`. This should not change much but slightly reduce memory usage. I also removed a few unused dependencies.