### PR TITLE
fix: menuinst windows shorcut path

### DIFF
--- a/crates/rattler_conda_types/src/menuinst/mod.rs
+++ b/crates/rattler_conda_types/src/menuinst/mod.rs
@@ -90,6 +90,9 @@ pub struct WindowsTracker {
     /// The menu mode that was used to install the menu entries
     pub menu_mode: MenuMode,
 
+    /// The sub-directory of `menu_name` in start menu.
+    pub start_menu_subdir_path: Option<PathBuf>,
+
     /// List of shortcuts that were installed
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub shortcuts: Vec<PathBuf>,
@@ -112,6 +115,7 @@ impl WindowsTracker {
     pub fn new(menu_mode: MenuMode) -> Self {
         Self {
             menu_mode,
+            start_menu_subdir_path: None,
             shortcuts: Vec::new(),
             file_extensions: Vec::new(),
             url_protocols: Vec::new(),

--- a/crates/rattler_conda_types/src/menuinst/mod.rs
+++ b/crates/rattler_conda_types/src/menuinst/mod.rs
@@ -91,6 +91,7 @@ pub struct WindowsTracker {
     pub menu_mode: MenuMode,
 
     /// The sub-directory of `menu_name` in start menu.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub start_menu_subdir_path: Option<PathBuf>,
 
     /// List of shortcuts that were installed

--- a/crates/rattler_menuinst/src/lib.rs
+++ b/crates/rattler_menuinst/src/lib.rs
@@ -157,6 +157,7 @@ pub fn install_menuitems(
             if let Some(windows_item) = item.platforms.win {
                 let command = item.command.merge(windows_item.base);
                 let tracker = windows::install_menu_item(
+                    &menu_inst.menu_name,
                     prefix,
                     windows_item.specific,
                     command,

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -340,6 +340,7 @@ impl WindowsMenu {
         let start_menu_subdir_path = self.directories.start_menu.join(&self.menu_name);
         if !start_menu_subdir_path.exists() {
             std::fs::create_dir(&start_menu_subdir_path)?;
+            tracker.start_menu_subdir_path = Some(start_menu_subdir_path.clone());
         }
         let start_menu_link_path = start_menu_subdir_path.join(&link_name);
         let shortcut = Shortcut {
@@ -546,6 +547,19 @@ pub(crate) fn remove_menu_item(tracker: &WindowsTracker) -> Result<(), MenuInstE
             Ok(_) => {}
             Err(e) => {
                 tracing::warn!("Failed to remove shortcut {}: {}", file.display(), e);
+            }
+        }
+    }
+
+    if let Some(subdir) = &tracker.start_menu_subdir_path {
+        match fs::remove_dir(subdir) {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to remove start menu sub-directory {}: {}",
+                    subdir.display(),
+                    e
+                );
             }
         }
     }

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -340,7 +340,6 @@ impl WindowsMenu {
         let start_menu_subdir_path = self.directories.start_menu.join(&self.menu_name);
         if !start_menu_subdir_path.exists() {
             std::fs::create_dir(&start_menu_subdir_path)?;
-            tracker.start_menu_subdir_path = Some(start_menu_subdir_path.clone());
         }
         let start_menu_link_path = start_menu_subdir_path.join(&link_name);
         let shortcut = Shortcut {
@@ -355,6 +354,7 @@ impl WindowsMenu {
         };
 
         create_shortcut::create_shortcut(shortcut)?;
+        tracker.start_menu_subdir_path = Some(start_menu_subdir_path.clone());
         tracker.shortcuts.push(start_menu_link_path.clone());
 
         // install desktop shortcut

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -337,14 +337,10 @@ impl WindowsMenu {
         let link_name = format!("{}.lnk", self.name);
 
         // install start menu shortcut
-        let start_menu_link_path = self
-            .directories
-            .start_menu
-            .join(&self.menu_name)
-            .join(&link_name);
-        if !start_menu_link_path.parent().unwrap().exists() {
-            std::fs::create_dir(start_menu_link_path.parent().unwrap())?;
-        }
+        let start_menu_subdir_path = self.directories.start_menu.join(&self.menu_name);
+        std::fs::create_dir(&start_menu_subdir_path)
+            .expect(format!("Directory `{}` is existing in start menu.", &self.menu_name).as_str());
+        let start_menu_link_path = start_menu_subdir_path.join(&link_name);
         let shortcut = Shortcut {
             path: command,
             description: &self.command.description.resolve(&self.placeholders),

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -336,7 +336,7 @@ impl WindowsMenu {
         // install start menu shortcut
         let start_menu_link_path = self.directories.start_menu.join(&link_name);
         let shortcut = Shortcut {
-            path: &self.name,
+            path: command,
             description: &self.command.description.resolve(&self.placeholders),
             filename: &start_menu_link_path,
             arguments: Some(&args),
@@ -372,7 +372,7 @@ impl WindowsMenu {
             if self.item.quicklaunch.unwrap_or(false) {
                 let quicklaunch_link_path = quick_launch_dir.join(link_name);
                 let shortcut = Shortcut {
-                    path: &self.name,
+                    path: command,
                     description: &self.command.description.resolve(&self.placeholders),
                     filename: &quicklaunch_link_path,
                     arguments: Some(&args),

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -552,14 +552,16 @@ pub(crate) fn remove_menu_item(tracker: &WindowsTracker) -> Result<(), MenuInstE
     }
 
     if let Some(subdir) = &tracker.start_menu_subdir_path {
-        match fs::remove_dir(subdir) {
-            Ok(_) => {}
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to remove start menu sub-directory {}: {}",
-                    subdir.display(),
-                    e
-                );
+        if subdir.exists() {
+            match fs::remove_dir(subdir) {
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to remove start menu sub-directory {}: {}",
+                        subdir.display(),
+                        e
+                    );
+                }
             }
         }
     }

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -375,8 +375,7 @@ impl WindowsMenu {
         // install quicklaunch shortcut
         if let Some(quick_launch_dir) = self.directories.quick_launch.as_ref() {
             if self.item.quicklaunch.unwrap_or(false) {
-                let quicklaunch_link_path = quick_launch_dir.join(&self.name).join(link_name);
-                std::fs::create_dir(quicklaunch_link_path.parent().unwrap())?;
+                let quicklaunch_link_path = quick_launch_dir.join(link_name);
                 let shortcut = Shortcut {
                     path: command,
                     description: &self.command.description.resolve(&self.placeholders),

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -351,7 +351,7 @@ impl WindowsMenu {
 
         // install desktop shortcut
         if self.item.desktop.unwrap_or(true) {
-            let desktop_link_path = self.directories.desktop.join(&link_name);
+            let desktop_link_path = self.directories.desktop.join(&self.name).join(&link_name);
             let shortcut = Shortcut {
                 path: command,
                 description: &self.command.description.resolve(&self.placeholders),
@@ -370,7 +370,7 @@ impl WindowsMenu {
         // install quicklaunch shortcut
         if let Some(quick_launch_dir) = self.directories.quick_launch.as_ref() {
             if self.item.quicklaunch.unwrap_or(false) {
-                let quicklaunch_link_path = quick_launch_dir.join(link_name);
+                let quicklaunch_link_path = quick_launch_dir.join(&self.name).join(link_name);
                 let shortcut = Shortcut {
                     path: command,
                     description: &self.command.description.resolve(&self.placeholders),

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -334,7 +334,12 @@ impl WindowsMenu {
         let link_name = format!("{}.lnk", self.name);
 
         // install start menu shortcut
-        let start_menu_link_path = self.directories.start_menu.join(&link_name);
+        let start_menu_link_path = self
+            .directories
+            .start_menu
+            .join(&self.name)
+            .join(&link_name);
+        std::fs::create_dir(start_menu_link_path.parent().unwrap())?;
         let shortcut = Shortcut {
             path: command,
             description: &self.command.description.resolve(&self.placeholders),
@@ -351,7 +356,7 @@ impl WindowsMenu {
 
         // install desktop shortcut
         if self.item.desktop.unwrap_or(true) {
-            let desktop_link_path = self.directories.desktop.join(&self.name).join(&link_name);
+            let desktop_link_path = self.directories.desktop.join(&link_name);
             let shortcut = Shortcut {
                 path: command,
                 description: &self.command.description.resolve(&self.placeholders),
@@ -371,6 +376,7 @@ impl WindowsMenu {
         if let Some(quick_launch_dir) = self.directories.quick_launch.as_ref() {
             if self.item.quicklaunch.unwrap_or(false) {
                 let quicklaunch_link_path = quick_launch_dir.join(&self.name).join(link_name);
+                std::fs::create_dir(quicklaunch_link_path.parent().unwrap())?;
                 let shortcut = Shortcut {
                     path: command,
                     description: &self.command.description.resolve(&self.placeholders),

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -339,8 +339,10 @@ impl WindowsMenu {
         // install start menu shortcut
         let start_menu_subdir_path = self.directories.start_menu.join(&self.menu_name);
         if !start_menu_subdir_path.exists() {
-            std::fs::create_dir(&start_menu_subdir_path)?;
+            fs::create_dir_all(&start_menu_subdir_path)?;
+            tracker.start_menu_subdir_path = Some(start_menu_subdir_path.clone());
         }
+
         let start_menu_link_path = start_menu_subdir_path.join(&link_name);
         let shortcut = Shortcut {
             path: command,
@@ -352,9 +354,7 @@ impl WindowsMenu {
             iconindex: Some(0),
             app_id: Some(&app_id),
         };
-
         create_shortcut::create_shortcut(shortcut)?;
-        tracker.start_menu_subdir_path = Some(start_menu_subdir_path.clone());
         tracker.shortcuts.push(start_menu_link_path.clone());
 
         // install desktop shortcut

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -342,7 +342,9 @@ impl WindowsMenu {
             .start_menu
             .join(&self.menu_name)
             .join(&link_name);
-        std::fs::create_dir(start_menu_link_path.parent().unwrap())?;
+        if !start_menu_link_path.parent().unwrap().exists() {
+            std::fs::create_dir(start_menu_link_path.parent().unwrap())?;
+        }
         let shortcut = Shortcut {
             path: command,
             description: &self.command.description.resolve(&self.placeholders),

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -552,7 +552,8 @@ pub(crate) fn remove_menu_item(tracker: &WindowsTracker) -> Result<(), MenuInstE
     }
 
     if let Some(subdir) = &tracker.start_menu_subdir_path {
-        if subdir.exists() {
+        // Check if subdir exists and is empty.
+        if subdir.exists() && subdir.read_dir()?.next().is_none() {
             match fs::remove_dir(subdir) {
                 Ok(_) => {}
                 Err(e) => {

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -338,8 +338,9 @@ impl WindowsMenu {
 
         // install start menu shortcut
         let start_menu_subdir_path = self.directories.start_menu.join(&self.menu_name);
-        std::fs::create_dir(&start_menu_subdir_path)
-            .expect(format!("Directory `{}` is existing in start menu.", &self.menu_name).as_str());
+        if !start_menu_subdir_path.exists() {
+            std::fs::create_dir(&start_menu_subdir_path)?;
+        }
         let start_menu_link_path = start_menu_subdir_path.join(&link_name);
         let shortcut = Shortcut {
             path: command,

--- a/crates/rattler_menuinst/src/windows.rs
+++ b/crates/rattler_menuinst/src/windows.rs
@@ -105,6 +105,7 @@ impl Directories {
 }
 
 pub struct WindowsMenu {
+    menu_name: String,
     prefix: PathBuf,
     name: String,
     item: Windows,
@@ -118,6 +119,7 @@ const SHORTCUT_EXTENSION: &str = "lnk";
 
 impl WindowsMenu {
     pub fn new(
+        menu_name: &str,
         prefix: &Path,
         item: Windows,
         command: MenuItemCommand,
@@ -135,6 +137,7 @@ impl WindowsMenu {
             .with_extension(SHORTCUT_EXTENSION);
 
         Self {
+            menu_name: menu_name.to_string(),
             prefix: prefix.to_path_buf(),
             name,
             item,
@@ -337,7 +340,7 @@ impl WindowsMenu {
         let start_menu_link_path = self
             .directories
             .start_menu
-            .join(&self.name)
+            .join(&self.menu_name)
             .join(&link_name);
         std::fs::create_dir(start_menu_link_path.parent().unwrap())?;
         let shortcut = Shortcut {
@@ -511,6 +514,7 @@ impl WindowsMenu {
 }
 
 pub(crate) fn install_menu_item(
+    menu_name: &str,
     prefix: &Path,
     windows_item: Windows,
     command: MenuItemCommand,
@@ -525,6 +529,7 @@ pub(crate) fn install_menu_item(
     };
 
     let menu = WindowsMenu::new(
+        menu_name,
         prefix,
         windows_item,
         command,


### PR DESCRIPTION
In recent pixi 0.46.0, windows desktop, start menu, quick launch shortcut are all installed successfully. But start menu and quick launch shortcut ink file do not point to the right command, while desktop shortcut do the right thing.

tasks:
- [x] The command path will set to `command` in creating start menu and quick launch shortcut, just like what it does in creating desktop shortcut. 
- [x] Start menu shortcut will be installed into the `menu_name` subdir. This is what conda menuinst does.
- [x] When removing a shortcut, the `menu_name` subdir in start menu will be removed if it exists and is empty.

## test with pixi in my pc
- [x] Install shortcuts and all types of shortcuts point to the right command/path.
- [x] Install shortcuts and remove env from `pixi-global.toml`, then run `pixi global  update`. The shortcuts ink files should be removed, and the `menu_name` subdir in start menu will also be removed. Also test removing env with `pixi global uninstall`.
- [x] Install shortcuts and remove env from `pixi-global.toml`, **add arbitrary file to `menu_name` subdir in start menu**, then run `pixi update`. The shortcuts ink files should be removed, and the `menu_name` subdir in start menu will still **exist**. Also test removing env with `pixi global uninstall`.