### PR TITLE
chore: benchmark branch for `resolvo` with ConditionalRequirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5187,8 +5187,7 @@ dependencies = [
 [[package]]
 name = "resolvo"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba027c8e5dd4b5e5a690cfcfb3900d5ffe6985adb048cbd111d5aa596a6c0c8"
+source = "git+https://github.com/baszalmstra/resolvo?branch=condition-dependencies#6cc440f9f92a0a88dc323f7c1f653ba85deddbe1"
 dependencies = [
  "ahash",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ regex = "1.11.1"
 reqwest = { version = "0.12.15", default-features = false }
 reqwest-middleware = "0.4.2"
 reqwest-retry = "0.7.0"
-resolvo = { version = "0.9.1" }
+resolvo = { git = "https://github.com/baszalmstra/resolvo", branch = "condition-dependencies" }
 # hold back at 0.4.0 until `reqwest-retry` is updated
 retry-policies = { version = "0.4.0", default-features = false }
 rmp-serde = { version = "1.3.0" }

--- a/crates/rattler_solve/src/resolvo/conda_sorting.rs
+++ b/crates/rattler_solve/src/resolvo/conda_sorting.rs
@@ -192,7 +192,7 @@ impl<'a, 'repo> SolvableSorter<'a, 'repo> {
             };
 
             for requirement in &known.requirements {
-                let version_set_id = match requirement {
+                let version_set_id = match requirement.requirement {
                     // Ignore union requirements, these do not occur in the conda ecosystem
                     // currently
                     Requirement::Union(_) => {
@@ -206,7 +206,7 @@ impl<'a, 'repo> SolvableSorter<'a, 'repo> {
                 // single package multiple times.
                 let dependency_name = self
                     .pool()
-                    .resolve_version_set_package_name(*version_set_id);
+                    .resolve_version_set_package_name(version_set_id);
 
                 // Check how often we have seen this dependency name
                 let name_count = match name_count.entry(dependency_name) {
@@ -221,9 +221,9 @@ impl<'a, 'repo> SolvableSorter<'a, 'repo> {
                 };
 
                 match id_and_deps.entry((solvable_id, dependency_name)) {
-                    Entry::Occupied(mut entry) => entry.get_mut().push(*version_set_id),
+                    Entry::Occupied(mut entry) => entry.get_mut().push(version_set_id),
                     Entry::Vacant(entry) => {
-                        entry.insert(vec![*version_set_id]);
+                        entry.insert(vec![version_set_id]);
                         *name_count += 1;
                     }
                 }


### PR DESCRIPTION
To check whether there are any performance regressions in https://github.com/prefix-dev/resolvo/pull/136 I updated `resolvo` to the branch (without modifying any behavior).

Resolvo is still super fast. Unfortunately there is a ~30% performance vs the current main branch in the worst case.

```
Gnuplot not found, using plotters backend
solve python=3.9/resolvo
                        time:   [13.772 ms 13.888 ms 14.040 ms]
                        change: [+11.979% +13.052% +14.177%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high severe

solve xtensor, xsimd/resolvo
                        time:   [8.3201 ms 8.4256 ms 8.5798 ms]
                        change: [+12.545% +14.122% +16.200%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 20 measurements (10.00%)
  2 (10.00%) high severe

Benchmarking solve tensorflow/resolvo: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 16.1s, or reduce sample count to 10.
solve tensorflow/resolvo
                        time:   [804.14 ms 808.80 ms 814.08 ms]
                        change: [+23.741% +24.590% +25.553%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 20 measurements (10.00%)
  2 (10.00%) high mild

Benchmarking solve quetz/resolvo: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 24.1s, or reduce sample count to 10.
solve quetz/resolvo     time:   [1.1879 s 1.1940 s 1.1986 s]
                        change: [+22.593% +23.296% +23.927%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) low severe

Benchmarking solve tensorboard=2.1.1, grpc-cpp=1.39.1/resolvo: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 6.3s, or reduce sample count to 10.
solve tensorboard=2.1.1, grpc-cpp=1.39.1/resolvo
                        time:   [315.52 ms 316.70 ms 317.94 ms]
                        change: [+29.161% +29.924% +30.600%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild

     Running benches/sorting_bench.rs (/Users/wolfv/Programs/rattler/target/release/deps/sorting_bench-e2351cc158530de7)
Gnuplot not found, using plotters backend
sort pytorch            time:   [27.789 ms 27.965 ms 28.159 ms]
                        change: [+2.4142% +3.2227% +4.2207%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking sort python: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.6s, enable flat sampling, or reduce sample count to 50.
sort python             time:   [1.8901 ms 1.8953 ms 1.9014 ms]
                        change: [+1.3577% +1.8006% +2.2393%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

sort tensorflow         time:   [10.741 ms 10.809 ms 10.879 ms]
                        change: [−2.3648% −1.2555% −0.1223%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```