### PR TITLE
feat: Adding locked packages to the js-rattler solver

### DIFF
--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -185,7 +185,7 @@ pub async fn simple_solve(
         }
 
         let task = SolverTask {
-            specs,
+            specs: filtered_specs,
             locked_packages: installed_packages,
             ..repodata.iter().collect::<SolverTask<_>>()
         };

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -81,7 +81,7 @@ pub async fn simple_solve(
             let js_locked_packages: Vec<JsLockedPackage> =
                 serde_wasm_bindgen::from_value(locked_packages).map_err(JsError::from)?;
 
-            let records = js_locked_packages
+            js_locked_packages
                 .into_iter()
                 .map(|pkg| {
                     let url = Url::parse(&pkg.url)
@@ -123,7 +123,6 @@ pub async fn simple_solve(
                 })
                 .collect::<Result<Vec<_>, JsError>>()?;
 
-            records
         };
 
     //if we do not need to solve the same packages, then filter them

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -1,15 +1,26 @@
 use std::path::PathBuf;
+use std::str::FromStr;
 
-use rattler_conda_types::{Channel, ChannelConfig, MatchSpec, ParseStrictness::Lenient};
+use rattler_conda_types::{
+    ParseChannelError, Channel, ChannelConfig, MatchSpec, ParseStrictness::Lenient, PackageName, Version, RepoDataRecord, PackageRecord, NoArchType,
+};
 use rattler_repodata_gateway::{Gateway, SourceConfig};
 use rattler_solve::{SolverImpl, SolverTask};
 use wasm_bindgen::prelude::*;
 
 use crate::{error::JsError, platform::JsPlatform};
 
-/// A package that has been solved by the solver.
-/// @public
+use web_sys::console::log_1;
+use serde::{Serialize, Deserialize};
+
+use std::collections::BTreeMap;
+use chrono::{DateTime, Utc};
+
+use url::Url;
+
+
 #[wasm_bindgen(getter_with_clone)]
+#[derive(Serialize)]
 pub struct SolvedPackage {
     pub url: String,
     #[wasm_bindgen(js_name = "packageName")]
@@ -23,6 +34,20 @@ pub struct SolvedPackage {
     pub version: String,
 }
 
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JsLockedPackage {
+    url: String,
+    package_name: String,
+    build: String,
+    build_number: u64,
+    repo_name: Option<String>,
+    filename: String,
+    version: String,
+    subdir: String,
+}
+
 /// Solve a set of specs with the given channels and platforms.
 /// @public
 #[wasm_bindgen(js_name = "simpleSolve")]
@@ -33,6 +58,7 @@ pub async fn simple_solve(
     #[wasm_bindgen(param_description = "The channels to request for repodata of packages")]
     channels: Vec<String>,
     #[wasm_bindgen(param_description = "The platforms to solve for")] platforms: Vec<JsPlatform>,
+    #[wasm_bindgen(param_description = "Installed packages")] locked_packages: JsValue,
 ) -> Result<Vec<SolvedPackage>, JsError> {
     // TODO: Dont hardcode
     let channel_config = ChannelConfig::default_with_root_dir(PathBuf::from(""));
@@ -61,20 +87,71 @@ pub async fn simple_solve(
             ..rattler_repodata_gateway::ChannelConfig::default()
         })
         .finish();
+
     let repodata = gateway
         .query(channels, platforms, specs.iter().cloned())
         .recursive(true)
         .execute()
         .await?;
 
-    // Solve
+    let js_locked_packages: Vec<JsLockedPackage> =
+        serde_wasm_bindgen::from_value(locked_packages).map_err(JsError::from)?;
+
+    let locked_packages = js_locked_packages
+        .into_iter()
+        .map(|pkg| {
+            let url = Url::parse(&pkg.url).map_err(|e| JsError::from(ParseChannelError::from(e)))?;
+
+
+        let package_record = PackageRecord {
+                name: PackageName::try_from(pkg.package_name.clone())?,
+                version: Version::from_str(&pkg.version)?.into(),
+                build:  pkg.build.clone(),
+                build_number: pkg.build_number,
+                subdir: "unknown".to_string(),
+                md5: None,
+                sha256: None,
+                size: None,
+                arch: None,
+                platform: None,
+                depends: vec![],
+                extra_depends: std::collections::BTreeMap::new(),
+                constrains: vec![],
+                track_features: vec![],
+                features: None,
+                noarch:  NoArchType::none(),
+                license: None,
+                license_family: None,
+                timestamp: None,
+                python_site_packages_path: None,
+                legacy_bz2_md5: None,
+                legacy_bz2_size: None,
+                purls: None,
+                run_exports: None,
+            };
+
+
+            Ok(RepoDataRecord {
+                url,
+                file_name: pkg.filename,
+                channel: pkg.repo_name,
+                package_record,
+            })
+        })
+        .collect::<Result<Vec<_>, JsError>>()?;
+
     let task = SolverTask {
         specs,
+        locked_packages,
+        pinned_packages: vec![],
         ..repodata.iter().collect::<SolverTask<_>>()
     };
+
     let solved = rattler_solve::resolvo::Solver.solve(task)?;
 
-    // Convert to JS types
+    let js_value = serde_wasm_bindgen::to_value(&solved.records).unwrap();
+    log_1(&js_value);
+
     Ok(solved
         .records
         .into_iter()

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -41,7 +41,7 @@ struct JsLockedPackage {
     filename: String,
     version: String,
     depends: Option<Vec<String>>,
-    build_number: u64,
+    build_number: Option<u64>,
     subdir: Option<String>,
 }
 
@@ -91,7 +91,7 @@ pub async fn simple_solve(
                         name: PackageName::try_from(pkg.package_name.clone())?,
                         version: Version::from_str(&pkg.version)?.into(),
                         build: pkg.build.clone(),
-                        build_number: pkg.build_number,
+                        build_number: pkg.build_number.unwrap_or_default(),
                         md5: None,
                         sha256: None,
                         size: None,

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::{error::JsError, platform::JsPlatform};
 use rattler_conda_types::{
     Channel, ChannelConfig, MatchSpec, NoArchType, PackageName, PackageRecord, ParseChannelError,
-    ParseStrictness::Lenient, RepoDataRecord, Version,
+    ParseStrictness::Lenient, RepoDataRecord, Version, Matches,
 };
 use rattler_repodata_gateway::{Gateway, SourceConfig};
 use rattler_solve::{SolverImpl, SolverTask};
@@ -27,6 +27,8 @@ pub struct SolvedPackage {
     pub repo_name: Option<String>,
     pub filename: String,
     pub version: String,
+    pub depends: Vec<String>,
+    pub subdir: String,
 }
 
 #[derive(Deserialize, Clone)]
@@ -40,6 +42,7 @@ struct JsLockedPackage {
     version: String,
     depends: Option<Vec<String>>,
     build_number: u64,
+    subdir: Option<String>,
 }
 
 /// Solve a set of specs with the given channels and platforms.
@@ -71,35 +74,6 @@ pub async fn simple_solve(
         .map(|p| serde_wasm_bindgen::from_value(p.into()))
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Fetch the repodata
-    let gateway = Gateway::builder()
-        .with_channel_config(rattler_repodata_gateway::ChannelConfig {
-            default: SourceConfig {
-                sharded_enabled: true,
-                ..SourceConfig::default()
-            },
-            ..rattler_repodata_gateway::ChannelConfig::default()
-        })
-        .finish();
-
-    let repodata = gateway
-        .query(channels, platforms, specs.iter().cloned())
-        .recursive(true)
-        .execute()
-        .await?;
-
-    // We need this to find depends for locked packages
-    let repodata_keys: HashMap<(String, String, &String), &Vec<String>> = repodata
-        .iter()
-        .flat_map(|r| r.iter())
-        .map(|rec| {
-            let name = rec.package_record.name.as_normalized().to_string();
-            let version = rec.package_record.version.to_string();
-            let build = &rec.package_record.build;
-            ((name, version, build), &rec.package_record.depends)
-        })
-        .collect();
-
     let mut installed_packages: Vec<RepoDataRecord> =
         if locked_packages.is_null() || locked_packages.is_undefined() {
             vec![]
@@ -118,13 +92,13 @@ pub async fn simple_solve(
                         version: Version::from_str(&pkg.version)?.into(),
                         build: pkg.build.clone(),
                         build_number: pkg.build_number,
-                        subdir: "unknown".to_string(),
                         md5: None,
                         sha256: None,
                         size: None,
                         arch: None,
                         platform: None,
                         depends: pkg.depends.unwrap_or_default(),
+                        subdir:pkg.subdir.unwrap_or_else(|| "unknown".to_string()),
                         extra_depends: BTreeMap::new(),
                         constrains: vec![],
                         track_features: vec![],
@@ -152,40 +126,88 @@ pub async fn simple_solve(
             records
         };
 
-    // if a locked package does not include depends then depends will be taken from repodata
-    for records in installed_packages.iter_mut() {
-        let key = (
-            records.package_record.name.as_normalized().to_string(),
-            records.package_record.version.to_string(),
-            &records.package_record.build,
-        );
+    //if we do not need to solve the same packages, then filter them
+    let filtered_specs: Vec<MatchSpec> = specs.clone()
+    .into_iter()
+    .filter(|spec| {
+        let matched = installed_packages
+            .iter()
+            .any(|rec| spec.matches(&rec.package_record));
 
-        if records.package_record.depends.is_empty() {
-            if let Some(deps) = repodata_keys.get(&key) {
-                records.package_record.depends = deps.to_vec();
+        !matched
+    })
+    .collect();
+
+
+    if filtered_specs.is_empty() {
+        Ok(vec![])
+    } else {
+        // Fetch the repodata
+        let gateway = Gateway::builder()
+            .with_channel_config(rattler_repodata_gateway::ChannelConfig {
+                default: SourceConfig {
+                    sharded_enabled: true,
+                    ..SourceConfig::default()
+                },
+                ..rattler_repodata_gateway::ChannelConfig::default()
+            })
+            .finish();
+
+        let repodata = gateway
+            .query(channels, platforms, specs.iter().cloned())
+            .recursive(true)
+            .execute()
+            .await?;
+
+        // We need this to find depends for locked packages
+        let repodata_keys: HashMap<(String, String, &String), &Vec<String>> = repodata
+            .iter()
+            .flat_map(|r| r.iter())
+            .map(|rec| {
+                let name = rec.package_record.name.as_normalized().to_string();
+                let version = rec.package_record.version.to_string();
+                let build = &rec.package_record.build;
+                ((name, version, build), &rec.package_record.depends)
+            })
+            .collect();
+
+        // if a locked package does not include depends then depends will be taken from repodata
+        for records in installed_packages.iter_mut() {
+            let key = (
+                records.package_record.name.as_normalized().to_string(),
+                records.package_record.version.to_string(),
+                &records.package_record.build,
+            );
+
+            if records.package_record.depends.is_empty() {
+                if let Some(deps) = repodata_keys.get(&key) {
+                    records.package_record.depends = deps.to_vec();
+                }
             }
         }
+
+        let task = SolverTask {
+            specs,
+            locked_packages: installed_packages,
+            ..repodata.iter().collect::<SolverTask<_>>()
+        };
+
+        let solved = rattler_solve::resolvo::Solver.solve(task)?;
+
+        Ok(solved
+            .records
+            .into_iter()
+            .map(|r| SolvedPackage {
+                url: r.url.to_string(),
+                package_name: r.package_record.name.as_source().to_string(),
+                build: r.package_record.build.clone(),
+                build_number: r.package_record.build_number,
+                repo_name: r.channel,
+                filename: r.file_name,
+                version: r.package_record.version.to_string(),
+                depends: r.package_record.depends,
+                subdir: r.package_record.subdir
+            })
+            .collect())
     }
-
-    let task = SolverTask {
-        specs,
-        locked_packages: installed_packages,
-        ..repodata.iter().collect::<SolverTask<_>>()
-    };
-
-    let solved = rattler_solve::resolvo::Solver.solve(task)?;
-
-    Ok(solved
-        .records
-        .into_iter()
-        .map(|r| SolvedPackage {
-            url: r.url.to_string(),
-            package_name: r.package_record.name.as_source().to_string(),
-            build: r.package_record.build.clone(),
-            build_number: r.package_record.build_number,
-            repo_name: r.channel,
-            filename: r.file_name,
-            version: r.package_record.version.to_string(),
-        })
-        .collect())
 }

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -88,7 +88,7 @@ pub async fn simple_solve(
         .execute()
         .await?;
 
-    // We need this to find depens for locked packages
+    // We need this to find depends for locked packages
     let repodata_keys: HashMap<(String, String, String), Vec<String>> = repodata
         .iter()
         .flat_map(|r| r.iter())

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -122,7 +122,6 @@ pub async fn simple_solve(
                     })
                 })
                 .collect::<Result<Vec<_>, JsError>>()?;
-
         };
 
     //if we do not need to solve the same packages, then filter them

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 
 use crate::{error::JsError, platform::JsPlatform};
 use rattler_conda_types::{
-    Channel, ChannelConfig, MatchSpec, NoArchType, PackageName, PackageRecord, ParseChannelError,
-    ParseStrictness::Lenient, RepoDataRecord, Version, Matches,
+    Channel, ChannelConfig, MatchSpec, Matches, NoArchType, PackageName, PackageRecord,
+    ParseChannelError, ParseStrictness::Lenient, RepoDataRecord, Version,
 };
 use rattler_repodata_gateway::{Gateway, SourceConfig};
 use rattler_solve::{SolverImpl, SolverTask};
@@ -98,7 +98,7 @@ pub async fn simple_solve(
                         arch: None,
                         platform: None,
                         depends: pkg.depends.unwrap_or_default(),
-                        subdir:pkg.subdir.unwrap_or_else(|| "unknown".to_string()),
+                        subdir: pkg.subdir.unwrap_or_else(|| "unknown".to_string()),
                         extra_depends: BTreeMap::new(),
                         constrains: vec![],
                         track_features: vec![],
@@ -127,17 +127,17 @@ pub async fn simple_solve(
         };
 
     //if we do not need to solve the same packages, then filter them
-    let filtered_specs: Vec<MatchSpec> = specs.clone()
-    .into_iter()
-    .filter(|spec| {
-        let matched = installed_packages
-            .iter()
-            .any(|rec| spec.matches(&rec.package_record));
+    let filtered_specs: Vec<MatchSpec> = specs
+        .clone()
+        .into_iter()
+        .filter(|spec| {
+            let matched = installed_packages
+                .iter()
+                .any(|rec| spec.matches(&rec.package_record));
 
-        !matched
-    })
-    .collect();
-
+            !matched
+        })
+        .collect();
 
     if filtered_specs.is_empty() {
         Ok(vec![])
@@ -206,7 +206,7 @@ pub async fn simple_solve(
                 filename: r.file_name,
                 version: r.package_record.version.to_string(),
                 depends: r.package_record.depends,
-                subdir: r.package_record.subdir
+                subdir: r.package_record.subdir,
             })
             .collect())
     }

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -112,17 +112,13 @@ pub async fn simple_solve(
         };
 
     //if we do not need to solve the same packages, then filter them
-    let filtered_specs: Vec<MatchSpec> = specs
-        .clone()
-        .into_iter()
-        .filter(|spec| {
-            !installed_packages
-                .iter()
-                .any(|rec| spec.matches(&rec.package_record))
-        })
-        .collect();
+    let all_matched = specs.clone().iter().all(|spec| {
+        installed_packages
+            .iter()
+            .any(|rec| spec.matches(&rec.package_record))
+    });
 
-    if filtered_specs.is_empty() {
+    if all_matched {
         return Ok(vec![]);
     }
     // Fetch the repodata
@@ -170,7 +166,7 @@ pub async fn simple_solve(
     }
 
     let task = SolverTask {
-        specs: filtered_specs,
+        specs,
         locked_packages: installed_packages,
         ..repodata.iter().collect::<SolverTask<_>>()
     };

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -121,7 +121,7 @@ pub async fn simple_solve(
                         package_record: rec.clone(),
                     })
                 })
-                .collect::<Result<Vec<_>, JsError>>()?;
+                .collect::<Result<Vec<_>, JsError>>()?
         };
 
     //if we do not need to solve the same packages, then filter them

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -1,20 +1,18 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use crate::{error::JsError, platform::JsPlatform};
 use rattler_conda_types::{
-    ParseChannelError, Channel, ChannelConfig, MatchSpec, ParseStrictness::Lenient, PackageName, Version, RepoDataRecord, PackageRecord,
+    Channel, ChannelConfig, MatchSpec, NoArchType, PackageName, PackageRecord, ParseChannelError,
+    ParseStrictness::Lenient, RepoDataRecord, Version,
 };
 use rattler_repodata_gateway::{Gateway, SourceConfig};
 use rattler_solve::{SolverImpl, SolverTask};
-use wasm_bindgen::prelude::*;
-
-use crate::{error::JsError, platform::JsPlatform};
-
-use web_sys::console::log_1;
-use serde::{Serialize, Deserialize};
-
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::collections::HashSet;
 use url::Url;
-
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Serialize)]
@@ -31,8 +29,7 @@ pub struct SolvedPackage {
     pub version: String,
 }
 
-
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct JsLockedPackage {
     url: String,
@@ -40,7 +37,9 @@ struct JsLockedPackage {
     build: String,
     repo_name: Option<String>,
     filename: String,
-    version: String
+    version: String,
+    depends: Option<Vec<String>>,
+    build_number: u64,
 }
 
 /// Solve a set of specs with the given channels and platforms.
@@ -89,40 +88,70 @@ pub async fn simple_solve(
         .execute()
         .await?;
 
-  
-  let installed_packages: Option<Vec<RepoDataRecord>> = if locked_packages.is_null() || locked_packages.is_undefined() {
-        None
-    } else {
-        let js_locked_packages: Vec<JsLockedPackage> =
-            serde_wasm_bindgen::from_value(locked_packages).map_err(JsError::from)?;
+    let (installed_packages, installed_filter_keys): (Option<Vec<RepoDataRecord>>, HashSet<_>) =
+        if locked_packages.is_null() || locked_packages.is_undefined() {
+            (None, HashSet::new())
+        } else {
+            let js_locked_packages: Vec<JsLockedPackage> =
+                serde_wasm_bindgen::from_value(locked_packages).map_err(JsError::from)?;
+            let js_locked_packages_for_filter = js_locked_packages.clone();
+            let records = js_locked_packages
+                .into_iter()
+                .map(|pkg| {
+                    let url = Url::parse(&pkg.url)
+                        .map_err(|e| JsError::from(ParseChannelError::from(e)))?;
 
-        let records = js_locked_packages
-            .into_iter()
-            .map(|pkg| {
-                let url = Url::parse(&pkg.url)
-                    .map_err(|e| JsError::from(ParseChannelError::from(e)))?;
+                    let rec = PackageRecord {
+                        name: PackageName::try_from(pkg.package_name.clone())?,
+                        version: Version::from_str(&pkg.version)?.into(),
+                        build: pkg.build.clone(),
+                        build_number: pkg.build_number,
+                        subdir: "unknown".to_string(),
+                        md5: None,
+                        sha256: None,
+                        size: None,
+                        arch: None,
+                        platform: None,
+                        depends: pkg.depends.unwrap_or_default(),
+                        extra_depends: BTreeMap::new(),
+                        constrains: vec![],
+                        track_features: vec![],
+                        features: None,
+                        noarch: NoArchType::none(),
+                        license: None,
+                        license_family: None,
+                        timestamp: None,
+                        python_site_packages_path: None,
+                        legacy_bz2_md5: None,
+                        legacy_bz2_size: None,
+                        purls: None,
+                        run_exports: None,
+                    };
 
-                  let rec = PackageRecord {
-                    ..PackageRecord::new(
-                        PackageName::try_from(pkg.package_name.clone())?,
-                        Version::from_str(&pkg.version)?,
-                        pkg.build.clone(),
-                    )
-                };
-
-                Ok(RepoDataRecord {
-                    url,
-                    file_name: pkg.filename,
-                    channel: pkg.repo_name,
-                    package_record:rec.clone()
+                    Ok(RepoDataRecord {
+                        url,
+                        file_name: pkg.filename,
+                        channel: pkg.repo_name,
+                        package_record: rec.clone(),
+                    })
                 })
-            })
-            .collect::<Result<Vec<_>, JsError>>()?;
+                .collect::<Result<Vec<_>, JsError>>()?;
 
-        Some(records)
-    };
+            let installed_filter_keys: HashSet<_> = js_locked_packages_for_filter
+                .into_iter()
+                .map(|pkg| {
+                    Ok((
+                        PackageName::try_from(pkg.package_name.clone())?,
+                        Version::from_str(&pkg.version)?.into(),
+                        pkg.build.clone(),
+                    ))
+                })
+                .collect::<Result<_, JsError>>()?;
 
-        let task = SolverTask {
+            (Some(records), installed_filter_keys)
+        };
+
+    let task = SolverTask {
         specs,
         locked_packages: installed_packages.unwrap_or_default(),
         pinned_packages: vec![],
@@ -131,12 +160,17 @@ pub async fn simple_solve(
 
     let solved = rattler_solve::resolvo::Solver.solve(task)?;
 
-    let js_value = serde_wasm_bindgen::to_value(&solved.records).unwrap();
-    log_1(&js_value);
-
     Ok(solved
         .records
         .into_iter()
+        .filter(|r| {
+            let key = (
+                r.package_record.name.clone(),
+                r.package_record.version.clone(),
+                r.package_record.build.clone(),
+            );
+            !installed_filter_keys.contains(&key)
+        })
         .map(|r| SolvedPackage {
             url: r.url.to_string(),
             package_name: r.package_record.name.as_source().to_string(),

--- a/js-rattler/src/solve.test.ts
+++ b/js-rattler/src/solve.test.ts
@@ -10,6 +10,7 @@ describe("solving", () => {
                 "https://prefix.dev/conda-forge",
             ],
             ["emscripten-wasm32", "noarch"],
+            []
         ).then((result) => {
             const expectedPrefixes = [
                 "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python-",

--- a/js-rattler/src/solve.test.ts
+++ b/js-rattler/src/solve.test.ts
@@ -26,4 +26,79 @@ describe("solving", () => {
             });
         });
     });
+
+    it("python should yield three packages but numpy should not be solved again", () => {
+        let big = 1n;
+        let buildNumber = Number(big);
+        return simpleSolve(
+            ["python", "numpy"],
+            [
+                "https://prefix.dev/emscripten-forge-dev",
+                "https://prefix.dev/conda-forge",
+            ],
+            ["emscripten-wasm32", "noarch"],
+            [
+                {
+                    build: "py313h6394566_1",
+                    buildNumber,
+                    filename: "numpy-2.2.6-py313h6394566_1.tar.bz2",
+                    packageName: "numpy",
+                    repoName: "https://prefix.dev/emscripten-forge-dev/",
+                    url: "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.6-py313h6394566_1.tar.bz2",
+                    version: "2.2.6",
+                },
+            ],
+        ).then((result) => {
+            const expectedPrefixes = [
+                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python-",
+                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python_abi-",
+                "https://prefix.dev/emscripten-forge-dev/noarch/emscripten-abi-",
+            ];
+
+            const urls = result.map((pkg) => pkg.url).sort();
+            expect(urls.length).toBe(expectedPrefixes.length);
+
+            urls.forEach((url, index) => {
+                expect(url.startsWith(expectedPrefixes[index])).toBe(true);
+            });
+        });
+    });
+
+    it("there should be 4 packages with python and numpy", () => {
+        let big = 1n;
+        let buildNumber = Number(big);
+        return simpleSolve(
+            ["python", "numpy<2.2.6"],
+            [
+                "https://prefix.dev/emscripten-forge-dev",
+                "https://prefix.dev/conda-forge",
+            ],
+            ["emscripten-wasm32", "noarch"],
+            [
+                {
+                    build: "py313h6394566_1",
+                    buildNumber,
+                    filename: "numpy-2.2.6-py313h6394566_1.tar.bz2",
+                    packageName: "numpy",
+                    repoName: "https://prefix.dev/emscripten-forge-dev/",
+                    url: "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.6-py313h6394566_1.tar.bz2",
+                    version: "2.2.6",
+                },
+            ],
+        ).then((result) => {
+            const expectedPrefixes = [
+                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-",
+                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python-",
+                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python_abi-",
+                "https://prefix.dev/emscripten-forge-dev/noarch/emscripten-abi-",
+            ];
+
+            const urls = result.map((pkg) => pkg.url).sort();
+            expect(urls.length).toBe(expectedPrefixes.length);
+
+            urls.forEach((url, index) => {
+                expect(url.startsWith(expectedPrefixes[index])).toBe(true);
+            });
+        });
+    });
 });

--- a/js-rattler/src/solve.test.ts
+++ b/js-rattler/src/solve.test.ts
@@ -10,7 +10,7 @@ describe("solving", () => {
                 "https://prefix.dev/conda-forge",
             ],
             ["emscripten-wasm32", "noarch"],
-            []
+            [],
         ).then((result) => {
             const expectedPrefixes = [
                 "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python-",

--- a/js-rattler/src/solve.test.ts
+++ b/js-rattler/src/solve.test.ts
@@ -27,11 +27,11 @@ describe("solving", () => {
         });
     });
 
-    it("python should yield three packages but numpy should not be solved again", () => {
+    it("numpy should not be solved again", () => {
         let big = 1n;
         let buildNumber = Number(big);
         return simpleSolve(
-            ["python", "numpy"],
+            ["numpy"],
             [
                 "https://prefix.dev/emscripten-forge-dev",
                 "https://prefix.dev/conda-forge",
@@ -49,18 +49,7 @@ describe("solving", () => {
                 },
             ],
         ).then((result) => {
-            const expectedPrefixes = [
-                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python-",
-                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python_abi-",
-                "https://prefix.dev/emscripten-forge-dev/noarch/emscripten-abi-",
-            ];
-
-            const urls = result.map((pkg) => pkg.url).sort();
-            expect(urls.length).toBe(expectedPrefixes.length);
-
-            urls.forEach((url, index) => {
-                expect(url.startsWith(expectedPrefixes[index])).toBe(true);
-            });
+          expect(result.length).toBe(0);
         });
     });
 

--- a/js-rattler/src/solve.test.ts
+++ b/js-rattler/src/solve.test.ts
@@ -27,9 +27,48 @@ describe("solving", () => {
         });
     });
 
-    it("numpy should not be solved again", () => {
-        let big = 1n;
-        let buildNumber = Number(big);
+    it("python should yield three packages and numpy 2.2.0 should be returned", () => {
+        return simpleSolve(
+            ["python", "numpy"],
+            [
+                "https://prefix.dev/emscripten-forge-dev",
+                "https://prefix.dev/conda-forge",
+            ],
+            ["emscripten-wasm32", "noarch"],
+            [
+                {
+                    build: "h7223423_0",
+                    buildNumber: 0n,
+                    depends: [
+                        "emscripten-abi >=3.1.73,<3.1.74.0a0",
+                        "python_abi 3.13.* *_cp313",
+                    ],
+                    filename: "numpy-2.2.0-h7223423_0.tar.bz2",
+                    packageName: "numpy",
+                    repoName: "https://repo.prefix.dev/emscripten-forge-dev/",
+                    subdir: "emscripten-wasm32",
+                    url: "https://repo.prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.0-h7223423_0.tar.bz2",
+                    version: "2.2.0",
+                },
+            ],
+        ).then((result) => {
+            const expectedPrefixes = [
+                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python-",
+                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python_abi-",
+                "https://prefix.dev/emscripten-forge-dev/noarch/emscripten-abi-",
+                "https://repo.prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.0-",
+            ];
+
+            const urls = result.map((pkg) => pkg.url).sort();
+            expect(urls.length).toBe(expectedPrefixes.length);
+
+            urls.forEach((url, index) => {
+                expect(url.startsWith(expectedPrefixes[index])).toBe(true);
+            });
+        });
+    });
+
+    it("numpy 2.2.0 should be returned", () => {
         return simpleSolve(
             ["numpy"],
             [
@@ -39,25 +78,37 @@ describe("solving", () => {
             ["emscripten-wasm32", "noarch"],
             [
                 {
-                    build: "py313h6394566_1",
-                    buildNumber,
-                    filename: "numpy-2.2.6-py313h6394566_1.tar.bz2",
+                    build: "h7223423_0",
+                    buildNumber: 0n,
+                    depends: [
+                        "emscripten-abi >=3.1.73,<3.1.74.0a0",
+                        "python_abi 3.13.* *_cp313",
+                    ],
+                    filename: "numpy-2.2.0-h7223423_0.tar.bz2",
                     packageName: "numpy",
-                    repoName: "https://prefix.dev/emscripten-forge-dev/",
-                    url: "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.6-py313h6394566_1.tar.bz2",
-                    version: "2.2.6",
+                    repoName: "https://repo.prefix.dev/emscripten-forge-dev/",
+                    subdir: "emscripten-wasm32",
+                    url: "https://repo.prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.0-h7223423_0.tar.bz2",
+                    version: "2.2.0",
                 },
             ],
         ).then((result) => {
-          expect(result.length).toBe(0);
+            const expectedPrefixes = [
+                "https://repo.prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.0-",
+            ];
+
+            const urls = result.map((pkg) => pkg.url).sort();
+            expect(urls.length).toBe(expectedPrefixes.length);
+
+            urls.forEach((url, index) => {
+                expect(url.startsWith(expectedPrefixes[index])).toBe(true);
+            });
         });
     });
 
-    it("there should be 4 packages with python and numpy", () => {
-        let big = 1n;
-        let buildNumber = Number(big);
+    it("numpy=2.2.6 should be returned", () => {
         return simpleSolve(
-            ["python", "numpy<2.2.6"],
+            ["numpy=2.2.6"],
             [
                 "https://prefix.dev/emscripten-forge-dev",
                 "https://prefix.dev/conda-forge",
@@ -65,26 +116,29 @@ describe("solving", () => {
             ["emscripten-wasm32", "noarch"],
             [
                 {
-                    build: "py313h6394566_1",
-                    buildNumber,
-                    filename: "numpy-2.2.6-py313h6394566_1.tar.bz2",
+                    build: "h7223423_0",
+                    buildNumber: 0n,
+                    depends: [
+                        "emscripten-abi >=3.1.73,<3.1.74.0a0",
+                        "python_abi 3.13.* *_cp313",
+                    ],
+                    filename: "numpy-2.2.0-h7223423_0.tar.bz2",
                     packageName: "numpy",
-                    repoName: "https://prefix.dev/emscripten-forge-dev/",
-                    url: "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.6-py313h6394566_1.tar.bz2",
-                    version: "2.2.6",
+                    repoName: "https://repo.prefix.dev/emscripten-forge-dev/",
+                    subdir: "emscripten-wasm32",
+                    url: "https://repo.prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.0-h7223423_0.tar.bz2",
+                    version: "2.2.0",
                 },
             ],
         ).then((result) => {
             const expectedPrefixes = [
-                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-",
-                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python-",
+                "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.6-",
                 "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/python_abi-",
                 "https://prefix.dev/emscripten-forge-dev/noarch/emscripten-abi-",
             ];
 
             const urls = result.map((pkg) => pkg.url).sort();
             expect(urls.length).toBe(expectedPrefixes.length);
-
             urls.forEach((url, index) => {
                 expect(url.startsWith(expectedPrefixes[index])).toBe(true);
             });


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Now, the js-rattler solver does not accept previously installed packages but it should take care about it. 

This PR has next changes:
- adding locked_packages to the solver
- if a locked package does not have depends then this data will be taken from repodata

### The result
For example, using this code
```
const test = await simpleSolve(
  ["xeus-python ", "numpy"],
  ["https://repo.prefix.dev/emscripten-forge-dev","conda-forge"
  ],
  ["emscripten-wasm32", "noarch"],
  [{
      build: "py313h027658c_2",
      buildNumber,
      filename: "xeus-python-0.17.4-py313h027658c_2.tar.bz2",
      packageName: "xeus-python",
      repoName: "https://repo.prefix.dev/emscripten-forge-dev/",
      url: "https://repo.prefix.dev/emscripten-forge-dev/emscripten-wasm32/xeus-python-0.17.4-py313h027658c_2.tar.bz2",
      version: "0.17.4",
  }]
);
console.log('test',test);
```
we will have this result
![image](https://github.com/user-attachments/assets/7203a211-4c52-4bad-9970-8faf6aa8f70f)
