### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.3"
+version = "0.63.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f77a921dbd2c78ebe70726799787c1d110a2245dd65e39b20923dfdfb2deee"
+checksum = "244f00666380d35c1c76b90f7b88a11935d11b84076ac22a4c014ea0939627af"
 dependencies = [
  "aws-smithy-http 0.62.1",
  "aws-smithy-types",
@@ -630,15 +630,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f491388e741b7ca73b24130ff464c1478acc34d5b331b7dd0a2ee4643595a15"
+checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.26",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -1251,7 +1251,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -2288,7 +2288,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2297,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2307,7 +2307,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2562,7 +2562,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -2800,9 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -3050,7 +3050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -3689,7 +3689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faee7227064121fcadcd2ff788ea26f0d8f2bd23a0574da11eca23bc935bcc05"
 dependencies = [
  "boxcar",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.13.0",
  "once_cell",
  "pep440_rs",
@@ -3761,7 +3761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -3874,7 +3874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "quick-xml",
  "serde",
  "time",
@@ -4058,7 +4058,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.4"
+version = "0.34.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4183,7 +4183,7 @@ dependencies = [
  "fs-err",
  "futures",
  "humantime",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "indicatif",
  "insta",
  "itertools 0.14.0",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.35.3"
+version = "0.35.4"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4299,7 +4299,7 @@ dependencies = [
  "glob",
  "hex",
  "hex-literal",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "insta",
  "itertools 0.14.0",
  "lazy-regex",
@@ -4334,11 +4334,11 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "console 0.15.11",
  "fs-err",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "insta",
  "rattler_conda_types",
  "serde",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "blake2",
  "digest",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_libsolv_c"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "cc",
@@ -4418,12 +4418,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "chrono",
  "file_url",
  "fxhash",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "insta",
  "itertools 0.14.0",
  "pep440_rs",
@@ -4446,7 +4446,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "quote",
  "syn",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "configparser",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4520,7 +4520,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.42"
+version = "0.22.43"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_sandbox"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "birdcage",
  "clap",
@@ -4648,12 +4648,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "enum_dispatch",
  "fs-err",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "insta",
  "itertools 0.14.0",
  "rattler_conda_types",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "chrono",
  "criterion",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.16"
+version = "2.0.17"
 dependencies = [
  "archspec",
  "libloading",
@@ -4868,9 +4868,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.16.3"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9323c0afb30e54f793f4705b10c890395bccc87c6e6ea62c4e7e82d09a380dc6"
+checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4892,6 +4892,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -4907,7 +4908,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -4993,7 +4994,7 @@ dependencies = [
  "event-listener",
  "futures",
  "human_bytes",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.14.0",
  "petgraph",
  "serde",
@@ -5140,7 +5141,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5153,7 +5154,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5291,6 +5292,18 @@ name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -5451,7 +5464,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5492,16 +5505,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
- "schemars",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5511,9 +5525,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5527,7 +5541,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -5900,7 +5914,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6155,7 +6169,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6743,7 +6757,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7344,7 +7358,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "time",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,25 +183,25 @@ zstd = { version = "0.13.3", default-features = false }
 
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.5", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.4", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.23", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.3", default-features = false }
-rattler_config = { path = "crates/rattler_config", version = "=0.2.0", default-features = false }
-rattler_digest = { path = "crates/rattler_digest", version = "=1.1.3", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.24.1", default-features = false }
-rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.2", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.8", default-features = false }
-rattler_macros = { path = "crates/rattler_macros", version = "=1.0.10", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.14", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.3", default-features = false }
-rattler_pty = { path = "crates/rattler_pty", version = "=0.2.3", default-features = false }
-rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.11", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.42", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.4", default-features = false }
-rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.9", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.24.1", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=2.1.3", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.16", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.5", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.24", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.4", default-features = false }
+rattler_config = { path = "crates/rattler_config", version = "=0.2.1", default-features = false }
+rattler_digest = { path = "crates/rattler_digest", version = "=1.1.4", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.24.2", default-features = false }
+rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.9", default-features = false }
+rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.15", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.4", default-features = false }
+rattler_pty = { path = "crates/rattler_pty", version = "=0.2.4", default-features = false }
+rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.12", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.43", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.5", default-features = false }
+rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.10", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.24.2", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.1.4", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.17", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.5](https://github.com/conda/rattler/compare/rattler-v0.34.4...rattler-v0.34.5) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.34.4](https://github.com/conda/rattler/compare/rattler-v0.34.3...rattler-v0.34.4) - 2025-06-26
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.4"
+version = "0.34.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.24](https://github.com/conda/rattler/compare/rattler_cache-v0.3.23...rattler_cache-v0.3.24) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.3.23](https://github.com/conda/rattler/compare/rattler_cache-v0.3.22...rattler_cache-v0.3.23) - 2025-06-26
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.23"
+version = "0.3.24"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.4](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.3...rattler_conda_types-v0.35.4) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+- use kebab-case ([#1482](https://github.com/conda/rattler/pull/1482))
+
 ## [0.35.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.2...rattler_conda_types-v0.35.3) - 2025-06-26
 
 ### Fixed

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.35.3"
+version = "0.35.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_config/CHANGELOG.md
+++ b/crates/rattler_config/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/conda/rattler/compare/rattler_config-v0.2.0...rattler_config-v0.2.1) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+- use kebab-case ([#1482](https://github.com/conda/rattler/pull/1482))
+
 ## [0.2.0](https://github.com/conda/rattler/compare/rattler_config-v0.1.1...rattler_config-v0.2.0) - 2025-06-26
 
 ### Other

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_config"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors = []
 description = "A crate to configure rattler and derived tools."

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.4](https://github.com/conda/rattler/compare/rattler_digest-v1.1.3...rattler_digest-v1.1.4) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [1.1.3](https://github.com/conda/rattler/compare/rattler_digest-v1.1.2...rattler_digest-v1.1.3) - 2025-06-23
 
 ### Other

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "1.1.3"
+version = "1.1.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2](https://github.com/conda/rattler/compare/rattler_index-v0.24.1...rattler_index-v0.24.2) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.24.1](https://github.com/conda/rattler/compare/rattler_index-v0.24.0...rattler_index-v0.24.1) - 2025-06-26
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.24.1"
+version = "0.24.2"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.2.2...rattler_libsolv_c-v1.2.3) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [1.2.2](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.2.1...rattler_libsolv_c-v1.2.2) - 2025-06-23
 
 ### Other

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "1.2.2"
+version = "1.2.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.9](https://github.com/conda/rattler/compare/rattler_lock-v0.23.8...rattler_lock-v0.23.9) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.23.8](https://github.com/conda/rattler/compare/rattler_lock-v0.23.7...rattler_lock-v0.23.8) - 2025-06-26
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.8"
+version = "0.23.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.11](https://github.com/conda/rattler/compare/rattler_macros-v1.0.10...rattler_macros-v1.0.11) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [1.0.10](https://github.com/conda/rattler/compare/rattler_macros-v1.0.9...rattler_macros-v1.0.10) - 2025-06-23
 
 ### Other

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "1.0.10"
+version = "1.0.11"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.15](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.14...rattler_menuinst-v0.2.15) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.2.14](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.13...rattler_menuinst-v0.2.14) - 2025-06-26
 
 ### Other

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.4](https://github.com/conda/rattler/compare/rattler_networking-v0.25.3...rattler_networking-v0.25.4) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
+### Other
+
+- *(ci)* Update Rust crate google-cloud-auth to 0.21.0 ([#1461](https://github.com/conda/rattler/pull/1461))
+
 ## [0.25.3](https://github.com/conda/rattler/compare/rattler_networking-v0.25.2...rattler_networking-v0.25.3) - 2025-06-26
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.3"
+version = "0.25.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.43](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.42...rattler_package_streaming-v0.22.43) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.22.42](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.41...rattler_package_streaming-v0.22.42) - 2025-06-26
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.42"
+version = "0.22.43"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_pty/CHANGELOG.md
+++ b/crates/rattler_pty/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/conda/rattler/compare/rattler_pty-v0.2.3...rattler_pty-v0.2.4) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.2.3](https://github.com/conda/rattler/compare/rattler_pty-v0.2.2...rattler_pty-v0.2.3) - 2025-06-26
 
 ### Other

--- a/crates/rattler_pty/Cargo.toml
+++ b/crates/rattler_pty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_pty"
-version = "0.2.3"
+version = "0.2.4"
 description = "A crate to create pty"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_redaction/CHANGELOG.md
+++ b/crates/rattler_redaction/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.11...rattler_redaction-v0.1.12) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.1.11](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.10...rattler_redaction-v0.1.11) - 2025-06-23
 
 ### Other

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_redaction"
-version = "0.1.11"
+version = "0.1.12"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Redact sensitive information from URLs (ie. conda tokens)"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.5](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.4...rattler_repodata_gateway-v0.23.5) - 2025-07-01
+
+### Added
+
+- set default User-Agent if not provided ([#1468](https://github.com/conda/rattler/pull/1468))
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.23.4](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.3...rattler_repodata_gateway-v0.23.4) - 2025-06-26
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.4"
+version = "0.23.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_sandbox/CHANGELOG.md
+++ b/crates/rattler_sandbox/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.9...rattler_sandbox-v0.1.10) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.1.9](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.8...rattler_sandbox-v0.1.9) - 2025-06-23
 
 ### Other

--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_sandbox"
-version = "0.1.9"
+version = "0.1.10"
 description = "A crate to run executables in a sandbox"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2](https://github.com/conda/rattler/compare/rattler_shell-v0.24.1...rattler_shell-v0.24.2) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [0.24.1](https://github.com/conda/rattler/compare/rattler_shell-v0.24.0...rattler_shell-v0.24.1) - 2025-06-26
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.24.1"
+version = "0.24.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.4](https://github.com/conda/rattler/compare/rattler_solve-v2.1.3...rattler_solve-v2.1.4) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [2.1.3](https://github.com/conda/rattler/compare/rattler_solve-v2.1.2...rattler_solve-v2.1.3) - 2025-06-26
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "2.1.3"
+version = "2.1.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.17](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.16...rattler_virtual_packages-v2.0.17) - 2025-07-01
+
+### Fixed
+
+- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
+
 ## [2.0.16](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.15...rattler_virtual_packages-v2.0.16) - 2025-06-26
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.16"
+version = "2.0.17"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `rattler_digest`: 1.1.3 -> 1.1.4 (✓ API compatible changes)
* `rattler_macros`: 1.0.10 -> 1.0.11
* `rattler_redaction`: 0.1.11 -> 0.1.12 (✓ API compatible changes)
* `rattler_conda_types`: 0.35.3 -> 0.35.4 (✓ API compatible changes)
* `rattler_config`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `rattler_networking`: 0.25.3 -> 0.25.4 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.42 -> 0.22.43 (✓ API compatible changes)
* `rattler_cache`: 0.3.23 -> 0.3.24 (✓ API compatible changes)
* `rattler_pty`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `rattler_shell`: 0.24.1 -> 0.24.2 (✓ API compatible changes)
* `rattler_menuinst`: 0.2.14 -> 0.2.15 (✓ API compatible changes)
* `rattler`: 0.34.4 -> 0.34.5 (✓ API compatible changes)
* `rattler_libsolv_c`: 1.2.2 -> 1.2.3 (✓ API compatible changes)
* `rattler_solve`: 2.1.3 -> 2.1.4 (✓ API compatible changes)
* `rattler_lock`: 0.23.8 -> 0.23.9 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.23.4 -> 0.23.5 (✓ API compatible changes)
* `rattler_virtual_packages`: 2.0.16 -> 2.0.17 (✓ API compatible changes)
* `rattler_index`: 0.24.1 -> 0.24.2 (✓ API compatible changes)
* `rattler_sandbox`: 0.1.9 -> 0.1.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_digest`

<blockquote>

## [1.1.4](https://github.com/conda/rattler/compare/rattler_digest-v1.1.3...rattler_digest-v1.1.4) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_macros`

<blockquote>

## [1.0.11](https://github.com/conda/rattler/compare/rattler_macros-v1.0.10...rattler_macros-v1.0.11) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_redaction`

<blockquote>

## [0.1.12](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.11...rattler_redaction-v0.1.12) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.35.4](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.3...rattler_conda_types-v0.35.4) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
- use kebab-case ([#1482](https://github.com/conda/rattler/pull/1482))
</blockquote>

## `rattler_config`

<blockquote>

## [0.2.1](https://github.com/conda/rattler/compare/rattler_config-v0.2.0...rattler_config-v0.2.1) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
- use kebab-case ([#1482](https://github.com/conda/rattler/pull/1482))
</blockquote>

## `rattler_networking`

<blockquote>

## [0.25.4](https://github.com/conda/rattler/compare/rattler_networking-v0.25.3...rattler_networking-v0.25.4) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))

### Other

- *(ci)* Update Rust crate google-cloud-auth to 0.21.0 ([#1461](https://github.com/conda/rattler/pull/1461))
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.43](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.42...rattler_package_streaming-v0.22.43) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.24](https://github.com/conda/rattler/compare/rattler_cache-v0.3.23...rattler_cache-v0.3.24) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_pty`

<blockquote>

## [0.2.4](https://github.com/conda/rattler/compare/rattler_pty-v0.2.3...rattler_pty-v0.2.4) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_shell`

<blockquote>

## [0.24.2](https://github.com/conda/rattler/compare/rattler_shell-v0.24.1...rattler_shell-v0.24.2) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.15](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.14...rattler_menuinst-v0.2.15) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler`

<blockquote>

## [0.34.5](https://github.com/conda/rattler/compare/rattler-v0.34.4...rattler-v0.34.5) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_libsolv_c`

<blockquote>

## [1.2.3](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.2.2...rattler_libsolv_c-v1.2.3) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_solve`

<blockquote>

## [2.1.4](https://github.com/conda/rattler/compare/rattler_solve-v2.1.3...rattler_solve-v2.1.4) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_lock`

<blockquote>

## [0.23.9](https://github.com/conda/rattler/compare/rattler_lock-v0.23.8...rattler_lock-v0.23.9) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.23.5](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.4...rattler_repodata_gateway-v0.23.5) - 2025-07-01

### Added

- set default User-Agent if not provided ([#1468](https://github.com/conda/rattler/pull/1468))

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.17](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.16...rattler_virtual_packages-v2.0.17) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_index`

<blockquote>

## [0.24.2](https://github.com/conda/rattler/compare/rattler_index-v0.24.1...rattler_index-v0.24.2) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>

## `rattler_sandbox`

<blockquote>

## [0.1.10](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.9...rattler_sandbox-v0.1.10) - 2025-07-01

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).