### PR TITLE
fix: indexing `extra-depends`

### DIFF
--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -41,7 +41,8 @@ pub struct IndexJson {
     /// Extra dependency groups that can be selected using `foobar[extras=["scientific"]]`
     /// The implementation is specified in this CEP: <https://github.com/conda/ceps/pull/111>
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub extra_depends: BTreeMap<String, Vec<String>>,
+    #[serde(rename = "extra_depends")]
+    pub experimental_extra_depends: BTreeMap<String, Vec<String>>,
 
     /// Features are a deprecated way to specify different feature sets for the
     /// conda solver. This is not supported anymore and should not be used.

--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -1,4 +1,7 @@
-use std::{collections::{BTreeMap, BTreeSet}, path::Path};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
 
 use rattler_macros::sorted;
 use serde::{Deserialize, Serialize};
@@ -37,7 +40,7 @@ pub struct IndexJson {
 
     /// Extra dependency groups that can be selected using `foobar[extras=["scientific"]]`
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub extras: BTreeMap<String, Vec<String>>,
+    pub extra_depends: BTreeMap<String, Vec<String>>,
 
     /// Features are a deprecated way to specify different feature sets for the
     /// conda solver. This is not supported anymore and should not be used.

--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -39,6 +39,7 @@ pub struct IndexJson {
     pub depends: Vec<String>,
 
     /// Extra dependency groups that can be selected using `foobar[extras=["scientific"]]`
+    /// The implementation is specified in this CEP: <https://github.com/conda/ceps/pull/111>
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra_depends: BTreeMap<String, Vec<String>>,
 

--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, path::Path};
+use std::{collections::{BTreeMap, BTreeSet}, path::Path};
 
 use rattler_macros::sorted;
 use serde::{Deserialize, Serialize};
@@ -34,6 +34,10 @@ pub struct IndexJson {
     /// The dependencies of the package
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub depends: Vec<String>,
+
+    /// Extra dependency groups that can be selected using `foobar[extras=["scientific"]]`
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extras: BTreeMap<String, Vec<String>>,
 
     /// Features are a deprecated way to specify different feature sets for the
     /// conda solver. This is not supported anymore and should not be used.

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -516,7 +516,7 @@ impl PackageRecord {
             noarch: index.noarch,
             platform: index.platform,
             python_site_packages_path: index.python_site_packages_path,
-            extra_depends: index.extras,
+            extra_depends: index.extra_depends,
             sha256,
             size,
             subdir,

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -516,7 +516,7 @@ impl PackageRecord {
             noarch: index.noarch,
             platform: index.platform,
             python_site_packages_path: index.python_site_packages_path,
-            extra_depends: index.extra_depends,
+            extra_depends: index.experimental_extra_depends,
             sha256,
             size,
             subdir,

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -121,7 +121,8 @@ pub struct PackageRecord {
     /// are only required if certain features are enabled or if certain
     /// conditions are met.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub extra_depends: BTreeMap<String, Vec<String>>,
+    #[serde(rename = "extra_depends")]
+    pub experimental_extra_depends: BTreeMap<String, Vec<String>>,
 
     /// Features are a deprecated way to specify different feature sets for the
     /// conda solver. This is not supported anymore and should not be used.
@@ -335,7 +336,7 @@ impl PackageRecord {
             noarch: NoArchType::default(),
             platform: None,
             python_site_packages_path: None,
-            extra_depends: BTreeMap::new(),
+            experimental_extra_depends: BTreeMap::new(),
             sha256: None,
             size: None,
             subdir: Platform::current().to_string(),
@@ -516,7 +517,7 @@ impl PackageRecord {
             noarch: index.noarch,
             platform: index.platform,
             python_site_packages_path: index.python_site_packages_path,
-            extra_depends: index.experimental_extra_depends,
+            experimental_extra_depends: index.experimental_extra_depends,
             sha256,
             size,
             subdir,

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -516,7 +516,7 @@ impl PackageRecord {
             noarch: index.noarch,
             platform: index.platform,
             python_site_packages_path: index.python_site_packages_path,
-            extra_depends: BTreeMap::new(),
+            extra_depends: index.extras,
             sha256,
             size,
             subdir,

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -67,7 +67,7 @@ pub fn package_record_from_index_json<T: Read>(
         arch: index.arch,
         platform: index.platform,
         depends: index.depends,
-        extra_depends: index.extra_depends,
+        extra_depends: index.experimental_extra_depends,
         constrains: index.constrains,
         track_features: index.track_features,
         features: index.features,

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -67,7 +67,7 @@ pub fn package_record_from_index_json<T: Read>(
         arch: index.arch,
         platform: index.platform,
         depends: index.depends,
-        extra_depends: index.extras,
+        extra_depends: index.extra_depends,
         constrains: index.constrains,
         track_features: index.track_features,
         features: index.features,

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -67,7 +67,7 @@ pub fn package_record_from_index_json<T: Read>(
         arch: index.arch,
         platform: index.platform,
         depends: index.depends,
-        extra_depends: index.experimental_extra_depends,
+        experimental_extra_depends: index.experimental_extra_depends,
         constrains: index.constrains,
         track_features: index.track_features,
         features: index.features,

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -67,7 +67,7 @@ pub fn package_record_from_index_json<T: Read>(
         arch: index.arch,
         platform: index.platform,
         depends: index.depends,
-        extra_depends: std::collections::BTreeMap::new(),
+        extra_depends: index.extras,
         constrains: index.constrains,
         track_features: index.track_features,
         features: index.features,

--- a/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
@@ -117,7 +117,7 @@ impl<'a> From<CondaPackageDataModel<'a>> for CondaPackageData {
                 build_number: value.build_number,
                 constrains: value.constrains.into_owned(),
                 depends: value.depends.into_owned(),
-                extra_depends: std::collections::BTreeMap::new(),
+                experimental_extra_depends: std::collections::BTreeMap::new(),
                 features: value.features.into_owned(),
                 legacy_bz2_md5: value.legacy_bz2_md5,
                 legacy_bz2_size: value.legacy_bz2_size.into_owned(),

--- a/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
@@ -79,7 +79,8 @@ pub(crate) struct CondaPackageDataModel<'a> {
     #[serde(default, skip_serializing_if = "<[String]>::is_empty")]
     pub constrains: Cow<'a, [String]>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub extra_depends: Cow<'a, BTreeMap<String, Vec<String>>>,
+    #[serde(rename = "extra_depends")]
+    pub experimental_extra_depends: Cow<'a, BTreeMap<String, Vec<String>>>,
 
     // Additional properties (in semi alphabetic order but grouped by commonality)
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -163,7 +164,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaPackageData {
             build_number,
             constrains: value.constrains.into_owned(),
             depends: value.depends.into_owned(),
-            extra_depends: value.extra_depends.into_owned(),
+            experimental_extra_depends: value.experimental_extra_depends.into_owned(),
             features: value.features.into_owned(),
             legacy_bz2_md5: value.legacy_bz2_md5,
             legacy_bz2_size: value.legacy_bz2_size.into_owned(),
@@ -279,7 +280,7 @@ impl<'a> From<&'a CondaPackageData> for CondaPackageDataModel<'a> {
             purls: Cow::Borrowed(&package_record.purls),
             depends: Cow::Borrowed(&package_record.depends),
             constrains: Cow::Borrowed(&package_record.constrains),
-            extra_depends: Cow::Borrowed(&package_record.extra_depends),
+            experimental_extra_depends: Cow::Borrowed(&package_record.experimental_extra_depends),
             md5: package_record.md5,
             legacy_bz2_md5: package_record.legacy_bz2_md5,
             sha256: package_record.sha256,

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -202,7 +202,7 @@ pub fn parse_v3_or_lower(
                             build_number,
                             constrains: value.constrains,
                             depends: value.dependencies,
-                            extra_depends: std::collections::BTreeMap::new(),
+                            experimental_extra_depends: std::collections::BTreeMap::new(),
                             features: value.features,
                             legacy_bz2_md5: None,
                             legacy_bz2_size: None,

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -272,7 +272,7 @@ impl RepoDataQuery {
                                 }
                             }
 
-                            for (_, dependencies) in record.package_record.extra_depends.iter() {
+                            for (_, dependencies) in record.package_record.experimental_extra_depends.iter() {
                                 for dependency in dependencies {
                                     let dependency_name = package_name_from_match_spec_str(dependency);
                                     if seen.insert(dependency_name.clone()) {

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -384,7 +384,7 @@ impl<'a> CondaDependencyProvider<'a> {
                 let mut all_entries = vec![(package_name, solvable_id)];
 
                 // Add feature-enabled solvables
-                for feature in record.package_record.extra_depends.keys() {
+                for feature in record.package_record.experimental_extra_depends.keys() {
                     let package_name_with_feature =
                         pool.intern_package_name(NameType::BaseWithFeature(
                             record.package_record.name.as_normalized().to_owned(),
@@ -643,7 +643,11 @@ impl DependencyProvider for CondaDependencyProvider<'_> {
         // If this is a feature-enabled package, add its feature dependencies
         if let Some(feature_name) = feature {
             // Find the feature's dependencies
-            if let Some(deps) = record.package_record.extra_depends.get(feature_name) {
+            if let Some(deps) = record
+                .package_record
+                .experimental_extra_depends
+                .get(feature_name)
+            {
                 // Add each dependency for this feature
                 for req in deps {
                     let version_set_id = match parse_match_spec(

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -105,7 +105,7 @@ fn installed_package(
             sha256: Some(dummy_sha256_hash()),
             size: None,
             arch: None,
-            extra_depends: BTreeMap::new(),
+            experimental_extra_depends: BTreeMap::new(),
             platform: None,
             depends: Vec::new(),
             constrains: Vec::new(),

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -85,7 +85,7 @@ pub async fn simple_solve(
                 platform: None,
                 depends: pkg.depends.unwrap_or_default(),
                 subdir: pkg.subdir.unwrap_or_else(|| "unknown".to_string()),
-                extra_depends: BTreeMap::new(),
+                experimental_extra_depends: BTreeMap::new(),
                 constrains: vec![],
                 track_features: vec![],
                 features: None,

--- a/py-rattler/src/record.rs
+++ b/py-rattler/src/record.rs
@@ -166,7 +166,7 @@ impl PyRecord {
                 subdir,
                 constrains: Vec::new(),
                 depends: Vec::new(),
-                extra_depends: BTreeMap::new(),
+                experimental_extra_depends: BTreeMap::new(),
                 features: None,
                 legacy_bz2_md5: None,
                 legacy_bz2_size: None,


### PR DESCRIPTION
We currently do not properly index extras because we fill the field with a `default` hash map. This PR fixes it.