### PR TITLE
feat: update `UploadOpts` and `get_auth_store`

### DIFF
--- a/crates/rattler_upload/src/lib.rs
+++ b/crates/rattler_upload/src/lib.rs
@@ -26,7 +26,8 @@ pub async fn upload_from_args(args: UploadOpts) -> miette::Result<()> {
     }
 
     // Initialize authentication store
-    let store = tool_configuration::get_auth_store(args.common.auth_file, args.auth_store).into_diagnostic()?;
+    let store = tool_configuration::get_auth_store(args.common.auth_file, args.auth_store)
+        .into_diagnostic()?;
 
     // Upload handler based on server type
     match args.server_type {

--- a/crates/rattler_upload/src/lib.rs
+++ b/crates/rattler_upload/src/lib.rs
@@ -26,7 +26,7 @@ pub async fn upload_from_args(args: UploadOpts) -> miette::Result<()> {
     }
 
     // Initialize authentication store
-    let store = tool_configuration::get_auth_store(args.common.auth_file).into_diagnostic()?;
+    let store = tool_configuration::get_auth_store(args.common.auth_file, args.auth_store).into_diagnostic()?;
 
     // Upload handler based on server type
     match args.server_type {

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -3,13 +3,13 @@ use clap::{arg, Parser};
 use rattler_conda_types::utils::url_with_trailing_slash::UrlWithTrailingSlash;
 use rattler_conda_types::{NamedChannelOrUrl, Platform};
 use rattler_networking::mirror_middleware;
+use rattler_networking::{
+    authentication_storage::AuthenticationStorageError, AuthenticationStorage,
+};
 use rattler_solve::ChannelPriority;
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 use tracing::warn;
 use url::Url;
-use rattler_networking::{
-    authentication_storage::AuthenticationStorageError, AuthenticationStorage,
-};
 
 #[cfg(feature = "s3")]
 use rattler_networking::s3_middleware;
@@ -175,7 +175,10 @@ pub struct UploadOpts {
 }
 
 impl UploadOpts {
-    pub fn with_auth_store(mut self, auth_store: Result<AuthenticationStorage, AuthenticationStorageError>) -> Self {
+    pub fn with_auth_store(
+        mut self,
+        auth_store: Result<AuthenticationStorage, AuthenticationStorageError>,
+    ) -> Self {
         self.auth_store = Some(auth_store);
         self
     }

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -3,9 +3,7 @@ use clap::{arg, Parser};
 use rattler_conda_types::utils::url_with_trailing_slash::UrlWithTrailingSlash;
 use rattler_conda_types::{NamedChannelOrUrl, Platform};
 use rattler_networking::mirror_middleware;
-use rattler_networking::{
-  AuthenticationStorage,
-};
+use rattler_networking::AuthenticationStorage;
 use rattler_solve::ChannelPriority;
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 use tracing::warn;
@@ -175,10 +173,7 @@ pub struct UploadOpts {
 }
 
 impl UploadOpts {
-    pub fn with_auth_store(
-        mut self,
-        auth_store: Option<AuthenticationStorage>,
-    ) -> Self {
+    pub fn with_auth_store(mut self, auth_store: Option<AuthenticationStorage>) -> Self {
         self.auth_store = auth_store;
         self
     }

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -7,6 +7,9 @@ use rattler_solve::ChannelPriority;
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 use tracing::warn;
 use url::Url;
+use rattler_networking::{
+    authentication_storage::AuthenticationStorageError, AuthenticationStorage,
+};
 
 #[cfg(feature = "s3")]
 use rattler_networking::s3_middleware;
@@ -166,6 +169,16 @@ pub struct UploadOpts {
     /// Common options.
     #[clap(flatten)]
     pub common: CommonOpts,
+
+    #[clap(skip)]
+    pub auth_store: Option<Result<AuthenticationStorage, AuthenticationStorageError>>,
+}
+
+impl UploadOpts {
+    pub fn with_auth_store(mut self, auth_store: Result<AuthenticationStorage, AuthenticationStorageError>) -> Self {
+        self.auth_store = Some(auth_store);
+        self
+    }
 }
 
 /// Server type.

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -4,7 +4,7 @@ use rattler_conda_types::utils::url_with_trailing_slash::UrlWithTrailingSlash;
 use rattler_conda_types::{NamedChannelOrUrl, Platform};
 use rattler_networking::mirror_middleware;
 use rattler_networking::{
-    authentication_storage::AuthenticationStorageError, AuthenticationStorage,
+  AuthenticationStorage,
 };
 use rattler_solve::ChannelPriority;
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
@@ -171,15 +171,15 @@ pub struct UploadOpts {
     pub common: CommonOpts,
 
     #[clap(skip)]
-    pub auth_store: Option<Result<AuthenticationStorage, AuthenticationStorageError>>,
+    pub auth_store: Option<AuthenticationStorage>,
 }
 
 impl UploadOpts {
     pub fn with_auth_store(
         mut self,
-        auth_store: Result<AuthenticationStorage, AuthenticationStorageError>,
+        auth_store: Option<AuthenticationStorage>,
     ) -> Self {
-        self.auth_store = Some(auth_store);
+        self.auth_store = auth_store;
         self
     }
 }

--- a/crates/rattler_upload/src/utils/tool_configuration.rs
+++ b/crates/rattler_upload/src/utils/tool_configuration.rs
@@ -7,16 +7,26 @@ use std::{path::PathBuf, sync::Arc};
 /// Get the authentication storage from the given file
 pub fn get_auth_store(
     auth_file: Option<PathBuf>,
+    auth_store: Option<Result<AuthenticationStorage, AuthenticationStorageError>>
 ) -> Result<AuthenticationStorage, AuthenticationStorageError> {
-    match auth_file {
-        Some(auth_file) => {
-            let mut store = AuthenticationStorage::empty();
-            store.add_backend(Arc::from(
-                authentication_storage::backends::file::FileStorage::from_path(auth_file)?,
-            ));
-            Ok(store)
+    match auth_store {
+        Some(auth_store) => {
+            auth_store
         }
-        None => rattler_networking::AuthenticationStorage::from_env_and_defaults(),
+        None => {
+            match auth_file {
+            Some(auth_file) => {
+                let mut store = AuthenticationStorage::empty();
+                store.add_backend(Arc::from(
+                    authentication_storage::backends::file::FileStorage::from_path(auth_file)?,
+                ));
+                Ok(store)
+            }
+            None => {
+                rattler_networking::AuthenticationStorage::from_env_and_defaults()
+            },
+        }
+        }
     }
 }
 

--- a/crates/rattler_upload/src/utils/tool_configuration.rs
+++ b/crates/rattler_upload/src/utils/tool_configuration.rs
@@ -7,14 +7,11 @@ use std::{path::PathBuf, sync::Arc};
 /// Get the authentication storage from the given file
 pub fn get_auth_store(
     auth_file: Option<PathBuf>,
-    auth_store: Option<Result<AuthenticationStorage, AuthenticationStorageError>>
+    auth_store: Option<Result<AuthenticationStorage, AuthenticationStorageError>>,
 ) -> Result<AuthenticationStorage, AuthenticationStorageError> {
     match auth_store {
-        Some(auth_store) => {
-            auth_store
-        }
-        None => {
-            match auth_file {
+        Some(auth_store) => auth_store,
+        None => match auth_file {
             Some(auth_file) => {
                 let mut store = AuthenticationStorage::empty();
                 store.add_backend(Arc::from(
@@ -22,11 +19,8 @@ pub fn get_auth_store(
                 ));
                 Ok(store)
             }
-            None => {
-                rattler_networking::AuthenticationStorage::from_env_and_defaults()
-            },
-        }
-        }
+            None => rattler_networking::AuthenticationStorage::from_env_and_defaults(),
+        },
     }
 }
 

--- a/crates/rattler_upload/src/utils/tool_configuration.rs
+++ b/crates/rattler_upload/src/utils/tool_configuration.rs
@@ -7,10 +7,10 @@ use std::{path::PathBuf, sync::Arc};
 /// Get the authentication storage from the given file
 pub fn get_auth_store(
     auth_file: Option<PathBuf>,
-    auth_store: Option<Result<AuthenticationStorage, AuthenticationStorageError>>,
+    auth_store: Option<AuthenticationStorage>,
 ) -> Result<AuthenticationStorage, AuthenticationStorageError> {
     match auth_store {
-        Some(auth_store) => auth_store,
+        Some(auth_store) => Ok(auth_store),
         None => match auth_file {
             Some(auth_file) => {
                 let mut store = AuthenticationStorage::empty();


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

#### What changes I made
Let `UploadOpts` support `auth_store` field, which allows `pixi` to pass auth_store into `rattler_upload`. 

#### Background
In the original `get_auth_store` function, `rattler_networking::AuthenticationStorage::from_env_and_defaults()` only works in `rattler_build`, but in `pixi` it doesn't work. 

The reason behind this: 

1) auth_store logic is different in `pixi` and `rattler_build`:

In `pixi`, we can see it will read from Config. 
<img width="768" height="551" alt="Screenshot 2025-07-31 at 11 35 12" src="https://github.com/user-attachments/assets/4872d0b2-7963-4162-b080-b292f2f0f460" />


But in `rattler_build`, it doesn't have this kind of logic. (`rattler_upload` crate is firstly migrated from `rattler_build`)
<img width="718" height="283" alt="Screenshot 2025-07-31 at 11 41 08" src="https://github.com/user-attachments/assets/7539d1e6-4031-426c-8224-bb8d34850c6c" />



2) the default key for `rattler_networking::AuthenticationStorage::from_env_and_defaults()` is hardcoded as "rattler".
<img width="503" height="519" alt="Screenshot 2025-07-31 at 11 42 10" src="https://github.com/user-attachments/assets/b39393b1-8a94-4a9b-a18b-185d9e166a18" />


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
