### PR TITLE
fix: Skip serializing if purls are None

### DIFF
--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -60,6 +60,7 @@ pub struct IndexJson {
 
     /// A list of Package URLs identifying this package.
     /// See this CEP: <https://github.com/conda/ceps/pull/63>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub purls: Option<BTreeSet<PackageUrl>>,
 
     /// Optionally a path within the environment of the site-packages directory.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->

https://github.com/conda/rattler/pull/1303#discussion_r2091102800