### PR TITLE
chore(deps): add `rust-src` for rust-analyzer

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -68,6 +68,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://prefix.dev/conda-forge/linux-64/rhash-1.4.3-hd590300_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/rust-1.88.0-h1a8d7c4_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rust-src-1.88.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.88.0-h2c6d0dc_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.0.0-hceb3a55_0.conda
@@ -125,6 +126,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
       - conda: https://prefix.dev/conda-forge/osx-64/rhash-1.4.3-h0dc2134_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/rust-1.88.0-h34a2095_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rust-src-1.88.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.88.0-h38e4360_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
@@ -186,6 +188,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/pkg-config-0.29.2-hde07d2e_1009.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/rhash-1.4.3-hb547adb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/rust-1.88.0-h4ff7c5d_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rust-src-1.88.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.88.0-hf6ec828_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
@@ -214,6 +217,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/pcre2-10.44-h3d7b363_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
       - conda: https://prefix.dev/conda-forge/win-64/rust-1.88.0-hf8d6059_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/rust-src-1.88.0-win_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.88.0-h17fc481_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h5fd82a7_24.conda
@@ -3034,6 +3038,28 @@ packages:
   license_family: MIT
   size: 250835268
   timestamp: 1751059235898
+- conda: https://prefix.dev/conda-forge/noarch/rust-src-1.88.0-unix_0.conda
+  sha256: 8e936e60bd731af3c3890adaa7d043c1aca653848869355da9e7e1c7ba46ba6c
+  md5: 2dc51db283c7d4566273f923d4b733eb
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.88.0,<1.88.1.0a0
+  license: MIT
+  license_family: MIT
+  size: 3665466
+  timestamp: 1751056966320
+- conda: https://prefix.dev/conda-forge/noarch/rust-src-1.88.0-win_0.conda
+  sha256: f811883a78a142c3b41768b2905d6e25cb7418d544ea1d020458421c350638b9
+  md5: 359c94c4e83c16f2451755634aa53eb1
+  depends:
+  - __win
+  constrains:
+  - rust >=1.88.0,<1.88.1.0a0
+  license: MIT
+  license_family: MIT
+  size: 3681851
+  timestamp: 1751058105734
 - conda: https://prefix.dev/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.88.0-hf6ec828_0.conda
   sha256: b14253e50bcafef9a61a289371b018d2664da23ae925b8fe2d52432fef187212
   md5: 90ec3b7a075f493fd5a4782eb00b45c1

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,6 +30,7 @@ pkg-config = "~=0.29.2"
 rust = "~=1.88.0"
 cmake = "~=3.26.4"
 cargo-nextest = ">=0.9.91,<0.10"
+rust-src = "~=1.88.0"
 
 [target.linux-64.dependencies]
 clang = ">=18.1.8,<19.0"

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,6 +30,7 @@ pkg-config = "~=0.29.2"
 rust = "~=1.88.0"
 cmake = "~=3.26.4"
 cargo-nextest = ">=0.9.91,<0.10"
+# for rust-analyzer
 rust-src = "~=1.88.0"
 
 [target.linux-64.dependencies]


### PR DESCRIPTION
to avoid locally:

```
2025-07-23T11:14:02.294041+01:00 ERROR can't load standard library, try installing `rust-src` sysroot_path=/Users/lucascolley/ghq/github.com/lucascolley/rattler/.pixi/envs/default
```

same as https://github.com/prefix-dev/rattler-build/pull/1374, https://github.com/prefix-dev/pixi/blob/463ae37fc728b6b518cf73d5d5803f84964bc474/pixi.toml#L161