### PR TITLE
fix: tar.bz2 archives not read to end resulting in wrong hash

### DIFF
--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -13,7 +13,7 @@ readme.workspace = true
 [dependencies]
 bzip2 = { workspace = true }
 chrono = { workspace = true }
-fs-err = { workspace = true }
+fs-err = { workspace = true, features = ["tokio"] }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
 rattler_conda_types = { workspace = true, default-features = false }

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -39,6 +39,9 @@ pub fn extract_tar_bz2(
     // Unpack the archive
     stream_tar_bz2(&mut md5_reader).unpack(destination)?;
 
+    // Read the file to the end to make sure the hash is properly computed.
+    std::io::copy(&mut md5_reader, &mut std::io::sink())?;
+
     // Get the hashes
     let (sha256_reader, md5) = md5_reader.finalize();
     let (_, sha256) = sha256_reader.finalize();

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -104,6 +104,11 @@ fn tar_bz2_archives(#[case] input: Url, #[case] sha256: &str, #[case] md5: &str)
     "20d1f1b5dc620b745c325844545fd5c0cdbfdb2385a0e27ef1507399844c8c6d",
     "13ee3577afc291dabd2d9edc59736688"
 )]
+#[case::openmp(
+    "https://conda.anaconda.org/conda-forge/linux-64/openmp-8.0.1-0.tar.bz2",
+    "a3332e80c633be1ee20a41c7dd8810260a2132cf7d03f363d83752cad907bcfd",
+    "b35241079152e5cc891c99368395b2c6"
+)]
 fn url_archives(#[case] input: Url, #[case] sha256: &str, #[case] md5: &str) {}
 
 #[apply(conda_archives)]


### PR DESCRIPTION
We need to fix reading small tar.bz2 archives to the end. The `openmp` archive is only ~8kB and it looks like we are not reading the last ~4 or so bytes, resulting in a wrong hash being computed. 

Since we recently started to always strictly validate package hashes, this is failing in `pixi` and other downstream users.

When I added some debug logging, it says:

`bytes_read: 8192`

while the entire archive is `8198` bytes long (so missing 6 bytes at the end).