### PR TITLE
fix!: rename entrypoint to entry_point

### DIFF
--- a/py-rattler/rattler/prefix/prefix_paths.py
+++ b/py-rattler/rattler/prefix/prefix_paths.py
@@ -22,9 +22,9 @@ class PrefixPathType:
             "softlink",
             "directory",
             "pyc_file",
-            "windows_python_entrypoint_script",
-            "windows_python_entrypoint_exe",
-            "unix_python_entrypoint",
+            "windows_python_entry_point_script",
+            "windows_python_entry_point_exe",
+            "unix_python_entry_point",
         ],
     ) -> None:
         """
@@ -82,25 +82,25 @@ class PrefixPathType:
         return self._inner.pyc_file
 
     @property
-    def windows_python_entrypoint_script(self) -> bool:
+    def windows_python_entry_point_script(self) -> bool:
         """
         A Windows entry point python script (a <entrypoint>-script.py Python script file)
         """
-        return self._inner.windows_python_entrypoint_script
+        return self._inner.windows_python_entry_point_script
 
     @property
-    def windows_python_entrypoint_exe(self) -> bool:
+    def windows_python_entry_point_exe(self) -> bool:
         """
         A Windows entry point python script (a <entrypoint>.exe executable)
         """
-        return self._inner.windows_python_entrypoint_exe
+        return self._inner.windows_python_entry_point_exe
 
     @property
-    def unix_python_entrypoint(self) -> bool:
+    def unix_python_entry_point(self) -> bool:
         """
         A Unix entry point python script (a <entrypoint> Python script file)
         """
-        return self._inner.unix_python_entrypoint
+        return self._inner.unix_python_entry_point
 
 
 class PrefixPathsEntry(BasePathLike):

--- a/py-rattler/src/prefix_paths.rs
+++ b/py-rattler/src/prefix_paths.rs
@@ -130,13 +130,13 @@ impl PyPrefixPathType {
             "pyc_file" => Ok(Self {
                 inner: PathType::PycFile,
             }),
-            "windows_python_entrypoint_script" => Ok(Self {
+            "windows_python_entry_point_script" => Ok(Self {
                 inner: PathType::WindowsPythonEntryPointScript,
             }),
-            "windows_python_entrypoint_exe" => Ok(Self {
+            "windows_python_entry_point_exe" => Ok(Self {
                 inner: PathType::WindowsPythonEntryPointExe,
             }),
-            "unix_python_entrypoint" => Ok(Self {
+            "unix_python_entry_point" => Ok(Self {
                 inner: PathType::UnixPythonEntryPoint,
             }),
             _ => Err(PyValueError::new_err("Invalid path type")),
@@ -169,20 +169,20 @@ impl PyPrefixPathType {
 
     /// A Windows entry point python script (a <entrypoint>-script.py Python script file)
     #[getter]
-    pub fn windows_python_entrypoint_script(&self) -> bool {
+    pub fn windows_python_entry_point_script(&self) -> bool {
         matches!(&self.inner, PathType::WindowsPythonEntryPointScript)
     }
 
     /// A Windows Python entry point executable (a <entrypoint>.exe file)
     #[getter]
-    pub fn windows_python_entrypoint_exe(&self) -> bool {
+    pub fn windows_python_entry_point_exe(&self) -> bool {
         matches!(&self.inner, PathType::WindowsPythonEntryPointExe)
     }
 
     /// This file is a Python entry point executable for Unix (a `<entrypoint>` Python script file)
     /// Entry points are created in the `bin/...` directory when installing Python noarch packages
     #[getter]
-    pub fn unix_python_entrypoint(&self) -> bool {
+    pub fn unix_python_entry_point(&self) -> bool {
         matches!(&self.inner, PathType::UnixPythonEntryPoint)
     }
 }


### PR DESCRIPTION
Fixes #1340 

Renames `entrypoint` to `entry_point` (just as we have in Rust).