### PR TITLE
fix: add rust-src to py-rattler

### DIFF
--- a/py-rattler/pixi.lock
+++ b/py-rattler/pixi.lock
@@ -868,6 +868,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.3.7-py39h7efa1f9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.85.0-h1a8d7c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-src-1.85.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.85.0-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
@@ -937,6 +938,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.3.7-py39h6792c9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.85.0-h34a2095_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-src-1.85.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.85.0-h38e4360_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
@@ -1005,6 +1007,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.3.7-py39hd984c07_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.85.0-h4ff7c5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-src-1.85.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.85.0-hf6ec828_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
@@ -1076,6 +1079,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.3.7-py39h756cfbc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.85.0-hf8d6059_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-src-1.85.0-win_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.85.0-h17fc481_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
@@ -4900,6 +4904,30 @@ packages:
   purls: []
   size: 211026909
   timestamp: 1740491861624
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-src-1.85.0-unix_0.conda
+  sha256: d8537f767036698fbfb4bda333f950500a5fdce7a16fb163f98c2d2411a3c3e4
+  md5: b5f031d6321c6b4023e7a606072b074e
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.85.0,<1.85.1.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 3518553
+  timestamp: 1740489074408
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-src-1.85.0-win_0.conda
+  sha256: e627088b101bed2435614616f8ccc1fb66e29feb24692e6e8668f3fc5a997b68
+  md5: 05385bea3f040fd5d0379435d0c6ce03
+  depends:
+  - __win
+  constrains:
+  - rust >=1.85.0,<1.85.1.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 3509423
+  timestamp: 1740490282772
 - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.85.0-hf6ec828_0.conda
   sha256: 5b8c5c8eae1ffc6613142c6a2f5e4476f3e9306d960a07f9503b5e0b34bca6d0
   md5: 90c86e95b25808f8f4d83ce9dcb63867

--- a/py-rattler/pixi.toml
+++ b/py-rattler/pixi.toml
@@ -36,6 +36,8 @@ pytest-xprocess = ">=0.23.0,<0.24"
 
 # used in examples
 typer = "*"
+# for rust-analyzer
+rust-src = ">=1.85.0,<2"
 
 [feature.test.pypi-dependencies]
 types-networkx = "*"

--- a/py-rattler/pixi.toml
+++ b/py-rattler/pixi.toml
@@ -37,7 +37,7 @@ pytest-xprocess = ">=0.23.0,<0.24"
 # used in examples
 typer = "*"
 # for rust-analyzer
-rust-src = ">=1.85.0,<2"
+rust-src = "~=1.85.0"
 
 [feature.test.pypi-dependencies]
 types-networkx = "*"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Trying to use rust-analyzer with py-rattler and ran into the error 
> can't load standard library, try installing `rust-src` sysroot_path=/Volumes/workspace/rattler/py-rattler/.pixi/envs/test

I found [this thread](https://discord.com/channels/1082332781146800168/1331668634707431506/1331668875820929124) from @lucascolley where just adding rust-src to the environment was proposed, so here I'm actually gonna do it 😄 


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
