### PR TITLE
fix: add missing `created_at` in shards

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/sharded.rs
+++ b/crates/rattler_conda_types/src/repo_data/sharded.rs
@@ -1,4 +1,6 @@
 //! Structs to deal with repodata "shards" which are per-package repodata files.
+
+use chrono::{DateTime, Utc};
 use fxhash::{FxHashMap, FxHashSet};
 use rattler_digest::Sha256Hash;
 use serde::{Deserialize, Serialize};
@@ -6,16 +8,19 @@ use serde::{Deserialize, Serialize};
 use crate::PackageRecord;
 
 /// The sharded repodata holds a hashmap of package name -> shard (hash).
-/// This index file is stored under `<channel>/<subdir>/repodata_shards.msgpack.zst`
+/// This index file is stored under
+/// `<channel>/<subdir>/repodata_shards.msgpack.zst`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShardedRepodata {
-    /// Additional information about the sharded subdirectory such as the base url.
+    /// Additional information about the sharded subdirectory such as the base
+    /// url.
     pub info: ShardedSubdirInfo,
     /// The individual shards indexed by package name.
     pub shards: FxHashMap<String, Sha256Hash>,
 }
 
-/// Information about a sharded subdirectory that is stored inside the index file.
+/// Information about a sharded subdirectory that is stored inside the index
+/// file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShardedSubdirInfo {
     /// The name of the subdirectory
@@ -27,11 +32,15 @@ pub struct ShardedSubdirInfo {
     /// This is used to construct the full url of the packages.
     pub base_url: String,
 
-    /// The base url of the individual shards. This is the location where the actual
-    /// packages are stored.
+    /// The base url of the individual shards. This is the location where the
+    /// actual packages are stored.
     ///
     /// This is used to construct the full url of the shard.
     pub shards_base_url: String,
+
+    /// The date at which this entry was created.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
 }
 
 /// An individual shard that contains repodata for a single package name.


### PR DESCRIPTION
Fixes #1326 

Adds the `created_at` field to the sharded subdir info. The field can be optional.