### PR TITLE
fix: properly dedup package names

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
@@ -26,3 +26,6 @@ expression: file_urls
 - channels/dummy/linux-64/track-features-1-xxx.tar.bz2
 - channels/dummy/linux-64/track-features-2-xxx.tar.bz2
 - channels/dummy/linux-64/track-features-4-xxx.tar.bz2
+- channels/dummy/linux-64/foobar-2.0-bla_1.conda
+- channels/dummy/linux-64/bors-2.1-bla_1.conda
+- channels/dummy/linux-64/issue_717-2.1-bla_1.conda

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
@@ -368,6 +368,54 @@ expression: json
       "version": "2"
     }
   },
-  "packages.conda": {},
+  "packages.conda": {
+    "bors-2.1-bla_1.conda": {
+      "build": "bla_1",
+      "build_number": 1,
+      "depends": [],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "bors",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1715610974,
+      "version": "2.1"
+    },
+    "foobar-2.0-bla_1.conda": {
+      "build": "bla_1",
+      "build_number": 1,
+      "depends": [
+        "bors <2.0"
+      ],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "foobar",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1605110689658,
+      "version": "2.0"
+    },
+    "issue_717-2.1-bla_1.conda": {
+      "build": "issue_717",
+      "build_number": 0,
+      "constrains": [
+        "ray[default,data] >=2.9.0,<3.0.0"
+      ],
+      "depends": [],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "issue_717",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1715610974,
+      "version": "2.1"
+    }
+  },
   "repodata_version": 2
 }

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
@@ -333,5 +333,47 @@ packages:
     subdir: linux-64
     timestamp: 1715610974
     version: "2"
-packages.conda: {}
+packages.conda:
+  bors-2.1-bla_1.conda:
+    build: bla_1
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: bors
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1715610974
+    version: "2.1"
+  foobar-2.0-bla_1.conda:
+    build: bla_1
+    build_number: 1
+    depends:
+      - bors <2.0
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: foobar
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: "2.0"
+  issue_717-2.1-bla_1.conda:
+    build: issue_717
+    build_number: 0
+    constrains:
+      - "ray[default,data] >=2.9.0,<3.0.0"
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: issue_717
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1715610974
+    version: "2.1"
 repodata_version: 2

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -12,7 +12,6 @@ use std::{
 
 use bytes::Bytes;
 use fs_err as fs;
-use itertools::Itertools;
 use rattler_conda_types::{
     compute_package_url, Channel, ChannelInfo, PackageName, PackageRecord, RepoDataRecord,
 };
@@ -165,14 +164,15 @@ impl SparseRepoData {
     /// This works by iterating over all elements in the `packages` and
     /// `conda_packages` fields of the repodata and returning the unique
     /// package names.
-    pub fn package_names(&self) -> impl Iterator<Item = &'_ str> + '_ {
+    pub fn package_names(&self) -> impl Iterator<Item = &'_ str> {
         let repo_data = self.inner.borrow_repo_data();
         repo_data
             .packages
             .iter()
             .chain(repo_data.conda_packages.iter())
             .map(|(name, _)| name.package)
-            .dedup()
+            .collect::<HashSet<_>>()
+            .into_iter()
     }
 
     /// Returns all the records for the specified package name.

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -12,6 +12,7 @@ use std::{
 
 use bytes::Bytes;
 use fs_err as fs;
+use itertools::Itertools;
 use rattler_conda_types::{
     compute_package_url, Channel, ChannelInfo, PackageName, PackageRecord, RepoDataRecord,
 };
@@ -166,13 +167,12 @@ impl SparseRepoData {
     /// package names.
     pub fn package_names(&self) -> impl Iterator<Item = &'_ str> {
         let repo_data = self.inner.borrow_repo_data();
-        repo_data
-            .packages
+        let tar_baz2_packages = repo_data.packages.iter().map(|(name, _)| name.package);
+        let conda_packages = repo_data
+            .conda_packages
             .iter()
-            .chain(repo_data.conda_packages.iter())
-            .map(|(name, _)| name.package)
-            .collect::<HashSet<_>>()
-            .into_iter()
+            .map(|(name, _)| name.package);
+        tar_baz2_packages.merge(conda_packages).dedup()
     }
 
     /// Returns all the records for the specified package name.
@@ -495,7 +495,10 @@ impl<'de> TryFrom<&'de str> for PackageFilename<'de> {
 
 #[cfg(test)]
 mod test {
-    use std::path::{Path, PathBuf};
+    use std::{
+        collections::HashSet,
+        path::{Path, PathBuf},
+    };
 
     use bytes::Bytes;
     use fs_err as fs;
@@ -526,6 +529,15 @@ mod test {
                 test_dir().join("channels/conda-forge/linux-64/repodata.json"),
             ),
         ]
+    }
+
+    fn dummy_repo_data() -> (Channel, &'static str, PathBuf) {
+        let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
+        (
+            Channel::from_str("dummy", &channel_config).unwrap(),
+            "linux-64",
+            test_dir().join("channels/dummy/linux-64/repodata.json"),
+        )
     }
 
     async fn default_repo_data_bytes() -> Vec<(Channel, &'static str, Bytes)> {
@@ -719,5 +731,14 @@ mod test {
 
         assert_eq!(repo_data.packages.len(), 0);
         assert_eq!(sparse_repodata.package_names().try_len().unwrap(), 0);
+    }
+
+    #[test]
+    fn dedup_packages() {
+        let (channel, platform, path) = dummy_repo_data();
+        let sparse = SparseRepoData::from_file(channel, platform, path, None).unwrap();
+        let names = sparse.package_names().collect_vec();
+        let deduped_names = names.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(names.len(), deduped_names.len());
     }
 }

--- a/test-data/channels/dummy/linux-64/repodata.json
+++ b/test-data/channels/dummy/linux-64/repodata.json
@@ -368,6 +368,55 @@
       "track_features": ["   foo   ","  bar  "]
     }
   },
-  "packages.conda": {},
+  "packages.conda": {
+    "foobar-2.0-bla_1.conda": {
+      "build": "bla_1",
+      "build_number": 1,
+      "depends": [
+        "bors <2.0"
+      ],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "foobar",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1605110689658,
+      "version": "2.0"
+    },
+    "bors-2.1-bla_1.conda": {
+      "build": "bla_1",
+      "build_number": 1,
+      "depends": [
+      ],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "bors",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1715610974000,
+      "version": "2.1"
+    },
+    "issue_717-2.1-bla_1.conda": {
+      "build": "issue_717",
+      "build_number": 0,
+      "depends": [],
+      "constrains": [
+        "ray[default,data] >=2.9.0,<3.0.0"
+      ],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "issue_717",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1715610974000,
+      "version": "2.1"
+    }
+  },
   "repodata_version": 2
 }


### PR DESCRIPTION
Fixes #1330 

Packages names werent properly deduplicated in the sparse repodata when both .conda and .tar.bz2 packages were present. This PR fixes that. Also added a test to verify this behavior.