### PR TITLE
fix: allow track_features to be patched to null

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/patches.rs
+++ b/crates/rattler_conda_types/src/repo_data/patches.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::option_option)]
 
+use std::{collections::BTreeSet, io, path::Path};
+
 use fxhash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
-use std::collections::BTreeSet;
-use std::io;
-use std::path::Path;
 
 use crate::{package::ArchiveType, PackageRecord, PackageUrl, RepoData, Shard};
 
@@ -13,8 +12,8 @@ use crate::{package::ArchiveType, PackageRecord, PackageUrl, RepoData, Shard};
 ///
 /// This struct contains information about a patch to a Conda repodata file,
 /// which is used to update the metadata for Conda packages. The patch contains
-/// information about changes to the repodata, such as removed (yanked) packages and updated package
-/// metadata.
+/// information about changes to the repodata, such as removed (yanked) packages
+/// and updated package metadata.
 #[derive(Debug, Default, Clone)]
 pub struct RepoDataPatch {
     /// The patches to apply for each subdir
@@ -22,7 +21,8 @@ pub struct RepoDataPatch {
 }
 
 impl RepoDataPatch {
-    /// Load repodata patches from an extracted repodata patches package archive.
+    /// Load repodata patches from an extracted repodata patches package
+    /// archive.
     pub fn from_package(package: impl AsRef<Path>) -> io::Result<Self> {
         let mut subdirs = FxHashMap::default();
 
@@ -44,13 +44,14 @@ impl RepoDataPatch {
     }
 }
 
-/// Contains items that overwrite metadata values stored for a single [`super::PackageRecord`].
+/// Contains items that overwrite metadata values stored for a single
+/// [`super::PackageRecord`].
 ///
-/// Not all entries of a [`super::PackageRecord`] can be overwritten because that would cause
-/// difficult to solve inconsistencies. For instance, changing the sha256 hash of a file could
-/// break local caches because usually the data is cached by filename. With this struct we
-/// explicitly define which fields of a [`super::PackageRecord`] can be modified through repodata
-/// patches.
+/// Not all entries of a [`super::PackageRecord`] can be overwritten because
+/// that would cause difficult to solve inconsistencies. For instance, changing
+/// the sha256 hash of a file could break local caches because usually the data
+/// is cached by filename. With this struct we explicitly define which fields of
+/// a [`super::PackageRecord`] can be modified through repodata patches.
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
@@ -58,20 +59,30 @@ pub struct PackageRecordPatch {
     /// Specification of packages this package depends on
     pub depends: Option<Vec<String>>,
 
-    /// Additional constraints on packages. `constrains` are different from `depends` in that packages
-    /// specified in `depends` must be installed next to this package, whereas packages specified in
-    /// `constrains` are not required to be installed, but if they are installed they must follow these
-    /// constraints.
+    /// Additional constraints on packages. `constrains` are different from
+    /// `depends` in that packages specified in `depends` must be installed
+    /// next to this package, whereas packages specified in `constrains` are
+    /// not required to be installed, but if they are installed they must follow
+    /// these constraints.
     pub constrains: Option<Vec<String>>,
 
-    /// Track features are nowadays only used to downweight packages (ie. give them less priority). To
-    /// that effect, the number of track features is counted (number of commas) and the package is downweighted
+    /// Track features are nowadays only used to downweight packages (ie. give
+    /// them less priority). To that effect, the number of track features is
+    /// counted (number of commas) and the package is downweighted
     /// by the number of track_features.
-    #[serde_as(as = "Option<crate::utils::serde::Features>")]
-    pub track_features: Option<Vec<String>>,
+    ///
+    /// This field is double wrapped to be able to express the value `null`
+    /// separate from it being missing from the JSON.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "self::tracked_features"
+    )]
+    pub track_features: Option<Option<Vec<String>>>,
 
-    /// Features are a deprecated way to specify different feature sets for the conda solver. This is not
-    /// supported anymore and should not be used. Instead, `mutex` packages should be used to specify
+    /// Features are a deprecated way to specify different feature sets for the
+    /// conda solver. This is not supported anymore and should not be used.
+    /// Instead, `mutex` packages should be used to specify
     /// mutually exclusive features.
     #[serde(
         default,
@@ -96,14 +107,50 @@ pub struct PackageRecordPatch {
     )]
     pub license_family: Option<Option<String>>,
 
-    /// Package identifiers of packages that are equivalent to this package but from other
-    /// ecosystems.
+    /// Package identifiers of packages that are equivalent to this package but
+    /// from other ecosystems.
     /// See this CEP: <https://github.com/conda/ceps/pull/63>
-    pub purls: Option<BTreeSet<PackageUrl>>,
+    ///
+    /// This field is double wrapped to be able to express the value `null`
+    /// separate from it being missing from the JSON.
+    #[serde(default, with = "::serde_with::rust::double_option")]
+    pub purls: Option<Option<BTreeSet<PackageUrl>>>,
 }
 
-/// Repodata patch instructions for a single subdirectory. See [`RepoDataPatch`] for more
-/// information.
+mod tracked_features {
+    //! Helper module to serialize and deserialize the `track_features` field
+    //! and also allow it to be set to `null`.
+
+    use serde::{Deserializer, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    use crate::utils::serde::Features;
+
+    /// Deserialize potentially non-existing optional value
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Option<Vec<String>>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<Features>::deserialize_as(deserializer).map(Some)
+    }
+
+    /// Serialize optional value
+    pub fn serialize<S>(
+        value: &Option<Option<Vec<String>>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match value {
+            None => serializer.serialize_unit(),
+            Some(v) => Option::<Features>::serialize_as(v, serializer),
+        }
+    }
+}
+
+/// Repodata patch instructions for a single subdirectory. See [`RepoDataPatch`]
+/// for more information.
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 pub struct PatchInstructions {
     /// Filenames that have been removed from the subdirectory
@@ -133,7 +180,7 @@ impl PackageRecord {
             self.constrains = constrains.clone();
         }
         if let Some(track_features) = &patch.track_features {
-            self.track_features = track_features.clone();
+            self.track_features = track_features.clone().unwrap_or_default();
         }
         if let Some(features) = &patch.features {
             self.features = features.clone();
@@ -145,7 +192,7 @@ impl PackageRecord {
             self.license_family = license_family.clone();
         }
         if let Some(package_urls) = &patch.purls {
-            self.purls = Some(package_urls.clone());
+            self.purls = package_urls.clone();
         }
     }
 }
@@ -236,7 +283,7 @@ mod test {
     #[test]
     fn test_null_values() {
         let record_patch: super::PackageRecordPatch =
-            serde_json::from_str(r#"{"features": null, "license": null, "license_family": null, "depends": [], "constrains": [], "track_features": []}"#).unwrap();
+            serde_json::from_str(r#"{"features": null, "license": null, "license_family": null, "depends": [], "constrains": [], "track_features": null}"#).unwrap();
         insta::assert_yaml_snapshot!(record_patch);
     }
 
@@ -244,8 +291,8 @@ mod test {
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/channels/patch")
     }
 
-    fn load_test_repodata() -> RepoData {
-        let repodata_path = test_data_path().join("linux-64/repodata_from_packages.json");
+    fn load_test_repodata(name: &str) -> RepoData {
+        let repodata_path = test_data_path().join("linux-64").join(name);
         let repodata: RepoData =
             serde_json::from_str(&std::fs::read_to_string(repodata_path).unwrap()).unwrap();
         repodata
@@ -262,7 +309,7 @@ mod test {
     #[test]
     fn test_patching() {
         // test data
-        let mut repodata = load_test_repodata();
+        let mut repodata = load_test_repodata("repodata_from_packages.json");
         let patch_instructions = load_patch_instructions("patch_instructions.json");
 
         // apply patch
@@ -275,7 +322,7 @@ mod test {
     #[test]
     fn test_removing_1() {
         // test data
-        let mut repodata = load_test_repodata();
+        let mut repodata = load_test_repodata("repodata_from_packages.json");
         let patch_instructions = load_patch_instructions("patch_instructions_2.json");
 
         // apply patch
@@ -288,7 +335,7 @@ mod test {
     #[test]
     fn test_removing_2() {
         // test data
-        let mut repodata = load_test_repodata();
+        let mut repodata = load_test_repodata("repodata_from_packages.json");
         let patch_instructions = load_patch_instructions("patch_instructions_3.json");
 
         // apply patch
@@ -301,8 +348,21 @@ mod test {
     #[test]
     fn test_patch_purl() {
         // test data
-        let mut repodata = load_test_repodata();
+        let mut repodata = load_test_repodata("repodata_from_packages.json");
         let patch_instructions = load_patch_instructions("patch_instructions_4.json");
+
+        // apply patch
+        repodata.apply_patches(&patch_instructions);
+
+        // check result
+        insta::assert_yaml_snapshot!(repodata);
+    }
+
+    #[test]
+    fn test_patch_tracked_features() {
+        // test data
+        let mut repodata = load_test_repodata("repodata_from_packages_5.json");
+        let patch_instructions = load_patch_instructions("patch_instructions_5.json");
 
         // apply patch
         repodata.apply_patches(&patch_instructions);

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__patches__test__null_values.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__patches__test__null_values.snap
@@ -4,7 +4,7 @@ expression: record_patch
 ---
 depends: []
 constrains: []
-track_features: ""
+track_features: ~
 features: ~
 license: ~
 license_family: ~

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__patches__test__patch_tracked_features.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__patches__test__patch_tracked_features.snap
@@ -1,0 +1,25 @@
+---
+source: crates/rattler_conda_types/src/repo_data/patches.rs
+expression: repodata
+---
+info:
+  subdir: linux-64
+packages: {}
+packages.conda:
+  pytorch-cpu-2.6.0-cpu_mkl_h8b52ce0_104.conda:
+    arch: x86_64
+    build: cpu_mkl_h8b52ce0_104
+    build_number: 104
+    depends:
+      - pytorch 2.6.0 cpu_mkl*104
+    license: BSD-3-Clause
+    license_family: BSD
+    md5: e3a5a0c7917998be56d9e21afd80dde8
+    name: pytorch-cpu
+    platform: win
+    sha256: 8926532f9e39c58e6a4eda21e7de14b9320828d8ba97b6ad05ce2d092d0dce58
+    size: 51596
+    subdir: win-64
+    timestamp: 1744247964462
+    version: 2.6.0
+repodata_version: 1

--- a/test-data/channels/patch/linux-64/patch_instructions_5.json
+++ b/test-data/channels/patch/linux-64/patch_instructions_5.json
@@ -1,0 +1,7 @@
+{
+    "packages.conda": {
+        "pytorch-cpu-2.6.0-cpu_mkl_h8b52ce0_104.conda": {
+            "track_features": null
+        }
+    }
+}

--- a/test-data/channels/patch/linux-64/repodata_from_packages_5.json
+++ b/test-data/channels/patch/linux-64/repodata_from_packages_5.json
@@ -1,0 +1,28 @@
+{
+  "info": {
+    "subdir": "linux-64"
+  },
+  "packages.conda": {
+    "pytorch-cpu-2.6.0-cpu_mkl_h8b52ce0_104.conda": {
+      "arch": "x86_64",
+      "build": "cpu_mkl_h8b52ce0_104",
+      "build_number": 104,
+      "depends": [
+        "pytorch 2.6.0 cpu_mkl*104"
+      ],
+      "license": "BSD-3-Clause",
+      "license_family": "BSD",
+      "md5": "e3a5a0c7917998be56d9e21afd80dde8",
+      "name": "pytorch-cpu",
+      "platform": "win",
+      "sha256": "8926532f9e39c58e6a4eda21e7de14b9320828d8ba97b6ad05ce2d092d0dce58",
+      "size": 51596,
+      "subdir": "win-64",
+      "timestamp": 1744247964462,
+      "track_features": "pytorch-cpu",
+      "version": "2.6.0"
+    }
+  },
+  "removed": [],
+  "repodata_version": 1
+}


### PR DESCRIPTION
We found out that `track_features` in repodata patches can be `null`. This would effectively remove all tracked features. At the moment though this field is ignored by our implementation which means its not actually applied at all. This PR fixes that.