### PR TITLE
feat: implement flagmatcher, tests and indexing

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/flags.rs
+++ b/crates/rattler_conda_types/src/match_spec/flags.rs
@@ -1,0 +1,212 @@
+use std::{
+    collections::BTreeSet,
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum FlagMatcher {
+    /// Match if flag exists
+    Required(String),
+    /// Match if flag doesn't exist
+    Negated(String),
+    /// Match if flag exists, but don't fail if it doesn't
+    Optional(String),
+}
+
+impl FlagMatcher {
+    pub fn matches(&self, flags: &BTreeSet<String>) -> bool {
+        match self {
+            FlagMatcher::Required(flag) => flags.contains(flag),
+            FlagMatcher::Negated(flag) => !flags.contains(flag),
+            FlagMatcher::Optional(flag) => !flags.contains(flag) || flags.contains(flag),
+        }
+    }
+}
+
+impl Display for FlagMatcher {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FlagMatcher::Required(flag) => write!(f, "{flag}"),
+            FlagMatcher::Negated(flag) => write!(f, "~{flag}"),
+            FlagMatcher::Optional(flag) => write!(f, "?{flag}"),
+        }
+    }
+}
+
+impl FromStr for FlagMatcher {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with('~') {
+            Ok(FlagMatcher::Negated(s[1..].to_string()))
+        } else if s.starts_with('?') {
+            Ok(FlagMatcher::Optional(s[1..].to_string()))
+        } else {
+            Ok(FlagMatcher::Required(s.to_string()))
+        }
+    }
+}
+
+impl Serialize for FlagMatcher {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            FlagMatcher::Required(flag) => serializer.serialize_str(flag),
+            FlagMatcher::Negated(flag) => serializer.serialize_str(&format!("~{}", flag)),
+            FlagMatcher::Optional(flag) => serializer.serialize_str(&format!("?{}", flag)),
+        }
+    }
+}
+
+// Add deserialization implementation
+impl<'de> Deserialize<'de> for FlagMatcher {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if s.starts_with('~') || s.starts_with('!') {
+            Ok(FlagMatcher::Negated(s[1..].to_string()))
+        } else if s.starts_with('?') {
+            Ok(FlagMatcher::Optional(s[1..].to_string()))
+        } else {
+            Ok(FlagMatcher::Required(s))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::match_spec::Matches;
+    use crate::ParseStrictness::Strict;
+    use crate::{match_spec::flags::FlagMatcher, MatchSpec, PackageName, PackageRecord, Version};
+    #[test]
+    fn test_flagmatcher() {
+        use std::collections::BTreeSet;
+
+        // Create a set of flags to test against
+        let mut flags = BTreeSet::new();
+        flags.insert("mkl".to_string());
+        flags.insert("cuda".to_string());
+
+        // Test Required flag matcher
+        let matcher = FlagMatcher::Required("mkl".to_string());
+        assert!(matcher.matches(&flags));
+
+        let matcher = FlagMatcher::Required("nomkl".to_string());
+        assert!(!matcher.matches(&flags));
+
+        // Test Negated flag matcher
+        let matcher = FlagMatcher::Negated("nomkl".to_string());
+        assert!(matcher.matches(&flags));
+
+        let matcher = FlagMatcher::Negated("mkl".to_string());
+        assert!(!matcher.matches(&flags));
+
+        // Test Optional flag matcher
+        let matcher = FlagMatcher::Optional("mkl".to_string());
+        assert!(matcher.matches(&flags));
+
+        let matcher = FlagMatcher::Optional("nomkl".to_string());
+        assert!(matcher.matches(&flags));
+    }
+
+    #[test]
+    fn test_flagmatcher_parsing() {
+        // Test parsing standard flag
+        let matcher = FlagMatcher::from_str("mkl").unwrap();
+        assert!(matches!(matcher, FlagMatcher::Required(_)));
+
+        // Test parsing negated flag
+        let matcher = FlagMatcher::from_str("~mkl").unwrap();
+        assert!(matches!(matcher, FlagMatcher::Negated(_)));
+
+        // Test parsing optional flag
+        let matcher = FlagMatcher::from_str("?mkl").unwrap();
+        assert!(matches!(matcher, FlagMatcher::Optional(_)));
+    }
+
+    #[test]
+    fn test_flagmatcher_display() {
+        // Test display formatting for Required flag
+        let matcher = FlagMatcher::Required("mkl".to_string());
+        assert_eq!(matcher.to_string(), "mkl");
+
+        // Test display formatting for Negated flag
+        let matcher = FlagMatcher::Negated("mkl".to_string());
+        assert_eq!(matcher.to_string(), "~mkl");
+
+        // Test display formatting for Optional flag
+        let matcher = FlagMatcher::Optional("mkl".to_string());
+        assert_eq!(matcher.to_string(), "?mkl");
+    }
+
+    #[test]
+    fn test_flagmatcher_serde() {
+        use serde_json;
+
+        // Test serialization
+        let matcher = FlagMatcher::Required("mkl".to_string());
+        assert_eq!(serde_json::to_string(&matcher).unwrap(), "\"mkl\"");
+
+        let matcher = FlagMatcher::Negated("mkl".to_string());
+        assert_eq!(serde_json::to_string(&matcher).unwrap(), "\"~mkl\"");
+
+        let matcher = FlagMatcher::Optional("mkl".to_string());
+        assert_eq!(serde_json::to_string(&matcher).unwrap(), "\"?mkl\"");
+
+        // Test deserialization
+        let matcher: FlagMatcher = serde_json::from_str("\"mkl\"").unwrap();
+        assert!(matches!(matcher, FlagMatcher::Required(_)));
+
+        let matcher: FlagMatcher = serde_json::from_str("\"~mkl\"").unwrap();
+        assert!(matches!(matcher, FlagMatcher::Negated(_)));
+
+        let matcher: FlagMatcher = serde_json::from_str("\"?mkl\"").unwrap();
+        assert!(matches!(matcher, FlagMatcher::Optional(_)));
+    }
+
+    #[test]
+    fn test_matchspec_with_flags() {
+        use std::collections::BTreeSet;
+
+        // Create a package record with flags
+        let mut flags = BTreeSet::new();
+        flags.insert("mkl".to_string());
+        flags.insert("cuda".to_string());
+
+        let mut package = PackageRecord::new(
+            PackageName::new_unchecked("numpy"),
+            Version::from_str("1.0").unwrap(),
+            String::from("py37_0"),
+        );
+        package.flags = flags;
+
+        // Test match with required flag
+        let spec = MatchSpec::from_str("numpy[flags=['mkl']]", Strict).unwrap();
+        assert!(spec.matches(&package));
+
+        // Test match with negated flag
+        let spec = MatchSpec::from_str("numpy[flags=['~nomkl']]", Strict).unwrap();
+        assert!(spec.matches(&package));
+
+        // Test match with optional flag
+        let spec = MatchSpec::from_str("numpy[flags=['?mkl']]", Strict).unwrap();
+        assert!(spec.matches(&package));
+
+        // Test match with multiple flags
+        let spec = MatchSpec::from_str("numpy[flags=['mkl', 'cuda']]", Strict).unwrap();
+        assert!(spec.matches(&package));
+
+        // Test non-match with missing required flag
+        let spec = MatchSpec::from_str("numpy[flags=['nomkl']]", Strict).unwrap();
+        assert!(!spec.matches(&package));
+    }
+}

--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -50,6 +50,10 @@ pub struct IndexJson {
     /// mutually exclusive features.
     pub features: Option<String>,
 
+    /// The flags (variant selection hints) that were used to build this package.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub flags: BTreeSet<String>,
+
     /// Optionally, the license
     pub license: Option<String>,
 

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -130,6 +130,11 @@ pub struct PackageRecord {
     /// mutually exclusive features.
     pub features: Option<String>,
 
+    /// Flags are a way to define build-time features. This has been traditionally
+    /// done by changing the build string, but flags are much nicer.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub flags: BTreeSet<String>,
+
     /// A deprecated md5 hash
     #[serde_as(as = "Option<SerializableHash::<rattler_digest::Md5>>")]
     pub legacy_bz2_md5: Option<Md5Hash>,
@@ -337,6 +342,7 @@ impl PackageRecord {
             platform: None,
             python_site_packages_path: None,
             experimental_extra_depends: BTreeMap::new(),
+            flags: BTreeSet::new(),
             sha256: None,
             size: None,
             subdir: Platform::current().to_string(),
@@ -518,6 +524,7 @@ impl PackageRecord {
             platform: index.platform,
             python_site_packages_path: index.python_site_packages_path,
             experimental_extra_depends: index.experimental_extra_depends,
+            flags: index.flags,
             sha256,
             size,
             subdir,

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -68,6 +68,7 @@ pub fn package_record_from_index_json<T: Read>(
         platform: index.platform,
         depends: index.depends,
         experimental_extra_depends: index.experimental_extra_depends,
+        flags: index.flags,
         constrains: index.constrains,
         track_features: index.track_features,
         features: index.features,

--- a/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
@@ -118,6 +118,7 @@ impl<'a> From<CondaPackageDataModel<'a>> for CondaPackageData {
                 constrains: value.constrains.into_owned(),
                 depends: value.depends.into_owned(),
                 experimental_extra_depends: std::collections::BTreeMap::new(),
+                flags: std::collections::BTreeSet::new(),
                 features: value.features.into_owned(),
                 legacy_bz2_md5: value.legacy_bz2_md5,
                 legacy_bz2_size: value.legacy_bz2_size.into_owned(),

--- a/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
@@ -81,6 +81,8 @@ pub(crate) struct CondaPackageDataModel<'a> {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     #[serde(rename = "extra_depends")]
     pub experimental_extra_depends: Cow<'a, BTreeMap<String, Vec<String>>>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub flags: Cow<'a, BTreeSet<String>>,
 
     // Additional properties (in semi alphabetic order but grouped by commonality)
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -165,6 +167,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaPackageData {
             constrains: value.constrains.into_owned(),
             depends: value.depends.into_owned(),
             experimental_extra_depends: value.experimental_extra_depends.into_owned(),
+            flags: value.flags.into_owned(),
             features: value.features.into_owned(),
             legacy_bz2_md5: value.legacy_bz2_md5,
             legacy_bz2_size: value.legacy_bz2_size.into_owned(),
@@ -281,6 +284,7 @@ impl<'a> From<&'a CondaPackageData> for CondaPackageDataModel<'a> {
             depends: Cow::Borrowed(&package_record.depends),
             constrains: Cow::Borrowed(&package_record.constrains),
             experimental_extra_depends: Cow::Borrowed(&package_record.experimental_extra_depends),
+            flags: Cow::Borrowed(&package_record.flags),
             md5: package_record.md5,
             legacy_bz2_md5: package_record.legacy_bz2_md5,
             sha256: package_record.sha256,

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -203,6 +203,7 @@ pub fn parse_v3_or_lower(
                             constrains: value.constrains,
                             depends: value.dependencies,
                             experimental_extra_depends: std::collections::BTreeMap::new(),
+                            flags: std::collections::BTreeSet::new(),
                             features: value.features,
                             legacy_bz2_md5: None,
                             legacy_bz2_size: None,


### PR DESCRIPTION
This implements the FlagMatcher that makes it easier to select variants.

Packages can advertise `flags` that can be selected using the matchspec. For example, a build of `libarchive` could have flags such as:

```
libarchive[static, zstd, bzip2, zlib]
libarchive[zstd, bzip2, zlib]
```

We can then use a matchspec like `libarchive[flags=[static]]` to select any static build of `libarchive`, or we could ask for a non-static build by asking for `libarchive[~static, zstd]` etc.

I guess we should think about how flags should be influencing the ordering (e.g. should packages with fewer flags be preferred, usually?).