### PR TITLE
feat: make `Platform` non_exhaustive

### DIFF
--- a/crates/rattler_conda_types/src/platform.rs
+++ b/crates/rattler_conda_types/src/platform.rs
@@ -1,14 +1,19 @@
 //! Platform-specific code.
+use std::{
+    cmp::Ordering,
+    fmt,
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
+
 use itertools::Itertools;
 use serde::{Deserializer, Serializer};
-use std::cmp::Ordering;
-use std::fmt::Display;
-use std::{fmt, fmt::Formatter, str::FromStr};
 use strum::{EnumIter, IntoEnumIterator};
 use thiserror::Error;
 
 /// A platform supported by Conda.
 #[allow(missing_docs)]
+#[non_exhaustive] // The `Platform` enum is non-exhaustive to allow for future extensions without breaking changes.
 #[derive(EnumIter, Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Platform {
     NoArch,
@@ -53,6 +58,7 @@ impl Ord for Platform {
 
 /// Known architectures supported by Conda.
 #[allow(missing_docs)]
+#[non_exhaustive] // The `Arch` enum is non-exhaustive to allow for future extensions without breaking changes.
 #[derive(EnumIter, Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Arch {
     X86,
@@ -324,7 +330,8 @@ impl From<Platform> for &'static str {
 impl Platform {
     /// Return the arch string for the platform
     /// The arch is usually the part after the `-` of the platform string.
-    /// Only for 32 and 64 bit platforms the arch is `x86` and `x86_64` respectively.
+    /// Only for 32 and 64 bit platforms the arch is `x86` and `x86_64`
+    /// respectively.
     pub fn arch(&self) -> Option<Arch> {
         match self {
             Platform::Unknown | Platform::NoArch => None,

--- a/crates/rattler_menuinst/src/windows/knownfolders.rs
+++ b/crates/rattler_menuinst/src/windows/knownfolders.rs
@@ -120,7 +120,7 @@ mod tests {
             match folders.get_folder_path(folder, handle) {
                 Ok(path) => {
                     println!("{folder:?} path for {handle:?}: {path:?}");
-                    assert!(path.exists())
+                    assert!(path.exists());
                 }
                 Err(e) => println!("Error getting {folder:?} path for {handle:?}: {e:?}"),
             }

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -605,6 +605,9 @@ impl Archspec {
 
             // The first every Apple Silicon Macs are based on m1.
             Platform::OsxArm64 => "m1",
+
+            // Otherwise, we assume that the architecture is unknown.
+            _ => return None
         };
 
         Some(Self::from_name(archspec_name))


### PR DESCRIPTION
Everytime a `Platform` is added it breaks the API. I forsee that in the future there might be more changes to the `Platform` enum so Im marking it `non_exhaustive` to make sure APIs dont rely on this fact.