### PR TITLE
fix: improve hash mismatch warning to include package path

### DIFF
--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -448,7 +448,8 @@ where
             tracing::debug!("cache directory does not exist, fetching package");
         } else if hash_mismatch {
             tracing::warn!(
-                "hash mismatch, wanted a package with hash {} but the cached package has hash {}, fetching package",
+                "hash mismatch, wanted a package at location {} with hash {} but the cached package has hash {}, fetching package",
+                path.display(),
                 given_sha.map_or(String::from("<unknown>"), |s| format!("{s:x}")),
                 locked_sha256.map_or(String::from("<unknown>"), |s| format!("{s:x}"))
             );


### PR DESCRIPTION
The error message gave no hint which package had a hash mismatch

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
