### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.2"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.35.1"
+version = "0.35.2"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "console",
  "fs-err",
@@ -4350,7 +4350,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4397,7 +4397,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "chrono",
  "file_url",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "configparser",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.40"
+version = "0.22.41"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4627,7 +4627,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.23.4"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.14"
+version = "2.0.15"
 dependencies = [
  "archspec",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,25 +183,25 @@ zstd = { version = "0.13.3", default-features = false }
 
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.5", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.2", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.21", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.1", default-features = false }
-rattler_config = { path = "crates/rattler_config", version = "=0.1.0", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.3", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.22", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.2", default-features = false }
+rattler_config = { path = "crates/rattler_config", version = "=0.1.1", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.1.3", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.23.2", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.23.3", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.2", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.6", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.7", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.10", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.12", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.1", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.13", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.2", default-features = false }
 rattler_pty = { path = "crates/rattler_pty", version = "=0.2.2", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.11", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.40", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.2", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.41", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.3", default-features = false }
 rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.9", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.23.4", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=2.1.1", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.14", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.24.0", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.1.2", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.15", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.3](https://github.com/conda/rattler/compare/rattler-v0.34.2...rattler-v0.34.3) - 2025-06-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_shell, rattler_package_streaming, rattler_cache, rattler_menuinst
+
 ## [0.34.2](https://github.com/conda/rattler/compare/rattler-v0.34.1...rattler-v0.34.2) - 2025-06-24
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.2"
+version = "0.34.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.22](https://github.com/conda/rattler/compare/rattler_cache-v0.3.21...rattler_cache-v0.3.22) - 2025-06-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming
+
 ## [0.3.21](https://github.com/conda/rattler/compare/rattler_cache-v0.3.20...rattler_cache-v0.3.21) - 2025-06-23
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.21"
+version = "0.3.22"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.1...rattler_conda_types-v0.35.2) - 2025-06-25
+
+### Other
+
+- *(ci)* Update Rust crate criterion to 0.6 ([#1438](https://github.com/conda/rattler/pull/1438))
+
 ## [0.35.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.0...rattler_conda_types-v0.35.1) - 2025-06-23
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.35.1"
+version = "0.35.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_config/CHANGELOG.md
+++ b/crates/rattler_config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/conda/rattler/compare/rattler_config-v0.1.0...rattler_config-v0.1.1) - 2025-06-25
+
+### Added
+
+- *(rattler_index)* Use rattler_config ([#1466](https://github.com/conda/rattler/pull/1466))
+
 ## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_config-v0.1.0) - 2025-06-23
 
 ### Added

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_config"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors = []
 description = "A crate to configure rattler and derived tools."

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.3](https://github.com/conda/rattler/compare/rattler_index-v0.23.2...rattler_index-v0.23.3) - 2025-06-25
+
+### Added
+
+- *(rattler_index)* Use rattler_config ([#1466](https://github.com/conda/rattler/pull/1466))
+
 ## [0.23.2](https://github.com/conda/rattler/compare/rattler_index-v0.23.1...rattler_index-v0.23.2) - 2025-06-24
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.23.2"
+version = "0.23.3"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.7](https://github.com/conda/rattler/compare/rattler_lock-v0.23.6...rattler_lock-v0.23.7) - 2025-06-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_solve
+
 ## [0.23.6](https://github.com/conda/rattler/compare/rattler_lock-v0.23.5...rattler_lock-v0.23.6) - 2025-06-23
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.6"
+version = "0.23.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.13](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.12...rattler_menuinst-v0.2.13) - 2025-06-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_shell
+
 ## [0.2.12](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.11...rattler_menuinst-v0.2.12) - 2025-06-24
 
 ### Other

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.2](https://github.com/conda/rattler/compare/rattler_networking-v0.25.1...rattler_networking-v0.25.2) - 2025-06-25
+
+### Added
+
+- *(rattler_index)* Use rattler_config ([#1466](https://github.com/conda/rattler/pull/1466))
+
 ## [0.25.1](https://github.com/conda/rattler/compare/rattler_networking-v0.25.0...rattler_networking-v0.25.1) - 2025-06-23
 
 ### Added

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.1"
+version = "0.25.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.41](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.40...rattler_package_streaming-v0.22.41) - 2025-06-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.22.40](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.39...rattler_package_streaming-v0.22.40) - 2025-06-23
 
 ### Added

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.40"
+version = "0.22.41"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.3](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.2...rattler_repodata_gateway-v0.23.3) - 2025-06-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_cache
+
 ## [0.23.2](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.1...rattler_repodata_gateway-v0.23.2) - 2025-06-24
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.2"
+version = "0.23.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/conda/rattler/compare/rattler_shell-v0.23.4...rattler_shell-v0.24.0) - 2025-06-25
+
+### Added
+
+- Add `deactivation()` method to Activator ([#1278](https://github.com/conda/rattler/pull/1278))
+
 ## [0.23.4](https://github.com/conda/rattler/compare/rattler_shell-v0.23.3...rattler_shell-v0.23.4) - 2025-06-24
 
 ### Fixed

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.23.4"
+version = "0.24.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.2](https://github.com/conda/rattler/compare/rattler_solve-v2.1.1...rattler_solve-v2.1.2) - 2025-06-25
+
+### Other
+
+- *(ci)* Update Rust crate criterion to 0.6 ([#1438](https://github.com/conda/rattler/pull/1438))
+
 ## [2.1.1](https://github.com/conda/rattler/compare/rattler_solve-v2.1.0...rattler_solve-v2.1.1) - 2025-06-23
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "2.1.1"
+version = "2.1.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.15](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.14...rattler_virtual_packages-v2.0.15) - 2025-06-25
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [2.0.14](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.13...rattler_virtual_packages-v2.0.14) - 2025-06-23
 
 ### Fixed

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.14"
+version = "2.0.15"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `rattler_conda_types`: 0.35.1 -> 0.35.2 (✓ API compatible changes)
* `rattler_config`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `rattler_networking`: 0.25.1 -> 0.25.2 (✓ API compatible changes)
* `rattler_shell`: 0.23.4 -> 0.24.0 (⚠ API breaking changes)
* `rattler_solve`: 2.1.1 -> 2.1.2 (✓ API compatible changes)
* `rattler_index`: 0.23.2 -> 0.23.3 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.40 -> 0.22.41
* `rattler_cache`: 0.3.21 -> 0.3.22
* `rattler_menuinst`: 0.2.12 -> 0.2.13
* `rattler`: 0.34.2 -> 0.34.3
* `rattler_lock`: 0.23.6 -> 0.23.7
* `rattler_repodata_gateway`: 0.23.2 -> 0.23.3
* `rattler_virtual_packages`: 2.0.14 -> 2.0.15

### ⚠ `rattler_shell` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ActivationVariables.current_env in /tmp/.tmpDut6RX/rattler/crates/rattler_shell/src/activation.rs:57
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_conda_types`

<blockquote>

## [0.35.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.1...rattler_conda_types-v0.35.2) - 2025-06-25

### Other

- *(ci)* Update Rust crate criterion to 0.6 ([#1438](https://github.com/conda/rattler/pull/1438))
</blockquote>

## `rattler_config`

<blockquote>

## [0.1.1](https://github.com/conda/rattler/compare/rattler_config-v0.1.0...rattler_config-v0.1.1) - 2025-06-25

### Added

- *(rattler_index)* Use rattler_config ([#1466](https://github.com/conda/rattler/pull/1466))
</blockquote>

## `rattler_networking`

<blockquote>

## [0.25.2](https://github.com/conda/rattler/compare/rattler_networking-v0.25.1...rattler_networking-v0.25.2) - 2025-06-25

### Added

- *(rattler_index)* Use rattler_config ([#1466](https://github.com/conda/rattler/pull/1466))
</blockquote>

## `rattler_shell`

<blockquote>

## [0.24.0](https://github.com/conda/rattler/compare/rattler_shell-v0.23.4...rattler_shell-v0.24.0) - 2025-06-25

### Added

- Add `deactivation()` method to Activator ([#1278](https://github.com/conda/rattler/pull/1278))
</blockquote>

## `rattler_solve`

<blockquote>

## [2.1.2](https://github.com/conda/rattler/compare/rattler_solve-v2.1.1...rattler_solve-v2.1.2) - 2025-06-25

### Other

- *(ci)* Update Rust crate criterion to 0.6 ([#1438](https://github.com/conda/rattler/pull/1438))
</blockquote>

## `rattler_index`

<blockquote>

## [0.23.3](https://github.com/conda/rattler/compare/rattler_index-v0.23.2...rattler_index-v0.23.3) - 2025-06-25

### Added

- *(rattler_index)* Use rattler_config ([#1466](https://github.com/conda/rattler/pull/1466))
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.41](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.40...rattler_package_streaming-v0.22.41) - 2025-06-25

### Other

- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.22](https://github.com/conda/rattler/compare/rattler_cache-v0.3.21...rattler_cache-v0.3.22) - 2025-06-25

### Other

- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.13](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.12...rattler_menuinst-v0.2.13) - 2025-06-25

### Other

- updated the following local packages: rattler_conda_types, rattler_shell
</blockquote>

## `rattler`

<blockquote>

## [0.34.3](https://github.com/conda/rattler/compare/rattler-v0.34.2...rattler-v0.34.3) - 2025-06-25

### Other

- updated the following local packages: rattler_conda_types, rattler_networking, rattler_shell, rattler_package_streaming, rattler_cache, rattler_menuinst
</blockquote>

## `rattler_lock`

<blockquote>

## [0.23.7](https://github.com/conda/rattler/compare/rattler_lock-v0.23.6...rattler_lock-v0.23.7) - 2025-06-25

### Other

- updated the following local packages: rattler_conda_types, rattler_solve
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.23.3](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.2...rattler_repodata_gateway-v0.23.3) - 2025-06-25

### Other

- updated the following local packages: rattler_conda_types, rattler_networking, rattler_cache
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.15](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.14...rattler_virtual_packages-v2.0.15) - 2025-06-25

### Other

- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).