### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.94.0"
+version = "1.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc24d9d761bd464534d9e477a9f724c118ca2557a95444097cf6ce71f3229a72"
+checksum = "6e25d24de44b34dcdd5182ac4e4c6f07bcec2661c505acef94c0d293b65505fe"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.73.0"
+version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ac1674cba7872061a29baaf02209fefe499ff034dfd91bd4cc59e4d7741489"
+checksum = "e0a69de9c1b9272da2872af60c7402683e7f45c06267735b4332deacb203239b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.74.0"
+version = "1.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6a22f077f5fd3e3c0270d4e1a110346cddf6769e9433eb9e6daceb4ca3b149"
+checksum = "f0b161d836fac72bdd5ac1a4cd1cdc38ab888c7af26cfd95f661be4409505e63"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.75.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3258fa707f2f585ee3049d9550954b959002abd59176975150a01d5cf38ae3f"
+checksum = "cb1cd79a3412751a341a28e2cd0d6fa4345241976da427b075a0c0cd5409f886"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+checksum = "c3aaec682eb189e43c8a19c3dab2fe54590ad5f2cc2d26ab27608a20f2acf81c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.62.1",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8531b6d8882fd8f48f82a9754e682e29dd44cff27154af51fa3eb730f59efb"
+checksum = "9852b9226cb60b78ce9369022c0df678af1cac231c882d5da97a0c4e03be6e67"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -970,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -1274,19 +1274,6 @@ dependencies = [
  "once_cell",
  "unicode-width 0.2.1",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.1",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2635,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2820,14 +2807,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.12"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console 0.16.0",
+ "console",
+ "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.1",
- "unit-prefix",
  "web-time",
 ]
 
@@ -2847,7 +2834,7 @@ version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
- "console 0.15.11",
+ "console",
  "globset",
  "once_cell",
  "pest",
@@ -2869,6 +2856,17 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -3470,6 +3468,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2-core-foundation"
@@ -4231,13 +4235,13 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.5"
+version = "0.34.6"
 dependencies = [
  "anyhow",
  "assert_matches",
  "axum",
  "clap",
- "console 0.15.11",
+ "console",
  "digest",
  "dirs",
  "fs-err",
@@ -4287,7 +4291,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "console 0.15.11",
+ "console",
  "indicatif",
  "itertools 0.14.0",
  "once_cell",
@@ -4307,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4345,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.35.4"
+version = "0.35.5"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4394,9 +4398,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
- "console 0.15.11",
+ "console",
  "fs-err",
  "indexmap 2.10.0",
  "insta",
@@ -4431,14 +4435,14 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "anyhow",
  "bytes",
  "chrono",
  "clap",
  "clap-verbosity-flag",
- "console 0.15.11",
+ "console",
  "fs-err",
  "futures",
  "fxhash",
@@ -4478,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "chrono",
  "file_url",
@@ -4515,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "chrono",
  "configparser",
@@ -4544,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4580,7 +4584,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.43"
+version = "0.22.44"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4632,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4709,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4731,7 +4735,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "chrono",
  "criterion",
@@ -4790,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.17"
+version = "2.0.18"
 dependencies = [
  "archspec",
  "libloading",
@@ -5196,13 +5200,12 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+checksum = "e7295b7ce3bf4806b419dc3420745998b447178b7005e2011947b38fc5aa6791"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
- "trim-in-place",
 ]
 
 [[package]]
@@ -5396,9 +5399,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -5587,6 +5590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5610,7 +5622,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.10.0",
  "schemars 0.9.0",
- "schemars 1.0.3",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5762,7 +5774,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
 dependencies = [
- "console 0.15.11",
+ "console",
  "similar",
 ]
 
@@ -6198,17 +6210,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -6296,9 +6310,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f271e09bde39ab52250160a67e88577e0559ad77e9085de6e9051a2c4353f8f8"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -6311,6 +6340,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6318,9 +6356,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5c1c469eda89749d2230d8156a5969a69ffe0d6d01200581cdc6110674d293e"
+dependencies = [
  "winnow",
 ]
 
@@ -6329,6 +6376,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b679217f2848de74cabd3e8fc5e6d66f40b7da40f8e1954d92054d9010690fd5"
 
 [[package]]
 name = "tools"
@@ -6488,12 +6541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trim-in-place"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6501,9 +6548,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2"
+checksum = "65af40ad689f2527aebbd37a0a816aea88ff5f774ceabe99de5be02f2f91dae2"
 dependencies = [
  "dissimilar",
  "glob",
@@ -6512,7 +6559,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.8.23",
+ "toml 0.9.0",
 ]
 
 [[package]]
@@ -6594,12 +6641,6 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,25 +183,25 @@ zstd = { version = "0.13.3", default-features = false }
 
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.5", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.5", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.24", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.4", default-features = false }
-rattler_config = { path = "crates/rattler_config", version = "=0.2.1", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.6", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.25", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.5", default-features = false }
+rattler_config = { path = "crates/rattler_config", version = "=0.2.2", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.1.4", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.24.2", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.24.3", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.9", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.10", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.15", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.4", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.16", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.5", default-features = false }
 rattler_pty = { path = "crates/rattler_pty", version = "=0.2.4", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.12", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.43", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.5", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.44", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.6", default-features = false }
 rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.10", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.24.2", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=2.1.4", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.17", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.24.3", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.1.5", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.18", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.6](https://github.com/conda/rattler/compare/rattler-v0.34.5...rattler-v0.34.6) - 2025-07-09
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming, rattler_cache, rattler_shell, rattler_menuinst
+
 ## [0.34.5](https://github.com/conda/rattler/compare/rattler-v0.34.4...rattler-v0.34.5) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.5"
+version = "0.34.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.25](https://github.com/conda/rattler/compare/rattler_cache-v0.3.24...rattler_cache-v0.3.25) - 2025-07-09
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming
+
 ## [0.3.24](https://github.com/conda/rattler/compare/rattler_cache-v0.3.23...rattler_cache-v0.3.24) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.24"
+version = "0.3.25"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.5](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.4...rattler_conda_types-v0.35.5) - 2025-07-09
+
+### Other
+
+- move upload from `rattler-build` to `rattler` ([#1386](https://github.com/conda/rattler/pull/1386))
+
 ## [0.35.4](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.3...rattler_conda_types-v0.35.4) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.35.4"
+version = "0.35.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_config"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors = []
 description = "A crate to configure rattler and derived tools."

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.3](https://github.com/conda/rattler/compare/rattler_index-v0.24.2...rattler_index-v0.24.3) - 2025-07-09
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.24.2](https://github.com/conda/rattler/compare/rattler_index-v0.24.1...rattler_index-v0.24.2) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.24.2"
+version = "0.24.3"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.10](https://github.com/conda/rattler/compare/rattler_lock-v0.23.9...rattler_lock-v0.23.10) - 2025-07-09
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_solve
+
 ## [0.23.9](https://github.com/conda/rattler/compare/rattler_lock-v0.23.8...rattler_lock-v0.23.9) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.9"
+version = "0.23.10"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.16](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.15...rattler_menuinst-v0.2.16) - 2025-07-09
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_shell
+
 ## [0.2.15](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.14...rattler_menuinst-v0.2.15) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.15"
+version = "0.2.16"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.5](https://github.com/conda/rattler/compare/rattler_networking-v0.25.4...rattler_networking-v0.25.5) - 2025-07-09
+
+### Other
+
+- updated the following local packages: rattler_config
+
 ## [0.25.4](https://github.com/conda/rattler/compare/rattler_networking-v0.25.3...rattler_networking-v0.25.4) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.4"
+version = "0.25.5"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.44](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.43...rattler_package_streaming-v0.22.44) - 2025-07-09
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.22.43](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.42...rattler_package_streaming-v0.22.43) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.43"
+version = "0.22.44"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.6](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.5...rattler_repodata_gateway-v0.23.6) - 2025-07-09
+
+### Added
+
+- implement config conversion for repodata_gateway ([#1498](https://github.com/conda/rattler/pull/1498))
+
 ## [0.23.5](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.4...rattler_repodata_gateway-v0.23.5) - 2025-07-01
 
 ### Added

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.5"
+version = "0.23.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.3](https://github.com/conda/rattler/compare/rattler_shell-v0.24.2...rattler_shell-v0.24.3) - 2025-07-09
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.24.2](https://github.com/conda/rattler/compare/rattler_shell-v0.24.1...rattler_shell-v0.24.2) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.24.2"
+version = "0.24.3"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.5](https://github.com/conda/rattler/compare/rattler_solve-v2.1.4...rattler_solve-v2.1.5) - 2025-07-09
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [2.1.4](https://github.com/conda/rattler/compare/rattler_solve-v2.1.3...rattler_solve-v2.1.4) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "2.1.4"
+version = "2.1.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_upload/CHANGELOG.md
+++ b/crates/rattler_upload/CHANGELOG.md
@@ -7,42 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.2](https://github.com/conda/rattler/compare/rattler_config-v0.2.1...rattler_config-v0.2.2) - 2025-07-09
+## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_upload-v0.1.0) - 2025-07-09
 
-### Other
+### Added
 
-- updated the following local packages: rattler_conda_types
-
-## [0.2.1](https://github.com/conda/rattler/compare/rattler_config-v0.2.0...rattler_config-v0.2.1) - 2025-07-01
+- better readme ([#118](https://github.com/conda/rattler/pull/118))
+- replace zulip with discord ([#116](https://github.com/conda/rattler/pull/116))
+- move all conda types to seperate crate
 
 ### Fixed
 
 - *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
-- use kebab-case ([#1482](https://github.com/conda/rattler/pull/1482))
-
-## [0.2.0](https://github.com/conda/rattler/compare/rattler_config-v0.1.1...rattler_config-v0.2.0) - 2025-06-26
-
-### Other
-
-- Fix typo ([#1479](https://github.com/conda/rattler/pull/1479))
-
-## [0.1.1](https://github.com/conda/rattler/compare/rattler_config-v0.1.0...rattler_config-v0.1.1) - 2025-06-25
-
-### Added
-
-- *(rattler_index)* Use rattler_config ([#1466](https://github.com/conda/rattler/pull/1466))
-
-## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_config-v0.1.0) - 2025-06-23
-
-### Added
-
-- add `rattler_config` crate (derived from `pixi_config`) ([#1389](https://github.com/conda/rattler/pull/1389))
-- better readme ([#118](https://github.com/conda/rattler/pull/118))
-- replace zulip with discord ([#116](https://github.com/conda/rattler/pull/116))
-- move all conda types to separate crate
-
-### Fixed
-
 - added missing hyphen to relative url linking to what-is-conda section in README.md ([#1192](https://github.com/conda/rattler/pull/1192))
 - typos ([#849](https://github.com/conda/rattler/pull/849))
 - move more links to the conda org from conda-incubator ([#816](https://github.com/conda/rattler/pull/816))
@@ -54,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
+- move upload from `rattler-build` to `rattler` ([#1386](https://github.com/conda/rattler/pull/1386))
 - update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
 - update readme ([#1364](https://github.com/conda/rattler/pull/1364))
 - Fix badge style ([#1110](https://github.com/conda/rattler/pull/1110))

--- a/crates/rattler_upload/CHANGELOG.md
+++ b/crates/rattler_upload/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - better readme ([#118](https://github.com/conda/rattler/pull/118))
 - replace zulip with discord ([#116](https://github.com/conda/rattler/pull/116))
-- move all conda types to seperate crate
+- move all conda types to separate crate
 
 ### Fixed
 

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.18](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.17...rattler_virtual_packages-v2.0.18) - 2025-07-09
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [2.0.17](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.16...rattler_virtual_packages-v2.0.17) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.17"
+version = "2.0.18"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `rattler_conda_types`: 0.35.4 -> 0.35.5 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.23.5 -> 0.23.6 (✓ API compatible changes)
* `rattler_index`: 0.24.2 -> 0.24.3 (✓ API compatible changes)
* `rattler_upload`: 0.1.0
* `rattler_config`: 0.2.1 -> 0.2.2
* `rattler_networking`: 0.25.4 -> 0.25.5
* `rattler_package_streaming`: 0.22.43 -> 0.22.44
* `rattler_cache`: 0.3.24 -> 0.3.25
* `rattler_shell`: 0.24.2 -> 0.24.3
* `rattler_menuinst`: 0.2.15 -> 0.2.16
* `rattler`: 0.34.5 -> 0.34.6
* `rattler_solve`: 2.1.4 -> 2.1.5
* `rattler_lock`: 0.23.9 -> 0.23.10
* `rattler_virtual_packages`: 2.0.17 -> 2.0.18

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_conda_types`

<blockquote>

## [0.35.5](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.4...rattler_conda_types-v0.35.5) - 2025-07-09

### Other

- move upload from `rattler-build` to `rattler` ([#1386](https://github.com/conda/rattler/pull/1386))
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.23.6](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.5...rattler_repodata_gateway-v0.23.6) - 2025-07-09

### Added

- implement config conversion for repodata_gateway ([#1498](https://github.com/conda/rattler/pull/1498))
</blockquote>

## `rattler_index`

<blockquote>

## [0.24.3](https://github.com/conda/rattler/compare/rattler_index-v0.24.2...rattler_index-v0.24.3) - 2025-07-09

### Other

- update Cargo.lock dependencies
</blockquote>

## `rattler_upload`

<blockquote>

## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_upload-v0.1.0) - 2025-07-09

### Added

- better readme ([#118](https://github.com/conda/rattler/pull/118))
- replace zulip with discord ([#116](https://github.com/conda/rattler/pull/116))
- move all conda types to seperate crate

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
- added missing hyphen to relative url linking to what-is-conda section in README.md ([#1192](https://github.com/conda/rattler/pull/1192))
- typos ([#849](https://github.com/conda/rattler/pull/849))
- move more links to the conda org from conda-incubator ([#816](https://github.com/conda/rattler/pull/816))
- use conda-incubator
- add python docs badge
- typo libsolve -> libsolv ([#164](https://github.com/conda/rattler/pull/164))
- change urls from baszalmstra to mamba-org
- build badge

### Other

- move upload from `rattler-build` to `rattler` ([#1386](https://github.com/conda/rattler/pull/1386))
- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
- Fix badge style ([#1110](https://github.com/conda/rattler/pull/1110))
- fix anchor link ([#1035](https://github.com/conda/rattler/pull/1035))
- change links from conda-incubator to conda ([#813](https://github.com/conda/rattler/pull/813))
- update banner ([#808](https://github.com/conda/rattler/pull/808))
- update README.md
- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
- update installation gif
- update banner image
- address issue #282 ([#283](https://github.com/conda/rattler/pull/283))
- Add an image to Readme ([#203](https://github.com/conda/rattler/pull/203))
- Improve getting started with a micromamba environment. ([#163](https://github.com/conda/rattler/pull/163))
- Misc/update readme ([#66](https://github.com/conda/rattler/pull/66))
- update readme
- layout the vision a little bit better
- *(docs)* add build badge
- matchspec parsing
</blockquote>

## `rattler_config`

<blockquote>

## [0.2.2](https://github.com/conda/rattler/compare/rattler_config-v0.2.1...rattler_config-v0.2.2) - 2025-07-09

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_networking`

<blockquote>

## [0.25.5](https://github.com/conda/rattler/compare/rattler_networking-v0.25.4...rattler_networking-v0.25.5) - 2025-07-09

### Other

- updated the following local packages: rattler_config
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.44](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.43...rattler_package_streaming-v0.22.44) - 2025-07-09

### Other

- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.25](https://github.com/conda/rattler/compare/rattler_cache-v0.3.24...rattler_cache-v0.3.25) - 2025-07-09

### Other

- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming
</blockquote>

## `rattler_shell`

<blockquote>

## [0.24.3](https://github.com/conda/rattler/compare/rattler_shell-v0.24.2...rattler_shell-v0.24.3) - 2025-07-09

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.16](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.15...rattler_menuinst-v0.2.16) - 2025-07-09

### Other

- updated the following local packages: rattler_conda_types, rattler_shell
</blockquote>

## `rattler`

<blockquote>

## [0.34.6](https://github.com/conda/rattler/compare/rattler-v0.34.5...rattler-v0.34.6) - 2025-07-09

### Other

- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming, rattler_cache, rattler_shell, rattler_menuinst
</blockquote>

## `rattler_solve`

<blockquote>

## [2.1.5](https://github.com/conda/rattler/compare/rattler_solve-v2.1.4...rattler_solve-v2.1.5) - 2025-07-09

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`

<blockquote>

## [0.23.10](https://github.com/conda/rattler/compare/rattler_lock-v0.23.9...rattler_lock-v0.23.10) - 2025-07-09

### Other

- updated the following local packages: rattler_conda_types, rattler_solve
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.18](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.17...rattler_virtual_packages-v2.0.18) - 2025-07-09

### Other

- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).