### PR TITLE
feat: Set default User-Agent if not provided

### DIFF
--- a/crates/rattler_networking/src/oci_middleware.rs
+++ b/crates/rattler_networking/src/oci_middleware.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use http::{
-    header::{ACCEPT, AUTHORIZATION, USER_AGENT},
+    header::{ACCEPT, AUTHORIZATION},
     Extensions,
 };
 use reqwest::{Request, Response};
@@ -14,8 +14,6 @@ use serde::Deserialize;
 use url::{ParseError, Url};
 
 use crate::mirror_middleware::create_404_response;
-
-static RATTLER_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 #[derive(thiserror::Error, Debug)]
 enum OciMiddlewareError {

--- a/crates/rattler_networking/src/oci_middleware.rs
+++ b/crates/rattler_networking/src/oci_middleware.rs
@@ -185,13 +185,6 @@ impl OCIUrl {
                 .expect("Could not parse token header"),
         );
 
-        req.headers_mut().insert(
-            USER_AGENT,
-            RATTLER_USER_AGENT
-                .parse()
-                .expect("Could not parse user-agent header"),
-        );
-
         // if we know the hash, we can pull the artifact directly
         // if we don't, we need to pull the manifest and then pull the artifact
         if let Some(expected_sha_hash) = req
@@ -208,7 +201,6 @@ impl OCIUrl {
                 .get(manifest_url)
                 .header(AUTHORIZATION, format!("Bearer {token}"))
                 .header(ACCEPT, "application/vnd.oci.image.manifest.v1+json")
-                .header(USER_AGENT, RATTLER_USER_AGENT)
                 .send()
                 .await?;
 

--- a/crates/rattler_repodata_gateway/src/gateway/builder.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/builder.rs
@@ -8,6 +8,8 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use crate::{gateway::GatewayInner, ChannelConfig, Gateway};
 
+static USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+
 /// Defines the maximum concurrency for the gateway.
 #[derive(Default)]
 pub enum MaxConcurrency {
@@ -132,9 +134,9 @@ impl GatewayBuilder {
 
     /// Finish the construction of the gateway returning a constructed gateway.
     pub fn finish(self) -> Gateway {
-        let client = self
-            .client
-            .unwrap_or_else(|| ClientWithMiddleware::from(Client::new()));
+        let client = self.client.unwrap_or_else(|| {
+            ClientWithMiddleware::from(Client::builder().user_agent(USER_AGENT).build().unwrap())
+        });
 
         #[cfg(not(target_arch = "wasm32"))]
         let cache = self.cache.unwrap_or_else(|| {

--- a/py-rattler/rattler/networking/client.py
+++ b/py-rattler/rattler/networking/client.py
@@ -20,9 +20,10 @@ class Client:
         middlewares: (
             list[AuthenticationMiddleware | MirrorMiddleware | OciMiddleware | GCSMiddleware | S3Middleware] | None
         ) = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         self._client = PyClientWithMiddleware(
-            [middleware._middleware for middleware in middlewares] if middlewares else None
+            [middleware._middleware for middleware in middlewares] if middlewares else None, headers
         )
 
     @classmethod

--- a/py-rattler/src/error.rs
+++ b/py-rattler/src/error.rs
@@ -81,6 +81,10 @@ pub enum PyRattlerError {
     AuthenticationStorageError(#[from] AuthenticationStorageError),
     #[error(transparent)]
     MatchSpecUrlError(#[from] rattler_conda_types::MatchSpecUrlError),
+    #[error(transparent)]
+    InvalidHeaderNameError(#[from] reqwest::header::InvalidHeaderName),
+    #[error(transparent)]
+    InvalidHeaderValueError(#[from] reqwest::header::InvalidHeaderValue),
 }
 
 fn pretty_print_error(mut err: &dyn Error) -> String {
@@ -175,6 +179,12 @@ impl From<PyRattlerError> for PyErr {
             PyRattlerError::MatchSpecUrlError(err) => {
                 InvalidMatchSpecException::new_err(pretty_print_error(&err))
             }
+            PyRattlerError::InvalidHeaderNameError(err) => {
+                InvalidHeaderNameException::new_err(pretty_print_error(&err))
+            }
+            PyRattlerError::InvalidHeaderValueError(err) => {
+                InvalidHeaderValueError::new_err(pretty_print_error(&err))
+            }
         }
     }
 }
@@ -213,3 +223,5 @@ create_exception!(
 create_exception!(exceptions, ValidatePackageRecordsException, PyException);
 create_exception!(exceptions, AuthenticationStorageException, PyException);
 create_exception!(exceptions, ShellException, PyException);
+create_exception!(exceptions, InvalidHeaderNameException, PyException);
+create_exception!(exceptions, InvalidHeaderValueError, PyException);

--- a/py-rattler/src/networking/client.rs
+++ b/py-rattler/src/networking/client.rs
@@ -8,6 +8,8 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest_middleware::ClientWithMiddleware;
 use std::collections::HashMap;
 
+static RATTLER_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
+
 #[pyclass]
 #[repr(transparent)]
 #[derive(Clone)]
@@ -36,6 +38,9 @@ impl PyClientWithMiddleware {
                 header_map.insert(header_name, header_value);
             }
             client_builder = client_builder.default_headers(header_map);
+        } else {
+            client_builder =
+                client_builder.user_agent(format!("py-rattler/{}", env!("CARGO_PKG_VERSION")));
         }
 
         let mut client = reqwest_middleware::ClientBuilder::new(client_builder.build().unwrap());

--- a/py-rattler/src/networking/client.rs
+++ b/py-rattler/src/networking/client.rs
@@ -39,8 +39,7 @@ impl PyClientWithMiddleware {
             }
             client_builder = client_builder.default_headers(header_map);
         } else {
-            client_builder =
-                client_builder.user_agent(format!("py-rattler/{}", env!("CARGO_PKG_VERSION")));
+            client_builder = client_builder.user_agent(RATTLER_USER_AGENT);
         }
 
         let mut client = reqwest_middleware::ClientBuilder::new(client_builder.build().unwrap());

--- a/py-rattler/src/networking/mod.rs
+++ b/py-rattler/src/networking/mod.rs
@@ -34,7 +34,7 @@ pub fn py_fetch_repo_data<'a>(
     fetch_options: Option<PyFetchRepoDataOptions>,
 ) -> PyResult<Bound<'a, PyAny>> {
     let mut meta_futures = Vec::new();
-    let client = client.unwrap_or(PyClientWithMiddleware::new(None)?);
+    let client = client.unwrap_or(PyClientWithMiddleware::new(None, None)?);
     let fetch_options = fetch_options.unwrap_or(PyFetchRepoDataOptions {
         inner: FetchRepoDataOptions::default(),
     });

--- a/py-rattler/src/repo_data/gateway.rs
+++ b/py-rattler/src/repo_data/gateway.rs
@@ -83,6 +83,10 @@ impl PyGateway {
 
         if let Some(client) = client {
             gateway.set_client(client.into());
+        } else {
+            // Set a default client if no client is provided to
+            // make sure a default user-agent is set.
+            gateway.set_client(PyClientWithMiddleware::new(None, None)?.into());
         }
 
         Ok(Self {


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixes #1442 

This PR is an attempt at fixing #1442.

Changes on the rust side:

* Set a default user-agent in `GatewayBuilder.finish()` if no client is provided.

Changes on the Python side:
* Add a `headers` keyword argument to `rattler.Client` to allow setting HTTP headers.
* If no `headers` are provided to `rattler.Client`, set the default user-agent to `py-rattler/<version>`.
* A PyClient will be created if no client is passed to `rattler.Gateway`, ensuring that
  the default user-agent is `py-rattler/<version>`.


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
