### PR TITLE
refactor(rattler_pty): fix `needless_continue` lint

### DIFF
--- a/crates/rattler_pty/src/unix/pty_session.rs
+++ b/crates/rattler_pty/src/unix/pty_session.rs
@@ -151,10 +151,8 @@ impl PtySession {
 
             let res = select::select(None, &mut select_set, None, None, &mut select_timeout);
             if let Err(error) = res {
-                if error == Errno::EINTR {
-                    // EINTR is not an error, it just means that we got interrupted by a signal (e.g. SIGWINCH)
-                    continue;
-                } else {
+                // EINTR is not an error, it just means that we got interrupted by a signal (e.g. SIGWINCH)
+                if error != Errno::EINTR {
                     self.process.set_mode(original_mode)?;
                     return Err(std::io::Error::from(error));
                 }


### PR DESCRIPTION
on `pixi run lint` for me locally, this avoids:

```console
error: this `continue` expression is redundant
   --> crates/rattler_pty/src/unix/pty_session.rs:156:21
    |
156 |                     continue;
    |                     ^^^^^^^^
    |
    = help: consider dropping the `continue` expression
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue
    = note: `-D clippy::needless-continue` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_continue)]`

error: could not compile `rattler_pty` (lib) due to 1 previous error
```