### PR TITLE
refactor: lock workspace member dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,17 +27,17 @@ anyhow = "1.0.97"
 archspec = "0.1.3"
 assert_matches = "1.5.0"
 async-compression = { version = "0.4.19", features = [
-  "gzip",
-  "tokio",
-  "bzip2",
-  "zstd",
+    "gzip",
+    "tokio",
+    "bzip2",
+    "zstd",
 ] }
 async-fd-lock = "0.2.0"
 fs4 = "0.13.1"
 async-trait = "0.1.88"
 axum = { version = "0.8.1", default-features = false, features = [
-  "tokio",
-  "http1",
+    "tokio",
+    "http1",
 ] }
 base64 = "0.22.1"
 bindgen = "0.71.1"
@@ -47,9 +47,9 @@ bzip2 = "0.5.2"
 cache_control = "0.2.0"
 cfg-if = "1.0"
 chrono = { version = "0.4.40", default-features = false, features = [
-  "std",
-  "serde",
-  "alloc",
+    "std",
+    "serde",
+    "alloc",
 ] }
 clap = { version = "4.5.34", features = ["derive"] }
 clap-verbosity-flag = "3.0.1"
@@ -74,15 +74,15 @@ glob = "0.3.2"
 google-cloud-auth = { version = "0.17.2", default-features = false }
 google-cloud-token = "0.1.2"
 aws-config = { version = "=1.5.18", default-features = false, features = [
-  "rt-tokio",
-  "rustls",
-  "sso",
-  "credentials-process",
+    "rt-tokio",
+    "rustls",
+    "sso",
+    "credentials-process",
 ] }
 aws-sdk-s3 = { version = "1.82.0", default-features = false, features = [
-  "rt-tokio",
-  "rustls",
-  "sigv4a",
+    "rt-tokio",
+    "rustls",
+    "sigv4a",
 ] }
 hex = "0.4.3"
 hex-literal = "0.4.1"
@@ -142,10 +142,10 @@ sha2 = "0.10.8"
 shlex = "1.3.0"
 similar-asserts = "1.6.1"
 smallvec = { version = "1.15.0", features = [
-  "serde",
-  "const_new",
-  "const_generics",
-  "union",
+    "serde",
+    "const_new",
+    "const_generics",
+    "union",
 ] }
 strum = { version = "0.27.0", features = ["derive"] }
 superslice = "1.0.0"
@@ -177,3 +177,27 @@ windows-sys = { version = "0.59.0", default-features = false }
 winver = { version = "1.0.0" }
 zip = { version = "2.6.1", default-features = false }
 zstd = { version = "0.13.3", default-features = false }
+
+# These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
+file_url = { path = "crates/file_url", version = "=0.2.4", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.33.5", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.17", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.32.0", default-features = false }
+rattler_digest = { path = "crates/rattler_digest", version = "=1.1.1", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.22.5", default-features = false }
+rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.0", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.2", default-features = false }
+rattler_macros = { path = "crates/rattler_macros", version = "=1.0.8", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.7", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.22.12", default-features = false }
+rattler_pty = { path = "crates/rattler_pty", version = "=0.2.0", default-features = false }
+rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.10", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.36", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.22.5", default-features = false }
+rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.7", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.22.26", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=1.4.5", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.10", default-features = false }
+
+# This is also a rattler crate, but we only pin it to minor version
+simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,14 +27,14 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.33.5", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.32.0", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.22.12", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.22.5", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.4.5", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.10", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.17", default-features = false }
-rattler_menuinst = { path="../rattler_menuinst", version = "0.2.7", default-features = false }
+rattler = { workspace = true, features = ["indicatif"] }
+rattler_conda_types = { workspace = true, default-features = false }
+rattler_networking = { workspace = true, default-features = false, features = ["gcs", "s3"] }
+rattler_repodata_gateway = { workspace = true, default-features = false, features = ["gateway"] }
+rattler_solve = { workspace = true, default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { workspace = true, default-features = false }
+rattler_cache = { workspace = true, default-features = false }
+rattler_menuinst = { workspace = true, default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -32,20 +32,20 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.17", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.1.1", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.12", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.26", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.36", default-features = false, features = ["reqwest"] }
-rattler_menuinst = { path = "../rattler_menuinst", version = "0.2.7", default-features = false }
+rattler_cache = { workspace = true }
+rattler_conda_types = { workspace = true }
+rattler_digest = { workspace = true }
+rattler_networking = { workspace = true }
+rattler_shell = { workspace = true }
+rattler_package_streaming = { workspace = true, features = ["reqwest"] }
+rattler_menuinst = { workspace = true, default-features = false }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }
 reqwest-middleware = { workspace = true }
 smallvec = { workspace = true }
-simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.1", default-features = false, features = ["tokio"] }
+simple_spawn_blocking = { workspace = true, features = ["tokio"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "io-util", "macros"] }

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -21,10 +21,10 @@ fs4 = { workspace = true, features = ["fs-err3-tokio", "tokio"] }
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.32.0", path = "../rattler_conda_types", default-features = false }
-rattler_digest = { version = "1.1.1", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.22.12", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.36", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { workspace = true, default-features = false }
+rattler_digest = { workspace = true, default-features = false }
+rattler_networking = { workspace = true, default-features = false }
+rattler_package_streaming = { workspace = true, default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros"] }
@@ -33,7 +33,7 @@ url.workspace = true
 thiserror.workspace = true
 reqwest-middleware.workspace = true
 digest.workspace = true
-simple_spawn_blocking = { version = "1.1.0", path = "../simple_spawn_blocking", features = ["tokio"] }
+simple_spawn_blocking = { workspace = true, features = ["tokio"] }
 rayon = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -16,7 +16,7 @@ experimental_extras = []
 
 [dependencies]
 chrono = { workspace = true }
-file_url = { path = "../file_url", version = "0.2.4" }
+file_url = { workspace = true }
 fxhash = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }
@@ -24,11 +24,11 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path = "../rattler_digest", version = "1.1.1", default-features = false, features = [
+rattler_digest = { workspace = true, default-features = false, features = [
   "serde",
 ] }
-rattler_macros = { path = "../rattler_macros", version = "1.0.8", default-features = false }
-rattler_redaction = { version = "0.1.10", path = "../rattler_redaction", default-features = false }
+rattler_macros = { workspace = true, default-features = false }
+rattler_redaction = { workspace = true, default-features = false }
 regex = { workspace = true }
 simd-json = { workspace = true, features = ["serde_impl"] }
 serde = { workspace = true, features = ["derive", "rc"] }

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -44,10 +44,10 @@ opendal = { workspace = true, features = [
   "services-s3",
   "services-fs",
 ], default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.12", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0" }
-rattler_digest = { path = "../rattler_digest", version = "1.1.1", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.36", default-features = false }
+rattler_networking = { workspace = true, default-features = false }
+rattler_conda_types = { workspace = true, default-features = false }
+rattler_digest = { workspace = true, default-features = false }
+rattler_package_streaming = { workspace = true, default-features = false }
 reqwest = { workspace = true, default-features = false, features = [
   "http2",
   "macos-system-configuration",

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -15,10 +15,10 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.1.1", default-features = false }
-rattler_solve = { path = "../rattler_solve", version = "1.4.5", default-features = false, features = ["serde"] }
-file_url = { path = "../file_url", version = "0.2.4" }
+rattler_conda_types = { workspace = true, default-features = false }
+rattler_digest = { workspace = true, default-features = false }
+rattler_solve = { workspace = true, default-features = false, features = ["serde"] }
+file_url = { workspace = true }
 pep508_rs = { workspace = true }
 pep440_rs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -15,8 +15,8 @@ dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.26", default-features = false }
+rattler_conda_types = { workspace = true, default-features = false }
+rattler_shell = { workspace = true, default-features = false }
 thiserror = { workspace = true }
 unicode-normalization = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -16,16 +16,16 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.1.1", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.12", default-features = false }
-rattler_redaction = { version = "0.1.10", path = "../rattler_redaction", features = [
+rattler_conda_types = { workspace = true, default-features = false }
+rattler_digest = { workspace = true, default-features = false }
+rattler_networking = { workspace = true, default-features = false }
+rattler_redaction = { workspace = true, features = [
   "reqwest",
   "reqwest-middleware",
 ], default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
-simple_spawn_blocking = { version = "1.1.0", path = "../simple_spawn_blocking", features = ["tokio"] }
+simple_spawn_blocking = { workspace = true, features = ["tokio"] }
 serde_json = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -22,7 +22,7 @@ cache_control = { workspace = true }
 chrono = { workspace = true, features = ["std", "serde", "alloc", "clock"] }
 dashmap = { workspace = true }
 dirs = { workspace = true }
-file_url = { path = "../file_url", version = "0.2.4" }
+file_url = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 http = { workspace = true, optional = true }
@@ -34,9 +34,9 @@ json-patch = { workspace = true }
 self_cell = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0", default-features = false, optional = true }
-rattler_digest = { path = "../rattler_digest", version = "1.1.1", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.22.12", default-features = false }
+rattler_conda_types = { workspace = true, default-features = false, optional = true }
+rattler_digest = { workspace = true, default-features = false, features = ["tokio", "serde"] }
+rattler_networking = { workspace = true, default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -53,8 +53,8 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.17", path = "../rattler_cache" }
-rattler_redaction = { version = "0.1.10", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+rattler_cache = { workspace = true }
+rattler_redaction = { workspace = true, features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
@@ -64,7 +64,7 @@ windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem", "Win32
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-fd-lock = { workspace = true }
-simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.1", features = ["tokio"] }
+simple_spawn_blocking = { workspace = true, features = ["tokio"] }
 tokio = { workspace = true, features = ["rt", "io-util"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -16,8 +16,8 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0", default-features = false }
-rattler_pty = { path = "../rattler_pty", version = "0.2.0", default-features = false }
+rattler_conda_types = { workspace = true, default-features = false }
+rattler_pty = { workspace = true, default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -11,15 +11,15 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.32.0", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.1.1", default-features = false }
+rattler_conda_types = { workspace = true, default-features = false }
+rattler_digest = { workspace = true, default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 itertools = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { path = "../rattler_libsolv_c", version = "1.1.3", default-features = false, optional = true }
+rattler_libsolv_c = { workspace = true, default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.32.0", default-features = false }
+rattler_conda_types = { workspace = true, default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/js-rattler/Cargo.lock
+++ b/js-rattler/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "sha2",
 ]
 
@@ -1041,11 +1041,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1265,12 +1263,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2069,7 +2065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2209,60 +2205,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
-dependencies = [
- "bytes",
- "getrandom 0.3.2",
- "rand 0.9.0",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.12",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,19 +2232,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
- "zerocopy 0.8.24",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2312,17 +2243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -2335,17 +2256,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.2",
-]
-
-[[package]]
 name = "rattler_cache"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -2375,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.31.6"
+version = "0.32.0"
 dependencies = [
  "chrono",
  "core-foundation 0.10.0",
@@ -2413,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "blake2",
  "digest",
@@ -2437,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.11"
+version = "0.22.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2462,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.35"
+version = "0.22.36"
 dependencies = [
  "bzip2",
  "chrono",
@@ -2490,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -2499,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2554,11 +2466,10 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.4.3"
+version = "1.4.5"
 dependencies = [
  "chrono",
  "futures",
- "indexmap 2.9.0",
  "itertools",
  "rattler_conda_types",
  "rattler_digest",
@@ -2566,7 +2477,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -2684,18 +2594,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
  "rustls-pemfile",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-service",
@@ -2704,7 +2609,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
  "windows-registry",
 ]
 
@@ -2725,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5314eb4b865d39acd1b3cd05eb91b87031bb49fd1278a1bdf8d6680f1389ec29"
+checksum = "996e40b356864ad72942a9ef6815df7f219b7b42ccc791906d3e0a17df5d66ab"
 dependencies = [
  "ahash",
  "bitvec",
@@ -2746,7 +2650,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2792,12 +2696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,23 +2728,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -2863,9 +2748,6 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-dependencies = [
- "web-time",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -2927,7 +2809,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2",
  "zbus",
@@ -3406,21 +3288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,25 +3696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "wee_alloc"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4187,7 +4035,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_repr",
  "sha1",


### PR DESCRIPTION
Pin all the workspace dependencies. 

release-plz automatically bumps any workspace member whose dependencies have changed. This means that crates are always bumped in tandem. This is useful because it means we also always test the crates together that will be used together.

So given that crates are always updated in tandem we choose to pin the member crates together as well.