### PR TITLE
fix: return correct channel urls from `NamelessMatchSpec.channel.base_url`

### DIFF
--- a/py-rattler/rattler/match_spec/nameless_match_spec.py
+++ b/py-rattler/rattler/match_spec/nameless_match_spec.py
@@ -71,9 +71,8 @@ class NamelessMatchSpec:
         """
         The channel of the package.
         """
-        if (channel := self._nameless_match_spec.channel) is not None:
-            return Channel(channel.name)
-        return None
+        channel = self._nameless_match_spec.channel
+        return channel and Channel._from_py_channel(channel)
 
     @property
     def subdir(self) -> Optional[str]:

--- a/py-rattler/tests/unit/test_matchspec.py
+++ b/py-rattler/tests/unit/test_matchspec.py
@@ -1,4 +1,4 @@
-from rattler import MatchSpec
+from rattler import MatchSpec, NamelessMatchSpec
 
 
 def test_parse_channel_from_canonical_name() -> None:
@@ -8,11 +8,27 @@ def test_parse_channel_from_canonical_name() -> None:
     assert m.channel.base_url == "https://conda.anaconda.org/conda-forge/"
 
 
+def test_parse_channel_from_canonical_name_nameless() -> None:
+    m = MatchSpec("conda-forge::python[version=3.9]")
+    nms = NamelessMatchSpec.from_match_spec(m)
+    assert nms.channel is not None
+    assert nms.channel.name == "conda-forge"
+    assert nms.channel.base_url == "https://conda.anaconda.org/conda-forge/"
+
+
 def test_parse_channel_from_url() -> None:
     m = MatchSpec("https://conda.anaconda.org/conda-forge::python[version=3.9]")
     assert m.channel is not None
     assert m.channel.name == "conda-forge"
     assert m.channel.base_url == "https://conda.anaconda.org/conda-forge/"
+
+
+def test_parse_channel_from_url_nameless() -> None:
+    m = MatchSpec("https://conda.anaconda.org/conda-forge::python[version=3.9]")
+    nms = NamelessMatchSpec.from_match_spec(m)
+    assert nms.channel is not None
+    assert nms.channel.name == "conda-forge"
+    assert nms.channel.base_url == "https://conda.anaconda.org/conda-forge/"
 
 
 def test_parse_channel_from_url_filesystem() -> None:
@@ -22,11 +38,27 @@ def test_parse_channel_from_url_filesystem() -> None:
     assert m.channel.base_url == "file:///Users/rattler/channel0/"
 
 
+def test_parse_channel_from_url_filesystem_nameless() -> None:
+    m = MatchSpec("file:///Users/rattler/channel0::python[version=3.9]")
+    nms = NamelessMatchSpec.from_match_spec(m)
+    assert nms.channel is not None
+    assert nms.channel.name == "channel0"
+    assert nms.channel.base_url == "file:///Users/rattler/channel0/"
+
+
 def test_parse_channel_from_url_localhost() -> None:
     m = MatchSpec("http://localhost:8000/channel0::python[version=3.9]")
     assert m.channel is not None
     assert m.channel.name == "channel0"
     assert m.channel.base_url == "http://localhost:8000/channel0/"
+
+
+def test_parse_channel_from_url_localhost_nameless() -> None:
+    m = MatchSpec("http://localhost:8000/channel0::python[version=3.9]")
+    nms = NamelessMatchSpec.from_match_spec(m)
+    assert nms.channel is not None
+    assert nms.channel.name == "channel0"
+    assert nms.channel.base_url == "http://localhost:8000/channel0/"
 
 
 def test_parse_no_channel() -> None:
@@ -35,3 +67,10 @@ def test_parse_no_channel() -> None:
     assert m.name is not None
     assert m.name.normalized == "python"
     assert m.version == "==3.9"
+
+
+def test_parse_no_channel_nameless() -> None:
+    m = MatchSpec("python[version=3.9]")
+    nms = NamelessMatchSpec.from_match_spec(m)
+    assert nms.channel is None
+    assert nms.version == "==3.9"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

closes #1390

As noted there, this is the identical fix as @baszalmstra applied to `MatchSpec.channel` in #885, except for `NamelessMatchSpec.channel`. I have mirrored all the `MatchSpec` unit tests for `NamelessMatchSpec`. Without this fix, there are two test failures in the added tests (which accurately represent the bug described in #1390):

```
=============================================================================================================================== FAILURES ===============================================================================================================================
___________________________________________________________________________________________________________ test_parse_channel_from_url_filesystem_nameless ____________________________________________________________________________________________________________

    def test_parse_channel_from_url_filesystem_nameless() -> None:
        m = MatchSpec("file:///Users/rattler/channel0::python[version=3.9]")
        nms = NamelessMatchSpec.from_match_spec(m)
        assert nms.channel is not None
        assert nms.channel.name == "channel0"
>       assert nms.channel.base_url == "file:///Users/rattler/channel0/"
E       AssertionError: assert 'https://conda.anaconda.org/channel0/' == 'file:///Users/rattler/channel0/'
E         - file:///Users/rattler/channel0/
E         + https://conda.anaconda.org/channel0/

tests/unit/test_matchspec.py:46: AssertionError
____________________________________________________________________________________________________________ test_parse_channel_from_url_localhost_nameless ____________________________________________________________________________________________________________

    def test_parse_channel_from_url_localhost_nameless() -> None:
        m = MatchSpec("http://localhost:8000/channel0::python[version=3.9]")
        nms = NamelessMatchSpec.from_match_spec(m)
        assert nms.channel is not None
        assert nms.channel.name == "channel0"
>       assert nms.channel.base_url == "http://localhost:8000/channel0/"
E       AssertionError: assert 'https://conda.anaconda.org/channel0/' == 'http://localhost:8000/channel0/'
E         - http://localhost:8000/channel0/
E         + https://conda.anaconda.org/channel0/

tests/unit/test_matchspec.py:61: AssertionError

```

With this fix applied, both of these tests now pass.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
