### PR TITLE
fix: use channel `subdir` instead of the one from the record

### DIFF
--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -3,6 +3,14 @@
 
 #![allow(clippy::mem_forget)]
 
+use std::{
+    borrow::Borrow,
+    collections::{HashSet, VecDeque},
+    fmt, io,
+    marker::PhantomData,
+    path::Path,
+};
+
 use bytes::Bytes;
 use fs_err as fs;
 use itertools::Itertools;
@@ -16,13 +24,6 @@ use serde::{
     Deserialize, Deserializer,
 };
 use serde_json::value::RawValue;
-use std::borrow::Borrow;
-use std::{
-    collections::{HashSet, VecDeque},
-    fmt, io,
-    marker::PhantomData,
-    path::Path,
-};
 use superslice::Ext;
 use thiserror::Error;
 
@@ -552,7 +553,7 @@ fn parse_record_raw<'i>(
             &channel
                 .base_url
                 .url()
-                .join(&format!("{}/", &package_record.subdir))
+                .join(&format!("{subdir}/"))
                 .expect("failed determine repo_base_url"),
             base_url,
             filename.filename,


### PR DESCRIPTION
This changes the way urls are constructed for package records that incorrectly report their `subdir`. When constructing the url we now take the subdir from where the repodata was downloading instead of the subdir that is recorded in the package record.

Fixes https://github.com/prefix-dev/pixi/issues/4164