### PR TITLE
feat(py): allow forcefully closing SparseRepoData

### DIFF
--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -3490,6 +3490,7 @@ dependencies = [
  "chrono",
  "futures",
  "openssl",
+ "parking_lot",
  "pep508_rs",
  "pyo3",
  "pyo3-async-runtimes",

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -26,6 +26,7 @@ vendored-openssl = ["openssl", "openssl/vendored"]
 anyhow = "1.0.97"
 chrono = { version = "0.4" }
 futures = "0.3.31"
+parking_lot = { version = "0.12.3", features = ["arc_lock", "send_guard"] }
 
 rattler = { path = "../crates/rattler", default-features = false, features = [
     "indicatif",

--- a/py-rattler/rattler/repo_data/sparse.py
+++ b/py-rattler/rattler/repo_data/sparse.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Type, Literal
+from types import TracebackType
 from rattler.channel.channel import Channel
 from rattler.package.package_name import PackageName
 
@@ -39,6 +40,40 @@ class SparseRepoData:
             )
         self._sparse = PySparseRepoData(channel._channel, subdir, str(path))
 
+    def close(self) -> None:
+        """
+        Closes any mapped resources associated with this `SparseRepoData`
+        instance. It is good practice to call this method when you are done
+        with it. This is especially important if you want to modify or delete
+        the file from which this instance was created.
+
+        This method will release all resources associated with this instance,
+        including those that are currently being used on another thread. This
+        method will block until all resources are released.
+
+        This method has no effect if the file is already closed. Once the
+        instance is closed, any operation on the instance will raise a
+        `ValueError`.
+
+        As a convenience, it is allowed to call this method more than once;
+        only the first call, however, will have an effect.
+
+        Examples
+        --------
+        ```python
+        >>> from rattler import Channel, ChannelConfig
+        >>> channel = Channel("dummy", ChannelConfig())
+        >>> path = "../test-data/channels/dummy/linux-64/repodata.json"
+        >>> sparse_data = SparseRepoData(channel, "linux-64", path)
+        >>> sparse_data.close()
+        >>> sparse_data.package_names() # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        ValueError: I/O operation on closed file.
+        >>>
+        ```
+        """
+        self._sparse.close()
+
     def package_names(self) -> List[str]:
         """
         Returns a list over all package names in this repodata file.
@@ -51,9 +86,8 @@ class SparseRepoData:
         ```python
         >>> from rattler import Channel, ChannelConfig
         >>> channel = Channel("dummy", ChannelConfig())
-        >>> subdir = "test-data/dummy/noarch"
         >>> path = "../test-data/channels/dummy/linux-64/repodata.json"
-        >>> sparse_data = SparseRepoData(channel, subdir, path)
+        >>> sparse_data = SparseRepoData(channel, "linux-64", path)
         >>> package_names = sparse_data.package_names()
         >>> package_names
         [...]
@@ -73,9 +107,8 @@ class SparseRepoData:
         ```python
         >>> from rattler import Channel, ChannelConfig, RepoDataRecord, PackageName
         >>> channel = Channel("dummy", ChannelConfig())
-        >>> subdir = "test-data/dummy/noarch"
         >>> path = "../test-data/channels/dummy/linux-64/repodata.json"
-        >>> sparse_data = SparseRepoData(channel, subdir, path)
+        >>> sparse_data = SparseRepoData(channel, "linux-64", path)
         >>> package_name = PackageName(sparse_data.package_names()[0])
         >>> records = sparse_data.load_records(package_name)
         >>> records
@@ -98,11 +131,10 @@ class SparseRepoData:
         ```python
         >>> from rattler import Channel, ChannelConfig
         >>> channel = Channel("dummy", ChannelConfig())
-        >>> subdir = "test-data/dummy/noarch"
         >>> path = "../test-data/channels/dummy/linux-64/repodata.json"
-        >>> sparse_data = SparseRepoData(channel, subdir, path)
+        >>> sparse_data = SparseRepoData(channel, "linux-64", path)
         >>> sparse_data.subdir
-        'test-data/dummy/noarch'
+        'linux-64'
         >>>
         ```
         """
@@ -127,7 +159,7 @@ class SparseRepoData:
         >>> channel = Channel("dummy")
         >>> subdir = "test-data/dummy/linux-64"
         >>> path = "../test-data/channels/dummy/linux-64/repodata.json"
-        >>> sparse_data = SparseRepoData(channel, subdir, path)
+        >>> sparse_data = SparseRepoData(channel, "linux-64", path)
         >>> package_name = PackageName("python")
         >>> SparseRepoData.load_records_recursive([sparse_data], [package_name])
         [...]
@@ -160,12 +192,57 @@ class SparseRepoData:
         ```python
         >>> from rattler import Channel, ChannelConfig
         >>> channel = Channel("dummy", ChannelConfig())
-        >>> subdir = "test-data/dummy/noarch"
         >>> path = "../test-data/channels/dummy/linux-64/repodata.json"
-        >>> sparse_data = SparseRepoData(channel, subdir, path)
+        >>> sparse_data = SparseRepoData(channel, "linux-64", path)
         >>> sparse_data
-        SparseRepoData(subdir="test-data/dummy/noarch")
+        SparseRepoData(subdir="linux-64")
         >>>
         ```
         """
         return f'SparseRepoData(subdir="{self.subdir}")'
+
+    def __enter__(self) -> SparseRepoData:
+        """
+        Returns the `SparseRepoData` instance itself. This is used to
+        enable the use of the `with` statement to automatically close
+        the instance when done.
+
+        Examples
+        --------
+        ```python
+        >>> from rattler import Channel, ChannelConfig
+        >>> channel = Channel("dummy", ChannelConfig())
+        >>> path = "../test-data/channels/dummy/linux-64/repodata.json"
+        >>> with SparseRepoData(channel, "linux-64", path) as sparse_data:
+        ...     print(sparse_data)
+        ...
+        SparseRepoData(subdir="linux-64")
+        >>>
+        ```
+        """
+        return self
+
+    def __exit__(
+        self,
+        exctype: Optional[Type[BaseException]],
+        excinst: Optional[BaseException],
+        exctb: Optional[TracebackType],
+    ) -> Literal[False]:
+        """
+        Closes the `SparseRepoData` instance when exiting the `with` statement.
+
+        Examples
+        --------
+        ```python
+        >>> from rattler import Channel, ChannelConfig
+        >>> channel = Channel("dummy", ChannelConfig())
+        >>> path = "../test-data/channels/dummy/linux-64/repodata.json"
+        >>> with SparseRepoData(channel, "linux-64", path) as sparse_data:
+        ...     print(sparse_data)
+        ...
+        SparseRepoData(subdir="linux-64")
+        >>>
+        ```
+        """
+        self.close()
+        return False

--- a/py-rattler/src/repo_data/sparse.rs
+++ b/py-rattler/src/repo_data/sparse.rs
@@ -1,31 +1,38 @@
 use std::{path::PathBuf, sync::Arc};
 
-use pyo3::{pyclass, pymethods, PyResult, Python};
+use pyo3::{pyclass, pymethods, Bound, PyResult, Python};
 
 use rattler_repodata_gateway::sparse::SparseRepoData;
 
 use crate::channel::PyChannel;
 use crate::package_name::PyPackageName;
 use crate::record::PyRecord;
+use parking_lot::RwLock;
+use pyo3::exceptions::PyValueError;
 
 #[pyclass]
-#[repr(transparent)]
-#[derive(Clone)]
 pub struct PySparseRepoData {
-    pub(crate) inner: Arc<SparseRepoData>,
+    // `SparseRepoData` holds a memory-mapped view on a file which prevents the file from being
+    // modified or deleted. We want to be able to close this view on demand. But we also want to
+    // move shared ownership into different threads to unblock the GIL.
+    //
+    // We wrap the `SparseRepoData` in an Option to indicate whether it's "open" or not. Closing
+    // simply means taking the value from the option and dropping it. This construct is wrapped
+    // in a RwLock because most of the time we just want to be able to read from it. We only
+    // need write access to close it.
+    //
+    // This whole thing is then wrapped in an Arc so we can share this with a background thread
+    // without blocking the GIL.
+    pub(crate) inner: Arc<RwLock<Option<SparseRepoData>>>,
+    subdir: String,
 }
 
 impl From<SparseRepoData> for PySparseRepoData {
     fn from(value: SparseRepoData) -> Self {
         Self {
-            inner: Arc::new(value),
+            subdir: value.subdir().to_owned(),
+            inner: Arc::new(RwLock::new(Some(value))),
         }
-    }
-}
-
-impl<'a> From<&'a PySparseRepoData> for &'a SparseRepoData {
-    fn from(value: &'a PySparseRepoData) -> Self {
-        value.inner.as_ref()
     }
 }
 
@@ -36,16 +43,20 @@ impl PySparseRepoData {
         Ok(SparseRepoData::from_file(channel.into(), subdir, path, None)?.into())
     }
 
-    pub fn package_names(&self) -> Vec<String> {
-        self.inner
-            .package_names()
-            .map(Into::into)
-            .collect::<Vec<_>>()
+    pub fn package_names(&self) -> PyResult<Vec<String>> {
+        let lock = self.inner.read();
+        let Some(sparse) = lock.as_ref() else {
+            return Err(PyValueError::new_err("I/O operation on closed file."));
+        };
+        Ok(sparse.package_names().map(Into::into).collect::<Vec<_>>())
     }
 
     pub fn load_records(&self, package_name: &PyPackageName) -> PyResult<Vec<PyRecord>> {
-        Ok(self
-            .inner
+        let lock = self.inner.read();
+        let Some(sparse) = lock.as_ref() else {
+            return Err(PyValueError::new_err("I/O operation on closed file."));
+        };
+        Ok(sparse
             .load_records(&package_name.inner)?
             .into_iter()
             .map(Into::into)
@@ -54,20 +65,39 @@ impl PySparseRepoData {
 
     #[getter]
     pub fn subdir(&self) -> String {
-        self.inner.subdir().into()
+        self.subdir.clone()
+    }
+
+    pub fn close(&self) {
+        self.inner.write().take();
     }
 
     #[staticmethod]
-    pub fn load_records_recursive(
-        py: Python<'_>,
-        repo_data: Vec<PySparseRepoData>,
+    pub fn load_records_recursive<'py>(
+        py: Python<'py>,
+        repo_data: Vec<Bound<'py, PySparseRepoData>>,
         package_names: Vec<PyPackageName>,
     ) -> PyResult<Vec<Vec<PyRecord>>> {
+        // Acquire read locks on the SparseRepoData instances. This allows us to safely access the
+        // object in another thread.
+        let repo_data_locks = repo_data
+            .into_iter()
+            .map(|s| s.borrow().inner.read_arc())
+            .collect::<Vec<_>>();
+
+        // Ensure that all the SparseRepoData instances are still valid, e.g. not closed.
+        let repo_data_refs = repo_data_locks
+            .iter()
+            .map(|s| {
+                s.as_ref()
+                    .ok_or_else(|| PyValueError::new_err("I/O operation on closed file."))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
         py.allow_threads(move || {
-            let repo_data = repo_data.iter().map(Into::into);
             let package_names = package_names.into_iter().map(Into::into);
             Ok(
-                SparseRepoData::load_records_recursive(repo_data, package_names, None)?
+                SparseRepoData::load_records_recursive(repo_data_refs, package_names, None)?
                     .into_iter()
                     .map(|v| v.into_iter().map(Into::into).collect::<Vec<_>>())
                     .collect::<Vec<_>>(),

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -162,6 +162,9 @@ pub fn py_solve_with_sparse_repodata<'py>(
             let available_packages =
                 SparseRepoData::load_records_recursive(repo_data_refs, package_names, None)?;
 
+            // Force drop the locks to avoid holding them longer than necessary.
+            drop(repo_data_locks);
+
             let task = SolverTask {
                 available_packages: available_packages
                     .iter()

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -6,7 +6,6 @@ use pyo3::{
 use pyo3_async_runtimes::tokio::future_into_py;
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use rattler_solve::{resolvo::Solver, RepoDataIter, SolveStrategy, SolverImpl, SolverTask};
-use std::sync::Arc;
 use tokio::task::JoinError;
 
 use crate::{
@@ -123,10 +122,10 @@ pub fn py_solve(
 #[pyfunction]
 #[pyo3(signature = (specs, sparse_repodata, constraints, locked_packages, pinned_packages, virtual_packages, channel_priority, timeout=None, exclude_newer_timestamp_ms=None, strategy=None)
 )]
-pub fn py_solve_with_sparse_repodata(
-    py: Python<'_>,
+pub fn py_solve_with_sparse_repodata<'py>(
+    py: Python<'py>,
     specs: Vec<PyMatchSpec>,
-    sparse_repodata: Vec<PySparseRepoData>,
+    sparse_repodata: Vec<Bound<'py, PySparseRepoData>>,
     constraints: Vec<PyMatchSpec>,
     locked_packages: Vec<PyRecord>,
     pinned_packages: Vec<PyRecord>,
@@ -135,25 +134,33 @@ pub fn py_solve_with_sparse_repodata(
     timeout: Option<u64>,
     exclude_newer_timestamp_ms: Option<i64>,
     strategy: Option<Wrap<SolveStrategy>>,
-) -> PyResult<Bound<'_, PyAny>> {
+) -> PyResult<Bound<'py, PyAny>> {
+    // Acquire read locks on the SparseRepoData instances. This allows us to safely access the
+    // object in another thread.
+    let repo_data_locks = sparse_repodata
+        .into_iter()
+        .map(|s| s.borrow().inner.read_arc())
+        .collect::<Vec<_>>();
+
     future_into_py(py, async move {
         let exclude_newer = exclude_newer_timestamp_ms.and_then(DateTime::from_timestamp_millis);
 
-        let sparse_repodata = sparse_repodata
-            .into_iter()
-            .map(|s| s.inner.clone())
-            .collect::<Vec<_>>();
-
         let solve_result = tokio::task::spawn_blocking(move || {
+            // Ensure that all the SparseRepoData instances are still valid, e.g. not closed.
+            let repo_data_refs = repo_data_locks
+                .iter()
+                .map(|s| {
+                    s.as_ref()
+                        .ok_or_else(|| PyValueError::new_err("I/O operation on closed file."))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
             let package_names = specs
                 .iter()
                 .filter_map(|match_spec| match_spec.inner.name.clone());
 
-            let available_packages = SparseRepoData::load_records_recursive(
-                sparse_repodata.iter().map(Arc::as_ref),
-                package_names,
-                None,
-            )?;
+            let available_packages =
+                SparseRepoData::load_records_recursive(repo_data_refs, package_names, None)?;
 
             let task = SolverTask {
                 available_packages: available_packages


### PR DESCRIPTION
This PR adds `SparseRepoData.close()` which will forcefully close any resource related to the instance. This is useful because otherwise one has to depend on the Python garbage collector.

Hopefully this helps with https://github.com/conda-incubator/conda-rattler-solver/issues/7