### PR TITLE
fix: Removing skipping logic

### DIFF
--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 
 use crate::{error::JsError, platform::JsPlatform};
 use rattler_conda_types::{
-    Channel, ChannelConfig, MatchSpec, Matches, NoArchType, PackageName, PackageRecord,
-    ParseChannelError, ParseStrictness::Lenient, RepoDataRecord, Version,
+    Channel, ChannelConfig, MatchSpec, NoArchType, PackageName, PackageRecord, ParseChannelError,
+    ParseStrictness::Lenient, RepoDataRecord, Version,
 };
 use rattler_repodata_gateway::{Gateway, SourceConfig};
 use rattler_solve::{SolverImpl, SolverTask};
@@ -109,16 +109,6 @@ pub async fn simple_solve(
         })
         .collect::<Result<Vec<_>, JsError>>()?;
 
-    //if we do not need to solve the same packages, then filter them
-    let all_matched = specs.clone().iter().all(|spec| {
-        installed_packages
-            .iter()
-            .any(|rec| spec.matches(&rec.package_record))
-    });
-
-    if all_matched {
-        return Ok(js_locked_packages);
-    }
     // Fetch the repodata
     let gateway = Gateway::builder()
         .with_channel_config(rattler_repodata_gateway::ChannelConfig {


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This PR removes skipping resolving logic because when we need to resolve for the case when we need to remove packages, the solver does not run



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
