### PR TITLE
fix: fix metadata "authors" and "description" missing in 'rattler_upload' crate

### DIFF
--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "rattler_upload"
 version = "0.1.0"
+edition.workspace = true
+authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>", "Magenta Qin <magenta2127@gmail.com>"]
+description = "A crate to Upload conda packages to various channels."
 categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
-edition.workspace = true
 readme.workspace = true
 
 [features]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Add metadata "authors" and "description"  for 'rattler_upload' crate

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
