### PR TITLE
feat: control over selection of .conda and .tar.bz2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,6 +4570,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "simple_spawn_blocking",
+ "strum",
  "superslice",
  "tempfile",
  "thiserror 2.0.12",

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
@@ -29,4 +29,4 @@ expression: file_urls
 - channels/dummy/linux-64/foobar-2.0-bla_1.conda
 - channels/dummy/linux-64/bors-2.1-bla_1.conda
 - channels/dummy/linux-64/issue_717-2.1-bla_1.conda
-- channels/dummy/linux-64/bors-1.1-bla_1.tar.bz2
+- channels/dummy/linux-64/bors-1.1-bla_1.conda

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
@@ -29,3 +29,4 @@ expression: file_urls
 - channels/dummy/linux-64/foobar-2.0-bla_1.conda
 - channels/dummy/linux-64/bors-2.1-bla_1.conda
 - channels/dummy/linux-64/issue_717-2.1-bla_1.conda
+- channels/dummy/linux-64/bors-1.1-bla_1.tar.bz2

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
@@ -369,6 +369,20 @@ expression: json
     }
   },
   "packages.conda": {
+    "bors-1.1-bla_1.conda": {
+      "build": "bla_1",
+      "build_number": 1,
+      "depends": [],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "bors",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1605110689658,
+      "version": "1.1"
+    },
     "bors-2.1-bla_1.conda": {
       "build": "bla_1",
       "build_number": 1,

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
@@ -334,7 +334,7 @@ packages:
     timestamp: 1715610974
     version: "2"
 packages.conda:
-  bors-1.1-bla_1.tar.bz2:
+  bors-1.1-bla_1.conda:
     build: bla_1
     build_number: 1
     depends: []

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
@@ -334,6 +334,19 @@ packages:
     timestamp: 1715610974
     version: "2"
 packages.conda:
+  bors-1.1-bla_1.tar.bz2:
+    build: bla_1
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: bors
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: "1.1"
   bors-2.1-bla_1.conda:
     build: bla_1
     build_number: 1

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -43,6 +43,7 @@ rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+strum = { workspace = true }
 superslice = { workspace = true, optional = true }
 
 tempfile = { workspace = true }

--- a/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
@@ -4,7 +4,7 @@ use rattler_conda_types::{Channel, PackageName, RepoDataRecord};
 
 use crate::{
     gateway::{error::SubdirNotFoundError, subdir::SubdirClient, GatewayError},
-    sparse::{SparseRepoData, VariantSelection},
+    sparse::{PackageFormatSelection, SparseRepoData},
     Reporter,
 };
 
@@ -73,14 +73,15 @@ impl SubdirClient for LocalSubdirClient {
         let sparse_repodata = self.sparse.clone();
         let name = name.clone();
 
-        let load_records =
-            move || match sparse_repodata.load_records(&name, VariantSelection::PreferConda) {
-                Ok(records) => Ok(records.into()),
-                Err(err) => Err(GatewayError::IoError(
-                    "failed to extract repodata records from sparse repodata".to_string(),
-                    err,
-                )),
-            };
+        let load_records = move || match sparse_repodata
+            .load_records(&name, PackageFormatSelection::PreferConda)
+        {
+            Ok(records) => Ok(records.into()),
+            Err(err) => Err(GatewayError::IoError(
+                "failed to extract repodata records from sparse repodata".to_string(),
+                err,
+            )),
+        };
 
         #[cfg(target_arch = "wasm32")]
         return load_records();

--- a/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
@@ -4,7 +4,7 @@ use rattler_conda_types::{Channel, PackageName, RepoDataRecord};
 
 use crate::{
     gateway::{error::SubdirNotFoundError, subdir::SubdirClient, GatewayError},
-    sparse::SparseRepoData,
+    sparse::{SparseRepoData, VariantSelection},
     Reporter,
 };
 
@@ -73,13 +73,14 @@ impl SubdirClient for LocalSubdirClient {
         let sparse_repodata = self.sparse.clone();
         let name = name.clone();
 
-        let load_records = move || match sparse_repodata.load_records(&name) {
-            Ok(records) => Ok(records.into()),
-            Err(err) => Err(GatewayError::IoError(
-                "failed to extract repodata records from sparse repodata".to_string(),
-                err,
-            )),
-        };
+        let load_records =
+            move || match sparse_repodata.load_records(&name, VariantSelection::PreferConda) {
+                Ok(records) => Ok(records.into()),
+                Err(err) => Err(GatewayError::IoError(
+                    "failed to extract repodata records from sparse repodata".to_string(),
+                    err,
+                )),
+            };
 
         #[cfg(target_arch = "wasm32")]
         return load_records();

--- a/crates/rattler_repodata_gateway/src/sparse/snapshots/rattler_repodata_gateway__sparse__test__only_conda@both.snap
+++ b/crates/rattler_repodata_gateway/src/sparse/snapshots/rattler_repodata_gateway__sparse__test__only_conda@both.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rattler_repodata_gateway/src/sparse/mod.rs
+expression: "records.join(\"\\n\")"
+---
+bors-1.0-bla_1.tar.bz2
+bors-1.1-bla_1.tar.bz2
+bors-1.2.1-bla_1.tar.bz2
+bors-2.0-bla_1.tar.bz2
+bors-2.1-bla_1.tar.bz2
+bors-1.1-bla_1.conda
+bors-2.1-bla_1.conda

--- a/crates/rattler_repodata_gateway/src/sparse/snapshots/rattler_repodata_gateway__sparse__test__only_conda@only-conda.snap
+++ b/crates/rattler_repodata_gateway/src/sparse/snapshots/rattler_repodata_gateway__sparse__test__only_conda@only-conda.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rattler_repodata_gateway/src/sparse/mod.rs
+expression: "records.join(\"\\n\")"
+---
+bors-1.1-bla_1.conda
+bors-2.1-bla_1.conda

--- a/crates/rattler_repodata_gateway/src/sparse/snapshots/rattler_repodata_gateway__sparse__test__only_conda@only-tar-bz2.snap
+++ b/crates/rattler_repodata_gateway/src/sparse/snapshots/rattler_repodata_gateway__sparse__test__only_conda@only-tar-bz2.snap
@@ -1,0 +1,9 @@
+---
+source: crates/rattler_repodata_gateway/src/sparse/mod.rs
+expression: "records.join(\"\\n\")"
+---
+bors-1.0-bla_1.tar.bz2
+bors-1.1-bla_1.tar.bz2
+bors-1.2.1-bla_1.tar.bz2
+bors-2.0-bla_1.tar.bz2
+bors-2.1-bla_1.tar.bz2

--- a/crates/rattler_repodata_gateway/src/sparse/snapshots/rattler_repodata_gateway__sparse__test__only_conda@prefer-conda.snap
+++ b/crates/rattler_repodata_gateway/src/sparse/snapshots/rattler_repodata_gateway__sparse__test__only_conda@prefer-conda.snap
@@ -1,0 +1,9 @@
+---
+source: crates/rattler_repodata_gateway/src/sparse/mod.rs
+expression: "records.join(\"\\n\")"
+---
+bors-1.0-bla_1.tar.bz2
+bors-1.1-bla_1.conda
+bors-1.2.1-bla_1.tar.bz2
+bors-2.0-bla_1.tar.bz2
+bors-2.1-bla_1.conda

--- a/crates/rattler_solve/benches/bench.rs
+++ b/crates/rattler_solve/benches/bench.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
 use rattler_conda_types::ParseStrictness::Strict;
 use rattler_conda_types::{Channel, ChannelConfig, MatchSpec};
-use rattler_repodata_gateway::sparse::{SparseRepoData, VariantSelection};
+use rattler_repodata_gateway::sparse::{PackageFormatSelection, SparseRepoData};
 use rattler_solve::{SolverImpl, SolverTask};
 
 fn conda_json_path() -> String {
@@ -59,7 +59,7 @@ fn bench_solve_environment(c: &mut Criterion, specs: Vec<&str>) {
         &sparse_repo_data,
         names,
         None,
-        VariantSelection::default(),
+        PackageFormatSelection::default(),
     )
     .unwrap();
 

--- a/crates/rattler_solve/benches/bench.rs
+++ b/crates/rattler_solve/benches/bench.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
 use rattler_conda_types::ParseStrictness::Strict;
 use rattler_conda_types::{Channel, ChannelConfig, MatchSpec};
-use rattler_repodata_gateway::sparse::SparseRepoData;
+use rattler_repodata_gateway::sparse::{SparseRepoData, VariantSelection};
 use rattler_solve::{SolverImpl, SolverTask};
 
 fn conda_json_path() -> String {
@@ -55,8 +55,13 @@ fn bench_solve_environment(c: &mut Criterion, specs: Vec<&str>) {
     ];
 
     let names = specs.iter().map(|s| s.name.clone().unwrap());
-    let available_packages =
-        SparseRepoData::load_records_recursive(&sparse_repo_data, names, None).unwrap();
+    let available_packages = SparseRepoData::load_records_recursive(
+        &sparse_repo_data,
+        names,
+        None,
+        VariantSelection::default(),
+    )
+    .unwrap();
 
     #[cfg(feature = "libsolv_c")]
     group.bench_function("libsolv_c", |b| {

--- a/crates/rattler_solve/benches/sorting_bench.rs
+++ b/crates/rattler_solve/benches/sorting_bench.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use futures::FutureExt;
 use rattler_conda_types::{Channel, MatchSpec};
-use rattler_repodata_gateway::sparse::{SparseRepoData, VariantSelection};
+use rattler_repodata_gateway::sparse::{PackageFormatSelection, SparseRepoData};
 use rattler_solve::{resolvo::CondaDependencyProvider, ChannelPriority};
 use resolvo::SolverCache;
 
@@ -16,7 +16,7 @@ fn bench_sort(c: &mut Criterion, sparse_repo_data: &SparseRepoData, spec: &str) 
         [sparse_repo_data],
         [package_name.clone()],
         None,
-        VariantSelection::default(),
+        PackageFormatSelection::default(),
     )
     .expect("failed to load records");
 

--- a/crates/rattler_solve/benches/sorting_bench.rs
+++ b/crates/rattler_solve/benches/sorting_bench.rs
@@ -3,9 +3,8 @@ use std::path::Path;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use futures::FutureExt;
 use rattler_conda_types::{Channel, MatchSpec};
-use rattler_repodata_gateway::sparse::SparseRepoData;
-use rattler_solve::resolvo::CondaDependencyProvider;
-use rattler_solve::ChannelPriority;
+use rattler_repodata_gateway::sparse::{SparseRepoData, VariantSelection};
+use rattler_solve::{resolvo::CondaDependencyProvider, ChannelPriority};
 use resolvo::SolverCache;
 
 fn bench_sort(c: &mut Criterion, sparse_repo_data: &SparseRepoData, spec: &str) {
@@ -13,9 +12,13 @@ fn bench_sort(c: &mut Criterion, sparse_repo_data: &SparseRepoData, spec: &str) 
         MatchSpec::from_str(spec, rattler_conda_types::ParseStrictness::Lenient).unwrap();
     let package_name = match_spec.name.clone().unwrap();
 
-    let repodata =
-        SparseRepoData::load_records_recursive([sparse_repo_data], [package_name.clone()], None)
-            .expect("failed to load records");
+    let repodata = SparseRepoData::load_records_recursive(
+        [sparse_repo_data],
+        [package_name.clone()],
+        None,
+        VariantSelection::default(),
+    )
+    .expect("failed to load records");
 
     // Construct a cache
     c.bench_function(&format!("sort {spec}"), |b| {

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -6,7 +6,7 @@ use rattler_conda_types::{
     Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, NoArchType, PackageRecord,
     ParseStrictness, RepoData, RepoDataRecord, SolverResult, Version,
 };
-use rattler_repodata_gateway::sparse::SparseRepoData;
+use rattler_repodata_gateway::sparse::{SparseRepoData, VariantSelection};
 use rattler_solve::{ChannelPriority, SolveError, SolveStrategy, SolverImpl, SolverTask};
 use url::Url;
 
@@ -133,8 +133,13 @@ fn solve_real_world<T: SolverImpl + Default>(specs: Vec<&str>) -> Vec<String> {
     let sparse_repo_data = read_real_world_repo_data();
 
     let names = specs.iter().filter_map(|s| s.name.as_ref().cloned());
-    let available_packages =
-        SparseRepoData::load_records_recursive(sparse_repo_data, names, None).unwrap();
+    let available_packages = SparseRepoData::load_records_recursive(
+        sparse_repo_data,
+        names,
+        None,
+        VariantSelection::default(),
+    )
+    .unwrap();
 
     let solver_task = SolverTask {
         specs: specs.clone(),
@@ -1397,8 +1402,13 @@ fn compare_solve(task: CompareTask<'_>) {
     let sparse_repo_data = read_real_world_repo_data();
 
     let names = specs.iter().filter_map(|s| s.name.as_ref().cloned());
-    let available_packages =
-        SparseRepoData::load_records_recursive(sparse_repo_data, names, None).unwrap();
+    let available_packages = SparseRepoData::load_records_recursive(
+        sparse_repo_data,
+        names,
+        None,
+        VariantSelection::default(),
+    )
+    .unwrap();
 
     let extract_pkgs = |records: Vec<RepoDataRecord>| {
         let mut pkgs = records
@@ -1530,7 +1540,8 @@ fn solve_to_get_channel_of_spec<T: SolverImpl + Default>(
     let names = specs.iter().filter_map(|s| s.name.as_ref().cloned());
 
     let available_packages =
-        SparseRepoData::load_records_recursive(repo_data, names, None).unwrap();
+        SparseRepoData::load_records_recursive(repo_data, names, None, VariantSelection::default())
+            .unwrap();
 
     let task = SolverTask {
         specs: specs.clone(),

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -6,7 +6,7 @@ use rattler_conda_types::{
     Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, NoArchType, PackageRecord,
     ParseStrictness, RepoData, RepoDataRecord, SolverResult, Version,
 };
-use rattler_repodata_gateway::sparse::{SparseRepoData, VariantSelection};
+use rattler_repodata_gateway::sparse::{PackageFormatSelection, SparseRepoData};
 use rattler_solve::{ChannelPriority, SolveError, SolveStrategy, SolverImpl, SolverTask};
 use url::Url;
 
@@ -137,7 +137,7 @@ fn solve_real_world<T: SolverImpl + Default>(specs: Vec<&str>) -> Vec<String> {
         sparse_repo_data,
         names,
         None,
-        VariantSelection::default(),
+        PackageFormatSelection::default(),
     )
     .unwrap();
 
@@ -1406,7 +1406,7 @@ fn compare_solve(task: CompareTask<'_>) {
         sparse_repo_data,
         names,
         None,
-        VariantSelection::default(),
+        PackageFormatSelection::default(),
     )
     .unwrap();
 
@@ -1539,9 +1539,13 @@ fn solve_to_get_channel_of_spec<T: SolverImpl + Default>(
     let specs = vec![spec.clone()];
     let names = specs.iter().filter_map(|s| s.name.as_ref().cloned());
 
-    let available_packages =
-        SparseRepoData::load_records_recursive(repo_data, names, None, VariantSelection::default())
-            .unwrap();
+    let available_packages = SparseRepoData::load_records_recursive(
+        repo_data,
+        names,
+        None,
+        PackageFormatSelection::default(),
+    )
+    .unwrap();
 
     let task = SolverTask {
         specs: specs.clone(),

--- a/crates/rattler_solve/tests/sorting.rs
+++ b/crates/rattler_solve/tests/sorting.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use rattler_conda_types::{
     Channel, MatchSpec, PackageName, ParseStrictness::Lenient, RepoDataRecord,
 };
-use rattler_repodata_gateway::sparse::{SparseRepoData, VariantSelection};
+use rattler_repodata_gateway::sparse::{PackageFormatSelection, SparseRepoData};
 use rattler_solve::{resolvo::CondaDependencyProvider, ChannelPriority, SolveStrategy};
 use resolvo::{Interner, SolverCache};
 use rstest::*;
@@ -28,7 +28,7 @@ fn load_repodata(package_name: &PackageName) -> Vec<Vec<RepoDataRecord>> {
         &[sparse_repo_data],
         [package_name.clone()],
         None,
-        VariantSelection::default(),
+        PackageFormatSelection::default(),
     )
     .expect("failed to load records")
 }

--- a/crates/rattler_solve/tests/sorting.rs
+++ b/crates/rattler_solve/tests/sorting.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use rattler_conda_types::{
     Channel, MatchSpec, PackageName, ParseStrictness::Lenient, RepoDataRecord,
 };
-use rattler_repodata_gateway::sparse::SparseRepoData;
+use rattler_repodata_gateway::sparse::{SparseRepoData, VariantSelection};
 use rattler_solve::{resolvo::CondaDependencyProvider, ChannelPriority, SolveStrategy};
 use resolvo::{Interner, SolverCache};
 use rstest::*;
@@ -24,8 +24,13 @@ fn load_repodata(package_name: &PackageName) -> Vec<Vec<RepoDataRecord>> {
     let sparse_repo_data = SparseRepoData::from_file(channel, "linux-64", repodata_json_path, None)
         .expect("failed to load sparse repodata");
 
-    SparseRepoData::load_records_recursive(&[sparse_repo_data], [package_name.clone()], None)
-        .expect("failed to load records")
+    SparseRepoData::load_records_recursive(
+        &[sparse_repo_data],
+        [package_name.clone()],
+        None,
+        VariantSelection::default(),
+    )
+    .expect("failed to load records")
 }
 
 fn create_sorting_snapshot(package_name: &str, strategy: SolveStrategy) -> String {

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -4093,6 +4093,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "simple_spawn_blocking",
+ "strum",
  "superslice",
  "tempfile",
  "thiserror 2.0.12",

--- a/py-rattler/rattler/__init__.py
+++ b/py-rattler/rattler/__init__.py
@@ -8,6 +8,7 @@ from rattler.repo_data import (
     SparseRepoData,
     Gateway,
     SourceConfig,
+    PackageFormatSelection,
 )
 from rattler.channel import Channel, ChannelConfig, ChannelPriority
 from rattler.networking import Client, fetch_repo_data
@@ -70,6 +71,7 @@ __all__ = [
     "PrefixPathsEntry",
     "PrefixPathType",
     "SparseRepoData",
+    "PackageFormatSelection",
     "LockFile",
     "Environment",
     "LockChannel",

--- a/py-rattler/rattler/repo_data/__init__.py
+++ b/py-rattler/rattler/repo_data/__init__.py
@@ -2,7 +2,7 @@ from rattler.repo_data.package_record import PackageRecord
 from rattler.repo_data.repo_data import RepoData
 from rattler.repo_data.patch_instructions import PatchInstructions
 from rattler.repo_data.record import RepoDataRecord
-from rattler.repo_data.sparse import SparseRepoData
+from rattler.repo_data.sparse import SparseRepoData, PackageFormatSelection
 from rattler.repo_data.gateway import Gateway, SourceConfig
 
 __all__ = [
@@ -13,4 +13,5 @@ __all__ = [
     "SparseRepoData",
     "Gateway",
     "SourceConfig",
+    "PackageFormatSelection",
 ]

--- a/py-rattler/rattler/repo_data/sparse.py
+++ b/py-rattler/rattler/repo_data/sparse.py
@@ -6,31 +6,31 @@ from rattler.channel.channel import Channel
 from rattler.package.package_name import PackageName
 from enum import Enum
 
-from rattler.rattler import PySparseRepoData, PyVariantSelection
+from rattler.rattler import PySparseRepoData, PyPackageFormatSelection
 from rattler.repo_data.record import RepoDataRecord
 
 
-class VariantSelection(Enum):
+class PackageFormatSelection(Enum):
     """
     Enum that describes what to do if both a `.tar.bz2` and a `.conda` package is available.
     """
 
-    ONLY_TAR_BZ2 = PyVariantSelection.OnlyTarBz2
+    ONLY_TAR_BZ2 = PyPackageFormatSelection.OnlyTarBz2
     """
     Only use the `.tar.bz2` packages, ignore all `.conda` packages.
     """
 
-    ONLY_CONDA = PyVariantSelection.OnlyConda
+    ONLY_CONDA = PyPackageFormatSelection.OnlyConda
     """
     Only use the `.conda` packages, ignore all `.tar.bz2` packages.
     """
 
-    PREFER_CONDA = PyVariantSelection.PreferConda
+    PREFER_CONDA = PyPackageFormatSelection.PreferConda
     """
     Only use the `.conda` packages if there are both a `.tar.bz2` and a `.conda` package available.
     """
 
-    BOTH = PyVariantSelection.Both
+    BOTH = PyPackageFormatSelection.Both
     """
     Use both the `.tar.bz2` and the `.conda` packages.
     """
@@ -92,7 +92,7 @@ class SparseRepoData:
         return self._sparse.package_names()
 
     def load_records(
-        self, package_name: PackageName, variant_selection: VariantSelection = VariantSelection.PREFER_CONDA
+        self, package_name: PackageName, variant_selection: PackageFormatSelection = PackageFormatSelection.PREFER_CONDA
     ) -> List[RepoDataRecord]:
         """
         Returns all the records for the specified package name.
@@ -144,7 +144,7 @@ class SparseRepoData:
     def load_records_recursive(
         repo_data: List[SparseRepoData],
         package_names: List[PackageName],
-        variant_selection: VariantSelection = VariantSelection.PREFER_CONDA,
+        variant_selection: PackageFormatSelection = PackageFormatSelection.PREFER_CONDA,
     ) -> List[List[RepoDataRecord]]:
         """
         Given a set of [`SparseRepoData`]s load all the records

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -6,7 +6,7 @@ from rattler import Channel, Platform, VirtualPackage, SparseRepoData
 from rattler.match_spec.match_spec import MatchSpec
 
 from rattler.channel import ChannelPriority
-from rattler.rattler import py_solve, PyMatchSpec, py_solve_with_sparse_repodata, PyVariantSelection
+from rattler.rattler import py_solve, PyMatchSpec, py_solve_with_sparse_repodata, PyPackageFormatSelection
 
 from rattler.platform.platform import PlatformLiteral
 from rattler.repo_data.gateway import Gateway
@@ -193,7 +193,9 @@ async def solve_with_sparse_repodata(
             ],
             channel_priority=channel_priority.value,
             timeout=int(timeout / datetime.timedelta(microseconds=1)) if timeout else None,
-            variant_selection=PyVariantSelection.OnlyTarBz2 if use_only_tar_bz2 else PyVariantSelection.PreferConda,
+            variant_selection=PyPackageFormatSelection.OnlyTarBz2
+            if use_only_tar_bz2
+            else PyPackageFormatSelection.PreferConda,
             exclude_newer_timestamp_ms=int(exclude_newer.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
             if exclude_newer
             else None,

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -11,7 +11,6 @@ from rattler.rattler import py_solve, PyMatchSpec, py_solve_with_sparse_repodata
 from rattler.platform.platform import PlatformLiteral
 from rattler.repo_data.gateway import Gateway
 from rattler.repo_data.record import RepoDataRecord
-from rattler.repo_data.sparse import VariantSelection
 from rattler.virtual_package.generic import GenericVirtualPackage
 
 SolveStrategy = Literal["highest", "lowest", "lowest-direct"]

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -6,11 +6,12 @@ from rattler import Channel, Platform, VirtualPackage, SparseRepoData
 from rattler.match_spec.match_spec import MatchSpec
 
 from rattler.channel import ChannelPriority
-from rattler.rattler import py_solve, PyMatchSpec, py_solve_with_sparse_repodata
+from rattler.rattler import py_solve, PyMatchSpec, py_solve_with_sparse_repodata, PyVariantSelection
 
 from rattler.platform.platform import PlatformLiteral
 from rattler.repo_data.gateway import Gateway
 from rattler.repo_data.record import RepoDataRecord
+from rattler.repo_data.sparse import VariantSelection
 from rattler.virtual_package.generic import GenericVirtualPackage
 
 SolveStrategy = Literal["highest", "lowest", "lowest-direct"]
@@ -127,6 +128,7 @@ async def solve_with_sparse_repodata(
     exclude_newer: Optional[datetime.datetime] = None,
     strategy: SolveStrategy = "highest",
     constraints: Optional[Sequence[MatchSpec | str]] = None,
+    use_only_tar_bz2: bool = False,
 ) -> List[RepoDataRecord]:
     """
     Resolve the dependencies and return the `RepoDataRecord`s
@@ -171,6 +173,7 @@ async def solve_with_sparse_repodata(
         constraints: Additional constraints that should be satisfied by the solver.
             Packages included in the `constraints` are not necessarily installed,
             but they must be satisfied by the solution.
+        use_only_tar_bz2: If `True` only `.tar.bz2` packages are used. If `False` `.conda` packages are preferred.
 
     Returns:
         Resolved list of `RepoDataRecord`s.
@@ -191,6 +194,7 @@ async def solve_with_sparse_repodata(
             ],
             channel_priority=channel_priority.value,
             timeout=int(timeout / datetime.timedelta(microseconds=1)) if timeout else None,
+            variant_selection=PyVariantSelection.OnlyTarBz2 if use_only_tar_bz2 else PyVariantSelection.PreferConda,
             exclude_newer_timestamp_ms=int(exclude_newer.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
             if exclude_newer
             else None,

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -66,7 +66,7 @@ use record::{PyLink, PyRecord};
 use repo_data::{
     gateway::{PyFetchRepoDataOptions, PyGateway, PySourceConfig},
     patch_instructions::PyPatchInstructions,
-    sparse::PySparseRepoData,
+    sparse::{PySparseRepoData, PyVariantSelection},
     PyRepoData,
 };
 use run_exports_json::PyRunExportsJson;
@@ -119,6 +119,7 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_class::<PyActivator>()?;
 
     m.add_class::<PySparseRepoData>()?;
+    m.add_class::<PyVariantSelection>()?;
     m.add_class::<PyRepoData>()?;
     m.add_class::<PyPatchInstructions>()?;
     m.add_class::<PyGateway>()?;

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -66,7 +66,7 @@ use record::{PyLink, PyRecord};
 use repo_data::{
     gateway::{PyFetchRepoDataOptions, PyGateway, PySourceConfig},
     patch_instructions::PyPatchInstructions,
-    sparse::{PySparseRepoData, PyVariantSelection},
+    sparse::{PyPackageFormatSelection, PySparseRepoData},
     PyRepoData,
 };
 use run_exports_json::PyRunExportsJson;
@@ -119,7 +119,7 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_class::<PyActivator>()?;
 
     m.add_class::<PySparseRepoData>()?;
-    m.add_class::<PyVariantSelection>()?;
+    m.add_class::<PyPackageFormatSelection>()?;
     m.add_class::<PyRepoData>()?;
     m.add_class::<PyPatchInstructions>()?;
     m.add_class::<PyGateway>()?;

--- a/py-rattler/src/repo_data/sparse.rs
+++ b/py-rattler/src/repo_data/sparse.rs
@@ -95,7 +95,11 @@ impl PySparseRepoData {
         Ok(sparse.package_names().map(Into::into).collect::<Vec<_>>())
     }
 
-    pub fn load_records(&self, package_name: &PyPackageName, package_format_selection: PyPackageFormatSelection) -> PyResult<Vec<PyRecord>> {
+    pub fn load_records(
+        &self,
+        package_name: &PyPackageName,
+        package_format_selection: PyPackageFormatSelection,
+    ) -> PyResult<Vec<PyRecord>> {
         let lock = self.inner.read();
         let Some(sparse) = lock.as_ref() else {
             return Err(PyValueError::new_err("I/O operation on closed file."));
@@ -141,12 +145,15 @@ impl PySparseRepoData {
 
         py.allow_threads(move || {
             let package_names = package_names.into_iter().map(Into::into);
-            Ok(
-                SparseRepoData::load_records_recursive(repo_data_refs, package_names, None, package_format_selection.into())?
-                    .into_iter()
-                    .map(|v| v.into_iter().map(Into::into).collect::<Vec<_>>())
-                    .collect::<Vec<_>>(),
-            )
+            Ok(SparseRepoData::load_records_recursive(
+                repo_data_refs,
+                package_names,
+                None,
+                package_format_selection.into(),
+            )?
+            .into_iter()
+            .map(|v| v.into_iter().map(Into::into).collect::<Vec<_>>())
+            .collect::<Vec<_>>())
         })
     }
 }

--- a/py-rattler/src/repo_data/sparse.rs
+++ b/py-rattler/src/repo_data/sparse.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use pyo3::{pyclass, pymethods, PyResult, Python};
 
-use rattler_repodata_gateway::sparse::SparseRepoData;
+use rattler_repodata_gateway::sparse::{SparseRepoData, VariantSelection};
 
 use crate::channel::PyChannel;
 use crate::package_name::PyPackageName;
@@ -29,6 +29,34 @@ impl<'a> From<&'a PySparseRepoData> for &'a SparseRepoData {
     }
 }
 
+#[pyclass(eq)]
+#[derive(Copy, Clone, PartialEq, Default)]
+pub enum PyVariantSelection {
+    OnlyTarBz2,
+    OnlyConda,
+    #[default]
+    PreferConda,
+    Both,
+}
+
+impl From<PyVariantSelection> for VariantSelection {
+    fn from(value: PyVariantSelection) -> Self {
+        match value {
+            PyVariantSelection::OnlyTarBz2 => VariantSelection::OnlyTarBz2,
+            PyVariantSelection::OnlyConda => VariantSelection::OnlyConda,
+            PyVariantSelection::PreferConda => VariantSelection::PreferConda,
+            PyVariantSelection::Both => VariantSelection::Both,
+        }
+    }
+}
+
+#[pymethods]
+impl PyVariantSelection {
+    fn __repr__(&self) -> &'static str {
+        VariantSelection::from(*self).into()
+    }
+}
+
 #[pymethods]
 impl PySparseRepoData {
     #[new]
@@ -43,10 +71,17 @@ impl PySparseRepoData {
             .collect::<Vec<_>>()
     }
 
-    pub fn load_records(&self, package_name: &PyPackageName) -> PyResult<Vec<PyRecord>> {
+    pub fn load_records(
+        &self,
+        package_name: &PyPackageName,
+        variant_selection: Option<PyVariantSelection>,
+    ) -> PyResult<Vec<PyRecord>> {
         Ok(self
             .inner
-            .load_records(&package_name.inner)?
+            .load_records(
+                &package_name.inner,
+                variant_selection.unwrap_or_default().into(),
+            )?
             .into_iter()
             .map(Into::into)
             .collect::<Vec<_>>())
@@ -62,16 +97,20 @@ impl PySparseRepoData {
         py: Python<'_>,
         repo_data: Vec<PySparseRepoData>,
         package_names: Vec<PyPackageName>,
+        variant_selection: Option<PyVariantSelection>,
     ) -> PyResult<Vec<Vec<PyRecord>>> {
         py.allow_threads(move || {
             let repo_data = repo_data.iter().map(Into::into);
             let package_names = package_names.into_iter().map(Into::into);
-            Ok(
-                SparseRepoData::load_records_recursive(repo_data, package_names, None)?
-                    .into_iter()
-                    .map(|v| v.into_iter().map(Into::into).collect::<Vec<_>>())
-                    .collect::<Vec<_>>(),
-            )
+            Ok(SparseRepoData::load_records_recursive(
+                repo_data,
+                package_names,
+                None,
+                variant_selection.unwrap_or_default().into(),
+            )?
+            .into_iter()
+            .map(|v| v.into_iter().map(Into::into).collect::<Vec<_>>())
+            .collect::<Vec<_>>())
         })
     }
 }

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -17,7 +17,7 @@ use crate::{
     platform::PyPlatform,
     record::PyRecord,
     repo_data::gateway::PyGateway,
-    PySparseRepoData, PyVariantSelection, Wrap,
+    PyPackageFormatSelection, PySparseRepoData, Wrap,
 };
 
 impl<'py> FromPyObject<'py> for Wrap<SolveStrategy> {
@@ -132,7 +132,7 @@ pub fn py_solve_with_sparse_repodata(
     pinned_packages: Vec<PyRecord>,
     virtual_packages: Vec<PyGenericVirtualPackage>,
     channel_priority: PyChannelPriority,
-    variant_selection: PyVariantSelection,
+    variant_selection: PyPackageFormatSelection,
     timeout: Option<u64>,
     exclude_newer_timestamp_ms: Option<i64>,
     strategy: Option<Wrap<SolveStrategy>>,

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -17,7 +17,7 @@ use crate::{
     platform::PyPlatform,
     record::PyRecord,
     repo_data::gateway::PyGateway,
-    PySparseRepoData, Wrap,
+    PySparseRepoData, PyVariantSelection, Wrap,
 };
 
 impl<'py> FromPyObject<'py> for Wrap<SolveStrategy> {
@@ -121,7 +121,7 @@ pub fn py_solve(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (specs, sparse_repodata, constraints, locked_packages, pinned_packages, virtual_packages, channel_priority, timeout=None, exclude_newer_timestamp_ms=None, strategy=None)
+#[pyo3(signature = (specs, sparse_repodata, constraints, locked_packages, pinned_packages, virtual_packages, channel_priority, variant_selection, timeout=None, exclude_newer_timestamp_ms=None, strategy=None)
 )]
 pub fn py_solve_with_sparse_repodata(
     py: Python<'_>,
@@ -132,6 +132,7 @@ pub fn py_solve_with_sparse_repodata(
     pinned_packages: Vec<PyRecord>,
     virtual_packages: Vec<PyGenericVirtualPackage>,
     channel_priority: PyChannelPriority,
+    variant_selection: PyVariantSelection,
     timeout: Option<u64>,
     exclude_newer_timestamp_ms: Option<i64>,
     strategy: Option<Wrap<SolveStrategy>>,
@@ -153,6 +154,7 @@ pub fn py_solve_with_sparse_repodata(
                 sparse_repodata.iter().map(Arc::as_ref),
                 package_names,
                 None,
+                variant_selection.into(),
             )?;
 
             let task = SolverTask {

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -160,8 +160,12 @@ pub fn py_solve_with_sparse_repodata<'py>(
                 .iter()
                 .filter_map(|match_spec| match_spec.inner.name.clone());
 
-            let available_packages =
-                SparseRepoData::load_records_recursive(repo_data_refs, package_names, None, package_format_selection.into())?;
+            let available_packages = SparseRepoData::load_records_recursive(
+                repo_data_refs,
+                package_names,
+                None,
+                package_format_selection.into(),
+            )?;
 
             // Force drop the locks to avoid holding them longer than necessary.
             drop(repo_data_locks);

--- a/test-data/channels/dummy/linux-64/repodata.json
+++ b/test-data/channels/dummy/linux-64/repodata.json
@@ -385,6 +385,21 @@
       "timestamp": 1605110689658,
       "version": "2.0"
     },
+    "bors-1.1-bla_1.conda": {
+      "build": "bla_1",
+      "build_number": 1,
+      "depends": [
+      ],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "bors",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1605110689658,
+      "version": "1.1"
+    },
     "bors-2.1-bla_1.conda": {
       "build": "bla_1",
       "build_number": 1,


### PR DESCRIPTION
Fixes #1328
Fixes #1329 

This PR adds the ability to tell SparseRepoData to only parse `.conda` or `.tar.bz2` packages. 

Also adds the `use_only_tar_bz2` to `solve_with_sparse_repodata` to only read `.tar.bz2`. Otherwise, prefers `.conda` packages.