### PR TITLE
[Issue #1302] - Correcting TypeError in py-rattler/gateway

### DIFF
--- a/py-rattler/rattler/repo_data/gateway.py
+++ b/py-rattler/rattler/repo_data/gateway.py
@@ -117,7 +117,7 @@ class Gateway:
             cache_dir=cache_dir,
             default_config=default_config._into_py(),
             per_channel_config={
-                channel._channel if isinstance(channel, Channel) else Channel(channel)._channel: config._into_py()
+                channel: config._into_py()
                 for channel, config in (per_channel_config or {}).items()
             },
             max_concurrent_requests=max_concurrent_requests,

--- a/py-rattler/tests/unit/test_gateway.py
+++ b/py-rattler/tests/unit/test_gateway.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rattler import Gateway, Channel
+from rattler import Gateway, Channel, SourceConfig
 
 
 @pytest.mark.asyncio
@@ -11,3 +11,19 @@ async def test_single_record_in_recursive_query(gateway: Gateway, conda_forge_ch
 
     python_records = [record for subdir in subdirs for record in subdir if record.name == "python"]
     assert len(python_records) == 1
+
+def test_init_per_channel_config_key():
+    test_source_config = SourceConfig()
+    # build an incorrect per_channel_config & check for TypeError
+    bad_config = {
+        123: test_source_config
+    }
+    with pytest.raises(TypeError):
+        Gateway(per_channel_config=bad_config)
+
+    # build right config & make sure gateway object initializes
+    right_config= {
+        "http://test-config-key.com": test_source_config
+    }
+    test_gateway = Gateway(per_channel_config=right_config)
+    assert test_gateway is not None


### PR DESCRIPTION
### Description

Issue link - #1302 

Fixing a `TypeError` observed in the `per_channel_config` function parameter in py-rattler/ gateway object.
Also adding a new reproducibility test for the same. 


### Technical Summary 

Changing the code implementation of the Gateway constructor in py-rattler. The function definition was expecting a string object as a key of the dict. However, the code was implemented to parse a `Channel` object. With this fix I am resolving this mismatch. More information on this in the issue #1302 


### Testing

- Added a new unit test for this check
- Made sure that all existing tests are good to go. 

