### PR TITLE
fix: rename struct and reexport

### DIFF
--- a/crates/rattler_lock/src/builder.rs
+++ b/crates/rattler_lock/src/builder.rs
@@ -13,7 +13,7 @@ use rattler_conda_types::{Platform, Version};
 use crate::{
     file_format_version::FileFormatVersion, Channel, CondaBinaryData, CondaPackageData,
     CondaSourceData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
-    LockedPackageRef, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, ResolverOptions,
+    LockedPackageRef, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, SolveOptions,
     UrlOrPath,
 };
 
@@ -161,7 +161,7 @@ impl LockFileBuilder {
                 channels: vec![],
                 packages: HashMap::default(),
                 indexes: None,
-                options: ResolverOptions::default(),
+                options: SolveOptions::default(),
             })
     }
 
@@ -179,7 +179,7 @@ impl LockFileBuilder {
     pub fn set_options(
         &mut self,
         environment: impl Into<String>,
-        options: ResolverOptions,
+        options: SolveOptions,
     ) -> &mut Self {
         self.environment_data(environment).options = options;
         self
@@ -339,11 +339,7 @@ impl LockFileBuilder {
     }
 
     /// Sets the options for an environment.
-    pub fn with_options(
-        mut self,
-        environment: impl Into<String>,
-        options: ResolverOptions,
-    ) -> Self {
+    pub fn with_options(mut self, environment: impl Into<String>, options: SolveOptions) -> Self {
         self.set_options(environment, options);
         self
     }

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -281,6 +281,11 @@ impl<'lock> Environment<'lock> {
         self.data().indexes.as_ref()
     }
 
+    /// Returns the solver options that were used to create this environment.
+    pub fn solve_options(&self) -> &SolveOptions {
+        &self.data().options
+    }
+
     /// Returns all the packages for a specific platform in this environment.
     pub fn packages(
         &self,

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -87,7 +87,7 @@ mod channel;
 mod conda;
 mod file_format_version;
 mod hash;
-mod options;
+pub mod options;
 mod parse;
 mod pypi;
 mod pypi_indexes;
@@ -100,7 +100,7 @@ pub use channel::Channel;
 pub use conda::{CondaBinaryData, CondaPackageData, CondaSourceData, ConversionError, InputHash};
 pub use file_format_version::FileFormatVersion;
 pub use hash::PackageHashes;
-pub use options::ResolverOptions;
+pub use options::SolveOptions;
 pub use parse::ParseCondaLockError;
 pub use pypi::{PypiPackageData, PypiPackageEnvironmentData, PypiSourceTreeHashable};
 pub use pypi_indexes::{FindLinksUrlOrPath, PypiIndexes};
@@ -161,7 +161,7 @@ struct EnvironmentData {
     indexes: Option<PypiIndexes>,
 
     /// The options that were used to solve the environment.
-    options: ResolverOptions,
+    options: SolveOptions,
 
     /// For each individual platform this environment supports we store the
     /// package identifiers associated with the environment.

--- a/crates/rattler_lock/src/options.rs
+++ b/crates/rattler_lock/src/options.rs
@@ -1,11 +1,12 @@
-use rattler_solve::{ChannelPriority, SolveStrategy};
+// Reexport these fields.
+pub use rattler_solve::{ChannelPriority, SolveStrategy};
 
 /// Options that were used during the resolution of the packages stored in the
 /// lock-file. These options strongly influence the outcome of the solve and are
 /// therefore stored along with the locked packages.
 #[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct ResolverOptions {
+pub struct SolveOptions {
     /// The strategy that was used to solve the dependencies.
     #[serde(default, skip_serializing_if = "crate::utils::serde::is_default")]
     pub strategy: SolveStrategy,

--- a/crates/rattler_lock/src/options.rs
+++ b/crates/rattler_lock/src/options.rs
@@ -1,3 +1,5 @@
+//! Defines [`SolveOptions`] and reexports from `rattler_solve` that are used.
+
 // Reexport these fields.
 pub use rattler_solve::{ChannelPriority, SolveStrategy};
 

--- a/crates/rattler_lock/src/parse/deserialize.rs
+++ b/crates/rattler_lock/src/parse/deserialize.rs
@@ -18,7 +18,7 @@ use crate::{
     file_format_version::FileFormatVersion,
     parse::{models, models::v6, V5, V6},
     Channel, CondaPackageData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
-    ParseCondaLockError, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, ResolverOptions,
+    ParseCondaLockError, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, SolveOptions,
     UrlOrPath,
 };
 
@@ -45,7 +45,7 @@ struct DeserializableEnvironment {
     #[serde(flatten)]
     indexes: Option<PypiIndexes>,
     #[serde(default)]
-    options: ResolverOptions,
+    options: SolveOptions,
     packages: BTreeMap<Platform, Vec<DeserializablePackageSelector>>,
 }
 

--- a/crates/rattler_lock/src/parse/serialize.rs
+++ b/crates/rattler_lock/src/parse/serialize.rs
@@ -15,7 +15,7 @@ use crate::{
     file_format_version::FileFormatVersion,
     parse::{models::v6, V6},
     Channel, CondaPackageData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
-    PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, ResolverOptions, UrlOrPath,
+    PypiIndexes, PypiPackageData, PypiPackageEnvironmentData, SolveOptions, UrlOrPath,
 };
 
 #[serde_as]
@@ -36,7 +36,7 @@ struct SerializableEnvironment<'a> {
     #[serde(flatten)]
     indexes: Option<&'a PypiIndexes>,
     #[serde(default, skip_serializing_if = "crate::utils::serde::is_default")]
-    options: ResolverOptions,
+    options: SolveOptions,
     packages: BTreeMap<Platform, Vec<SerializablePackageSelector<'a>>>,
 }
 

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -22,7 +22,7 @@ use crate::{
         LocationDerivedFields,
     },
     Channel, CondaPackageData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
-    PackageHashes, PypiPackageData, PypiPackageEnvironmentData, ResolverOptions, UrlOrPath,
+    PackageHashes, PypiPackageData, PypiPackageEnvironmentData, SolveOptions, UrlOrPath,
     DEFAULT_ENVIRONMENT_NAME,
 };
 
@@ -258,7 +258,7 @@ pub fn parse_v3_or_lower(
         channels: lock_file.metadata.channels,
         indexes: None,
         packages: per_platform,
-        options: ResolverOptions::default(),
+        options: SolveOptions::default(),
     };
 
     Ok(LockFile {


### PR DESCRIPTION
Renames the `options` struct to be more in line with our other crates and reexports some fields so that an import of `rattler_solve` is not perse needed in downstream crates.