### PR TITLE
chore: remove patch version of async-compression dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lto = true
 anyhow = "1.0.98"
 archspec = "0.1.3"
 assert_matches = "1.5.0"
-async-compression = { version = "0.4.23", features = [
+async-compression = { version = "0.4", features = [
   "gzip",
   "tokio",
   "bzip2",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Hey @baszalmstra, would it be ok for you do loosen up the dependency to `async-compression` a little bit? I checked that all `async-compression` features that you are using exist since version [0.4.0](https://github.com/Nullus157/async-compression/blob/async-compression-v0.4.0/Cargo.toml).

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
