### PR TITLE
fix: clean up URL before serializing or printing

### DIFF
--- a/crates/rattler_conda_types/src/channel/channel_url.rs
+++ b/crates/rattler_conda_types/src/channel/channel_url.rs
@@ -22,7 +22,7 @@ impl ChannelUrl {
     }
 
     /// Returns the string representation of the url.
-    pub fn to_string(&self) -> String {
+    pub fn to_sanitized_string(&self) -> String {
         let mut url = self.0.as_ref().clone();
         url.set_username("").ok();
         url.set_password(None).ok();
@@ -63,13 +63,15 @@ impl Serialize for ChannelUrl {
     where
         S: serde::Serializer,
     {
-        self.to_string().trim_end_matches('/').serialize(serializer)
+        self.to_sanitized_string()
+            .trim_end_matches('/')
+            .serialize(serializer)
     }
 }
 
 impl Debug for ChannelUrl {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_string())
+        write!(f, "{}", self.to_sanitized_string())
     }
 }
 
@@ -107,7 +109,7 @@ mod tests {
         let channel_url = ChannelUrl::from(url.clone());
         assert_eq!(channel_url.url(), &UrlWithTrailingSlash::from(url));
         assert_eq!(
-            channel_url.to_string(),
+            channel_url.to_sanitized_string(),
             "https://repo.anaconda.com/pkgs/main/"
         );
     }
@@ -117,7 +119,7 @@ mod tests {
         let url = Url::parse("https://user:pass@repo.anaconda.com/pkgs/main/").unwrap();
         let channel_url = ChannelUrl::from(url);
         assert_eq!(
-            channel_url.to_string(),
+            channel_url.to_sanitized_string(),
             "https://repo.anaconda.com/pkgs/main/"
         );
         assert_eq!(
@@ -131,7 +133,7 @@ mod tests {
         let url = Url::parse("https://repo.anaconda.com/t/secret-token/pkgs/main/").unwrap();
         let channel_url = ChannelUrl::from(url);
         assert_eq!(
-            channel_url.to_string(),
+            channel_url.to_sanitized_string(),
             "https://repo.anaconda.com/pkgs/main/"
         );
         assert_eq!(

--- a/crates/rattler_conda_types/src/channel/channel_url.rs
+++ b/crates/rattler_conda_types/src/channel/channel_url.rs
@@ -27,7 +27,7 @@ impl ChannelUrl {
         url.set_username("").ok();
         url.set_password(None).ok();
 
-        // Remove a `/t/token` from the url if it exists.
+        // Remove a `/t/token` from the url if it exists
         let path = url.path();
         if path.starts_with("/t/") {
             let mut parts = path.splitn(4, '/');
@@ -106,23 +106,38 @@ mod tests {
         let url = Url::parse("https://repo.anaconda.com/pkgs/main/").unwrap();
         let channel_url = ChannelUrl::from(url.clone());
         assert_eq!(channel_url.url(), &UrlWithTrailingSlash::from(url));
-        assert_eq!(channel_url.to_string(), "https://repo.anaconda.com/pkgs/main/");
+        assert_eq!(
+            channel_url.to_string(),
+            "https://repo.anaconda.com/pkgs/main/"
+        );
     }
 
     #[test]
     fn test_url_with_credentials() {
         let url = Url::parse("https://user:pass@repo.anaconda.com/pkgs/main/").unwrap();
         let channel_url = ChannelUrl::from(url);
-        assert_eq!(channel_url.to_string(), "https://repo.anaconda.com/pkgs/main/");
-        assert_eq!(channel_url.as_str_with_secrets(), "https://user:pass@repo.anaconda.com/pkgs/main/");
+        assert_eq!(
+            channel_url.to_string(),
+            "https://repo.anaconda.com/pkgs/main/"
+        );
+        assert_eq!(
+            channel_url.as_str_with_secrets(),
+            "https://user:pass@repo.anaconda.com/pkgs/main/"
+        );
     }
 
     #[test]
     fn test_url_with_token() {
         let url = Url::parse("https://repo.anaconda.com/t/secret-token/pkgs/main/").unwrap();
         let channel_url = ChannelUrl::from(url);
-        assert_eq!(channel_url.to_string(), "https://repo.anaconda.com/pkgs/main/");
-        assert_eq!(channel_url.as_str_with_secrets(), "https://repo.anaconda.com/t/secret-token/pkgs/main/");
+        assert_eq!(
+            channel_url.to_string(),
+            "https://repo.anaconda.com/pkgs/main/"
+        );
+        assert_eq!(
+            channel_url.as_str_with_secrets(),
+            "https://repo.anaconda.com/t/secret-token/pkgs/main/"
+        );
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -340,8 +340,8 @@ impl Channel {
             "https" | "http" => self
                 .name
                 .as_deref()
-                .unwrap_or_else(|| self.base_url.as_str()),
-            _ => self.base_url.as_str(),
+                .unwrap_or_else(|| &self.base_url.as_str_with_secrets()),
+            _ => &self.base_url.as_str_with_secrets(),
         }
     }
 
@@ -776,21 +776,21 @@ mod tests {
 
         for channel_str in test_channels {
             let channel = Channel::from_str(channel_str, &channel_config).unwrap();
-            assert!(channel.base_url.as_str().ends_with('/'));
-            assert!(!channel.base_url.as_str().ends_with("//"));
+            assert!(channel.base_url.as_str_with_secrets().ends_with('/'));
+            assert!(!channel.base_url.as_str_with_secrets().ends_with("//"));
 
             let named_channel = NamedChannelOrUrl::from_str(channel_str).unwrap();
             let base_url = named_channel
                 .clone()
                 .into_base_url(&channel_config)
                 .unwrap();
-            let base_url_str = base_url.as_str();
+            let base_url_str = base_url.as_str_with_secrets();
             assert!(base_url_str.ends_with('/'));
             assert!(!base_url_str.ends_with("//"));
 
             let channel = named_channel.into_channel(&channel_config).unwrap();
-            assert!(channel.base_url.as_str().ends_with('/'));
-            assert!(!channel.base_url.as_str().ends_with("//"));
+            assert!(channel.base_url.as_str_with_secrets().ends_with('/'));
+            assert!(!channel.base_url.as_str_with_secrets().ends_with("//"));
         }
     }
 

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -340,8 +340,8 @@ impl Channel {
             "https" | "http" => self
                 .name
                 .as_deref()
-                .unwrap_or_else(|| &self.base_url.as_str_with_secrets()),
-            _ => &self.base_url.as_str_with_secrets(),
+                .unwrap_or_else(|| self.base_url.as_str_with_secrets()),
+            _ => self.base_url.as_str_with_secrets(),
         }
     }
 
@@ -592,7 +592,7 @@ mod tests {
         assert_eq!(channel.name(), "conda-forge");
         assert_eq!(channel.platforms, None);
         assert_eq!(
-            channel.base_url.to_string(),
+            channel.base_url.to_sanitized_string(),
             "https://conda.anaconda.org/conda-forge/"
         );
 
@@ -616,7 +616,7 @@ mod tests {
         );
         assert_eq!(channel.platforms, None);
         assert_eq!(
-            channel.base_url.to_string(),
+            channel.base_url.to_sanitized_string(),
             "file:///var/channels/conda-forge/"
         );
 

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -267,7 +267,7 @@ impl RepoData {
                     base_url.as_deref(),
                     &filename,
                 ),
-                channel: Some(channel.base_url.to_string()),
+                channel: Some(channel.base_url.to_sanitized_string()),
                 package_record,
                 file_name: filename,
             });

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -267,7 +267,7 @@ impl RepoData {
                     base_url.as_deref(),
                     &filename,
                 ),
-                channel: Some(channel.base_url.as_str().to_string()),
+                channel: Some(channel.base_url.to_string()),
                 package_record,
                 file_name: filename,
             });

--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -253,7 +253,7 @@ impl TryFrom<CondaBinaryData> for RepoDataRecord {
             package_record: value.package_record,
             file_name: value.file_name,
             url: value.location.try_into_url()?,
-            channel: value.channel.map(|channel| channel.to_string()),
+            channel: value.channel.map(|channel| channel.to_sanitized_string()),
         })
     }
 }

--- a/crates/rattler_lock/src/utils/derived_fields.rs
+++ b/crates/rattler_lock/src/utils/derived_fields.rs
@@ -39,7 +39,10 @@ impl Debug for LocationDerivedFields {
             .field("version", &self.version.as_ref().map(|s| s.as_str()))
             .field("build", &self.build)
             .field("subdir", &self.subdir)
-            .field("channel", &self.channel.as_ref().map(ChannelUrl::as_str))
+            .field(
+                "channel",
+                &self.channel.as_ref().map(ChannelUrl::to_sanitized_string),
+            )
             .finish()
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
@@ -62,7 +62,7 @@ impl ChannelConfig {
             .iter()
             .filter_map(|(url, config)| {
                 let key_url = url.as_str().strip_suffix('/').unwrap_or(url.as_str());
-                if channel.as_str().starts_with(key_url) {
+                if channel.as_str_with_secrets().starts_with(key_url) {
                     Some((key_url.len(), config))
                 } else {
                     None

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -445,7 +445,7 @@ impl<'a> CondaDependencyProvider<'a> {
                                         spec_channel
                                             .name
                                             .clone()
-                                            .unwrap_or(spec_channel.base_url.to_string())
+                                            .unwrap_or(spec_channel.base_url.to_sanitized_string())
                                     );
                                     candidates
                                         .excluded

--- a/py-rattler/src/lock/mod.rs
+++ b/py-rattler/src/lock/mod.rs
@@ -139,7 +139,11 @@ impl PyEnvironment {
             &name,
             channels.into_iter().map(|c| {
                 rattler_lock::Channel::from(
-                    c.inner.base_url.as_str().trim_end_matches('/').to_string(),
+                    c.inner
+                        .base_url
+                        .to_sanitized_string()
+                        .trim_end_matches('/')
+                        .to_string(),
                 )
             }),
         );


### PR DESCRIPTION
This fixes the root cause of the issue in rattler-build where URLs with secrets leaked into the package: https://github.com/prefix-dev/rattler-build/issues/1636

I think this should be "OK" to do like this, although now users would have a hard time serializing this value _with_ credentials. But I think that should only happen if someone "really" wants it.