### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
 dependencies = [
  "async-lock",
  "blocking",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -255,10 +255,9 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -274,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
  "async-channel",
  "async-io",
@@ -287,8 +286,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.0.7",
- "tracing",
+ "rustix 1.0.8",
 ]
 
 [[package]]
@@ -304,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -314,10 +312,10 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -381,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -393,15 +391,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.8"
+version = "1.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6c68419d8ba16d9a7463671593c54f81ba58cab466e9b759418da606dcc2e2"
+checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -418,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.96.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e25d24de44b34dcdd5182ac4e4c6f07bcec2661c505acef94c0d293b65505fe"
+checksum = "029e89cae7e628553643aecb3a3f054a0a0912ff0fd1f5d6a0b4fda421dce64b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -428,7 +426,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -452,14 +450,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.74.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a69de9c1b9272da2872af60c7402683e7f45c06267735b4332deacb203239b"
+checksum = "64bf26698dd6d238ef1486bdda46f22a589dc813368ba868dc3d94c8d27b56ba"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -474,14 +472,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.75.0"
+version = "1.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b161d836fac72bdd5ac1a4cd1cdc38ab888c7af26cfd95f661be4409505e63"
+checksum = "09cd07ed1edd939fae854a22054299ae3576500f4e0fadc560ca44f9c6ea1664"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -496,14 +494,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.76.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1cd79a3412751a341a28e2cd0d6fa4345241976da427b075a0c0cd5409f886"
+checksum = "37f7766d2344f56d10d12f3c32993da36d78217f32594fe4fb8e57a538c1cdea"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -525,7 +523,7 @@ checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -558,11 +556,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.4"
+version = "0.63.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244f00666380d35c1c76b90f7b88a11935d11b84076ac22a4c014ea0939627af"
+checksum = "5ab9472f7a8ec259ddb5681d2ef1cb1cf16c0411890063e67cdc7b62562cc496"
 dependencies = [
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -578,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.9"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338a3642c399c0a5d157648426110e199ca7fd1c689cc395676b81aa563700c4"
+checksum = "604c7aec361252b8f1c871a7641d5e0ba3a7f5a586e51b66bc9510a5519594d9"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -609,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+checksum = "43c82ba4cab184ea61f6edaafc1072aad3c2a17dcf4c0fce19ac5694b90d8b5f"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -684,7 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3aaec682eb189e43c8a19c3dab2fe54590ad5f2cc2d26ab27608a20f2acf81c"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -998,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61138465baf186c63e8d9b6b613b508cd832cba4ce93cf37ce5f096f91ac1a6"
+checksum = "33d9ef19ae5263a138da9a86871eca537478ab0332a7770bac7e3f08b801f89f"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -1008,11 +1006,11 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d1dad34aa19bf02295382f08d9bc40651585bd497266831d40ee6296fb49ca"
+checksum = "577ae008f2ca11ca7641bd44601002ee5ab49ef0af64846ce1ab6057218a5cc1"
 dependencies = [
- "darling",
+ "darling 0.21.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1101,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -1389,7 +1387,7 @@ dependencies = [
  "crc",
  "digest",
  "libc",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
 ]
 
@@ -1529,8 +1527,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+dependencies = [
+ "darling_core 0.21.0",
+ "darling_macro 0.21.0",
 ]
 
 [[package]]
@@ -1548,12 +1556,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+dependencies = [
+ "darling_core 0.21.0",
  "quote",
  "syn",
 ]
@@ -1899,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "file_url"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -2000,7 +2033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "fs-err",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "tokio",
  "windows-sys 0.59.0",
 ]
@@ -2242,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88f66b6fccca3449ad9f0366ec3d1b74a004fa1100d98353a201dabc3203bd2"
+checksum = "5560b3cedeea7041862717175d98733ac81f7bedfdd0c7949bf06d761bf4094f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2253,7 +2286,7 @@ dependencies = [
  "google-cloud-wkt",
  "http 1.3.1",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -2262,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rpc"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b4b7867ab6e94e56944116f2b1bdcdbac522eea794743a9884d84db7728470"
+checksum = "949f5858642f68efbd836a82400d04f2572e6d18a612c1144d0868832f40996e"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2275,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b1dbeb30ab8bde2423081b76f9c302d82fea1b99f8ca750f223d32065d3c6c"
+checksum = "8e2916ee3f086766d6989abd8a0b1c3910322af60d72352f6cdf5cb8eb951464"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3102,13 +3135,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.15",
 ]
 
 [[package]]
@@ -3729,7 +3762,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.15",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3999,17 +4032,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.7",
- "tracing",
- "windows-sys 0.59.0",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4081,7 +4113,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -4159,7 +4191,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls 0.23.29",
@@ -4232,9 +4264,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4304,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.7"
+version = "0.34.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4325,7 +4357,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.4",
  "path_resolver",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rattler_cache",
  "rattler_conda_types",
  "rattler_digest",
@@ -4382,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.26"
+version = "0.3.27"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4420,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.35.6"
+version = "0.36.0"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4442,7 +4474,7 @@ dependencies = [
  "nom-language",
  "pathdiff",
  "purl",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rattler_digest",
  "rattler_macros",
  "rattler_package_streaming",
@@ -4469,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "console 0.15.11",
  "fs-err",
@@ -4487,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "blake2",
  "digest",
@@ -4506,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4553,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.11"
+version = "0.23.12"
 dependencies = [
  "chrono",
  "file_url",
@@ -4590,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "configparser",
@@ -4619,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4655,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.45"
+version = "0.22.46"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4689,7 +4721,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -4707,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4784,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4806,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "chrono",
  "criterion",
@@ -4832,7 +4864,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -4865,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.19"
+version = "2.1.0"
 dependencies = [
  "archspec",
  "libloading",
@@ -4920,9 +4952,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4966,7 +4998,7 @@ checksum = "78c81d000a2c524133cc00d2f92f019d399e57906c3b7119271a2495354fe895"
 dependencies = [
  "cfg-if",
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows 0.61.3",
 ]
 
@@ -5315,15 +5347,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5641,9 +5673,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -5710,7 +5742,7 @@ version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -5931,23 +5963,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -6125,7 +6156,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -6144,7 +6175,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -6760,7 +6791,7 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "wasm-bindgen",
 ]
@@ -6988,9 +7019,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7002,7 +7033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "winsafe",
 ]
 
@@ -7435,7 +7466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,27 +183,27 @@ zip = { version = ">=3.0.0,<4.1", default-features = false }
 zstd = { version = "0.13.3", default-features = false }
 
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
-file_url = { path = "crates/file_url", version = "=0.2.5", default-features = false }
+file_url = { path = "crates/file_url", version = "=0.2.6", default-features = false }
 path_resolver = { path = "crates/path_resolver", version = "=0.1.1", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.7", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.26", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.6", default-features = false }
-rattler_config = { path = "crates/rattler_config", version = "=0.2.3", default-features = false }
-rattler_digest = { path = "crates/rattler_digest", version = "=1.1.4", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.24.4", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.8", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.27", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.36.0", default-features = false }
+rattler_config = { path = "crates/rattler_config", version = "=0.2.4", default-features = false }
+rattler_digest = { path = "crates/rattler_digest", version = "=1.1.5", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.24.5", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.11", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.12", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.17", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.6", default-features = false }
-rattler_pty = { path = "crates/rattler_pty", version = "=0.2.4", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.18", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.7", default-features = false }
+rattler_pty = { path = "crates/rattler_pty", version = "=0.2.5", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.12", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.45", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.7", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.46", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.8", default-features = false }
 rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.10", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.24.4", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=2.1.6", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.19", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.24.5", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.1.7", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.0", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/file_url/CHANGELOG.md
+++ b/crates/file_url/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/conda/rattler/compare/file_url-v0.2.5...file_url-v0.2.6) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [0.2.5](https://github.com/conda/rattler/compare/file_url-v0.2.4...file_url-v0.2.5) - 2025-05-16
 
 ### Other

--- a/crates/file_url/Cargo.toml
+++ b/crates/file_url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_url"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Helper functions to work with file:// urls"

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.8](https://github.com/conda/rattler/compare/rattler-v0.34.7...rattler-v0.34.8) - 2025-07-21
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.34.7](https://github.com/conda/rattler/compare/rattler-v0.34.6...rattler-v0.34.7) - 2025-07-14
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.7"
+version = "0.34.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.27](https://github.com/conda/rattler/compare/rattler_cache-v0.3.26...rattler_cache-v0.3.27) - 2025-07-21
+
+### Other
+
+- updated the following local packages: rattler_digest, rattler_conda_types, rattler_package_streaming, rattler_networking
+
 ## [0.3.26](https://github.com/conda/rattler/compare/rattler_cache-v0.3.25...rattler_cache-v0.3.26) - 2025-07-14
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.26"
+version = "0.3.27"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.6...rattler_conda_types-v0.36.0) - 2025-07-21
+
+### Added
+
+- make `Platform` `non_exhaustive` ([#1539](https://github.com/conda/rattler/pull/1539))
+- add support for loong64 platform to rattler ([#1534](https://github.com/conda/rattler/pull/1534))
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [0.35.6](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.5...rattler_conda_types-v0.35.6) - 2025-07-14
 
 ### Fixed

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.35.6"
+version = "0.36.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_config/CHANGELOG.md
+++ b/crates/rattler_config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/conda/rattler/compare/rattler_config-v0.2.3...rattler_config-v0.2.4) - 2025-07-21
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.3](https://github.com/conda/rattler/compare/rattler_config-v0.2.2...rattler_config-v0.2.3) - 2025-07-14
 
 ### Other

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_config"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors = []
 description = "A crate to configure rattler and derived tools."

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5](https://github.com/conda/rattler/compare/rattler_digest-v1.1.4...rattler_digest-v1.1.5) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [1.1.4](https://github.com/conda/rattler/compare/rattler_digest-v1.1.3...rattler_digest-v1.1.4) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "1.1.4"
+version = "1.1.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5](https://github.com/conda/rattler/compare/rattler_index-v0.24.4...rattler_index-v0.24.5) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [0.24.4](https://github.com/conda/rattler/compare/rattler_index-v0.24.3...rattler_index-v0.24.4) - 2025-07-14
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.24.4"
+version = "0.24.5"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.12](https://github.com/conda/rattler/compare/rattler_lock-v0.23.11...rattler_lock-v0.23.12) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [0.23.11](https://github.com/conda/rattler/compare/rattler_lock-v0.23.10...rattler_lock-v0.23.11) - 2025-07-14
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.11"
+version = "0.23.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.18](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.17...rattler_menuinst-v0.2.18) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [0.2.17](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.16...rattler_menuinst-v0.2.17) - 2025-07-14
 
 ### Other

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.17"
+version = "0.2.18"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.7](https://github.com/conda/rattler/compare/rattler_networking-v0.25.6...rattler_networking-v0.25.7) - 2025-07-21
+
+### Other
+
+- updated the following local packages: rattler_config
+
 ## [0.25.6](https://github.com/conda/rattler/compare/rattler_networking-v0.25.5...rattler_networking-v0.25.6) - 2025-07-14
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.6"
+version = "0.25.7"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.46](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.45...rattler_package_streaming-v0.22.46) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [0.22.45](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.44...rattler_package_streaming-v0.22.45) - 2025-07-14
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.45"
+version = "0.22.46"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_pty/CHANGELOG.md
+++ b/crates/rattler_pty/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/conda/rattler/compare/rattler_pty-v0.2.4...rattler_pty-v0.2.5) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [0.2.4](https://github.com/conda/rattler/compare/rattler_pty-v0.2.3...rattler_pty-v0.2.4) - 2025-07-01
 
 ### Fixed

--- a/crates/rattler_pty/Cargo.toml
+++ b/crates/rattler_pty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_pty"
-version = "0.2.4"
+version = "0.2.5"
 description = "A crate to create pty"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.8](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.7...rattler_repodata_gateway-v0.23.8) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [0.23.7](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.6...rattler_repodata_gateway-v0.23.7) - 2025-07-14
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.7"
+version = "0.23.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5](https://github.com/conda/rattler/compare/rattler_shell-v0.24.4...rattler_shell-v0.24.5) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [0.24.4](https://github.com/conda/rattler/compare/rattler_shell-v0.24.3...rattler_shell-v0.24.4) - 2025-07-14
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.24.4"
+version = "0.24.5"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.7](https://github.com/conda/rattler/compare/rattler_solve-v2.1.6...rattler_solve-v2.1.7) - 2025-07-21
+
+### Other
+
+- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
+
 ## [2.1.6](https://github.com/conda/rattler/compare/rattler_solve-v2.1.5...rattler_solve-v2.1.6) - 2025-07-14
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "2.1.6"
+version = "2.1.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_upload/CHANGELOG.md
+++ b/crates/rattler_upload/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/conda/rattler/compare/rattler_upload-v0.1.0...rattler_upload-v0.1.1) - 2025-07-21
+
+### Other
+
+- updated the following local packages: rattler_digest, rattler_conda_types, rattler_config, rattler_package_streaming, rattler_solve, rattler_networking
+
 ## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_upload-v0.1.0) - 2025-07-09
 
 ### Added

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_upload"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>", "Magenta Qin <magenta2127@gmail.com>"]
 description = "A crate to Upload conda packages to various channels."

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.19...rattler_virtual_packages-v2.1.0) - 2025-07-21
+
+### Added
+
+- make `Platform` `non_exhaustive` ([#1539](https://github.com/conda/rattler/pull/1539))
+- add support for loong64 platform to rattler ([#1534](https://github.com/conda/rattler/pull/1534))
+
 ## [2.0.19](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.18...rattler_virtual_packages-v2.0.19) - 2025-07-14
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.19"
+version = "2.1.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `file_url`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `rattler_digest`: 1.1.4 -> 1.1.5 (✓ API compatible changes)
* `rattler_conda_types`: 0.35.6 -> 0.36.0 (⚠ API breaking changes)
* `rattler_config`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.45 -> 0.22.46 (✓ API compatible changes)
* `rattler_pty`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `rattler_shell`: 0.24.4 -> 0.24.5 (✓ API compatible changes)
* `rattler_menuinst`: 0.2.17 -> 0.2.18 (✓ API compatible changes)
* `rattler`: 0.34.7 -> 0.34.8 (✓ API compatible changes)
* `rattler_solve`: 2.1.6 -> 2.1.7 (✓ API compatible changes)
* `rattler_lock`: 0.23.11 -> 0.23.12 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.23.7 -> 0.23.8 (✓ API compatible changes)
* `rattler_virtual_packages`: 2.0.19 -> 2.1.0 (✓ API compatible changes)
* `rattler_index`: 0.24.4 -> 0.24.5 (✓ API compatible changes)
* `rattler_networking`: 0.25.6 -> 0.25.7
* `rattler_cache`: 0.3.26 -> 0.3.27
* `rattler_upload`: 0.1.0 -> 0.1.1

### ⚠ `rattler_conda_types` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum Platform in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:18
  enum Platform in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:18
  enum Arch in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:64
  enum Arch in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:64

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Arch::Ppc64le 6 -> 7 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:74
  variant Arch::Ppc64 7 -> 8 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:75
  variant Arch::Ppc 8 -> 9 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:76
  variant Arch::S390X 9 -> 10 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:77
  variant Arch::Riscv32 10 -> 11 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:78
  variant Arch::Riscv64 11 -> 12 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:79
  variant Arch::Wasm32 12 -> 13 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:80
  variant Arch::Z 13 -> 14 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:81
  variant Arch::Ppc64le 6 -> 7 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:74
  variant Arch::Ppc64 7 -> 8 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:75
  variant Arch::Ppc 8 -> 9 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:76
  variant Arch::S390X 9 -> 10 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:77
  variant Arch::Riscv32 10 -> 11 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:78
  variant Arch::Riscv64 11 -> 12 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:79
  variant Arch::Wasm32 12 -> 13 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:80
  variant Arch::Z 13 -> 14 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:81
  variant Platform::LinuxPpc64le 7 -> 8 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:28
  variant Platform::LinuxPpc64 8 -> 9 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:29
  variant Platform::LinuxPpc 9 -> 10 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:30
  variant Platform::LinuxS390X 10 -> 11 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:31
  variant Platform::LinuxRiscv32 11 -> 12 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:32
  variant Platform::LinuxRiscv64 12 -> 13 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:33
  variant Platform::Osx64 13 -> 14 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:35
  variant Platform::OsxArm64 14 -> 15 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:36
  variant Platform::Win32 15 -> 16 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:38
  variant Platform::Win64 16 -> 17 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:39
  variant Platform::WinArm64 17 -> 18 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:40
  variant Platform::EmscriptenWasm32 18 -> 19 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:42
  variant Platform::WasiWasm32 19 -> 20 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:43
  variant Platform::ZosZ 20 -> 21 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:45
  variant Platform::LinuxPpc64le 7 -> 8 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:28
  variant Platform::LinuxPpc64 8 -> 9 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:29
  variant Platform::LinuxPpc 9 -> 10 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:30
  variant Platform::LinuxS390X 10 -> 11 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:31
  variant Platform::LinuxRiscv32 11 -> 12 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:32
  variant Platform::LinuxRiscv64 12 -> 13 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:33
  variant Platform::Osx64 13 -> 14 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:35
  variant Platform::OsxArm64 14 -> 15 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:36
  variant Platform::Win32 15 -> 16 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:38
  variant Platform::Win64 16 -> 17 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:39
  variant Platform::WinArm64 17 -> 18 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:40
  variant Platform::EmscriptenWasm32 18 -> 19 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:42
  variant Platform::WasiWasm32 19 -> 20 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:43
  variant Platform::ZosZ 20 -> 21 in /tmp/.tmpyRZaM5/rattler/crates/rattler_conda_types/src/platform.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `file_url`

<blockquote>

## [0.2.6](https://github.com/conda/rattler/compare/file_url-v0.2.5...file_url-v0.2.6) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_digest`

<blockquote>

## [1.1.5](https://github.com/conda/rattler/compare/rattler_digest-v1.1.4...rattler_digest-v1.1.5) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.36.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.6...rattler_conda_types-v0.36.0) - 2025-07-21

### Added

- make `Platform` `non_exhaustive` ([#1539](https://github.com/conda/rattler/pull/1539))
- add support for loong64 platform to rattler ([#1534](https://github.com/conda/rattler/pull/1534))

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_config`

<blockquote>

## [0.2.4](https://github.com/conda/rattler/compare/rattler_config-v0.2.3...rattler_config-v0.2.4) - 2025-07-21

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.46](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.45...rattler_package_streaming-v0.22.46) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_pty`

<blockquote>

## [0.2.5](https://github.com/conda/rattler/compare/rattler_pty-v0.2.4...rattler_pty-v0.2.5) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_shell`

<blockquote>

## [0.24.5](https://github.com/conda/rattler/compare/rattler_shell-v0.24.4...rattler_shell-v0.24.5) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.18](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.17...rattler_menuinst-v0.2.18) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler`

<blockquote>

## [0.34.8](https://github.com/conda/rattler/compare/rattler-v0.34.7...rattler-v0.34.8) - 2025-07-21

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_solve`

<blockquote>

## [2.1.7](https://github.com/conda/rattler/compare/rattler_solve-v2.1.6...rattler_solve-v2.1.7) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_lock`

<blockquote>

## [0.23.12](https://github.com/conda/rattler/compare/rattler_lock-v0.23.11...rattler_lock-v0.23.12) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.23.8](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.7...rattler_repodata_gateway-v0.23.8) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.1.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.19...rattler_virtual_packages-v2.1.0) - 2025-07-21

### Added

- make `Platform` `non_exhaustive` ([#1539](https://github.com/conda/rattler/pull/1539))
- add support for loong64 platform to rattler ([#1534](https://github.com/conda/rattler/pull/1534))
</blockquote>

## `rattler_index`

<blockquote>

## [0.24.5](https://github.com/conda/rattler/compare/rattler_index-v0.24.4...rattler_index-v0.24.5) - 2025-07-21

### Other

- bump rust 1.88.0 ([#1536](https://github.com/conda/rattler/pull/1536))
</blockquote>

## `rattler_networking`

<blockquote>

## [0.25.7](https://github.com/conda/rattler/compare/rattler_networking-v0.25.6...rattler_networking-v0.25.7) - 2025-07-21

### Other

- updated the following local packages: rattler_config
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.27](https://github.com/conda/rattler/compare/rattler_cache-v0.3.26...rattler_cache-v0.3.27) - 2025-07-21

### Other

- updated the following local packages: rattler_digest, rattler_conda_types, rattler_package_streaming, rattler_networking
</blockquote>

## `rattler_upload`

<blockquote>

## [0.1.1](https://github.com/conda/rattler/compare/rattler_upload-v0.1.0...rattler_upload-v0.1.1) - 2025-07-21

### Other

- updated the following local packages: rattler_digest, rattler_conda_types, rattler_config, rattler_package_streaming, rattler_solve, rattler_networking
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).