### PR TITLE
feat: Provide more details when hash mismatch occurs

### DIFF
--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -284,6 +284,8 @@ impl PackageCache {
                                     // Delete the package if the hash does not match
                                     tokio_fs::remove_dir_all(&destination).await.unwrap();
                                     return Err(ExtractError::HashMismatch {
+                                        url: url.as_ref().to_string(),
+                                        destination: destination.display().to_string(),
                                         expected: format!("{md5:x}"),
                                         actual: format!("{:x}", result.md5),
                                     });
@@ -295,6 +297,8 @@ impl PackageCache {
                                     // Delete the package if the hash does not match
                                     tokio_fs::remove_dir_all(&destination).await.unwrap();
                                     return Err(ExtractError::HashMismatch {
+                                        url: url.as_ref().to_string(),
+                                        destination: destination.display().to_string(),
                                         expected: format!("{sha256:x}"),
                                         actual: format!("{:x}", result.sha256),
                                     });

--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -288,6 +288,7 @@ impl PackageCache {
                                         destination: destination.display().to_string(),
                                         expected: format!("{md5:x}"),
                                         actual: format!("{:x}", result.md5),
+                                        total_size: result.total_size,
                                     });
                                 }
                             }
@@ -301,6 +302,7 @@ impl PackageCache {
                                         destination: destination.display().to_string(),
                                         expected: format!("{sha256:x}"),
                                         actual: format!("{:x}", result.sha256),
+                                        total_size: result.total_size,
                                     });
                                 }
                             }

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -87,6 +87,9 @@ pub struct ExtractResult {
 
     /// The Md5 hash of the extracted archive.
     pub md5: Md5Hash,
+    
+    /// The total size of the extracted archive in bytes.
+    pub total_size: u64,
 }
 
 /// A trait that can be implemented to report download progress.

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -94,7 +94,7 @@ pub struct ExtractResult {
 
     /// The Md5 hash of the extracted archive.
     pub md5: Md5Hash,
-    
+
     /// The total size of the extracted archive in bytes.
     pub total_size: u64,
 }

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -29,13 +29,14 @@ pub enum ExtractError {
     IoError(#[from] std::io::Error),
 
     #[error(
-        "hash mismatch when extracting {url} to {destination}: expected {expected}, got {actual}"
+        "hash mismatch when extracting {url} to {destination}: expected {expected}, got {actual}, total size {total_size} bytes"
     )]
     HashMismatch {
         url: String,
         destination: String,
         expected: String,
         actual: String,
+        total_size: u64,
     },
 
     #[error("could not create the destination path: {0}")]

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -28,8 +28,15 @@ pub enum ExtractError {
     #[error("an io error occurred: {0}")]
     IoError(#[from] std::io::Error),
 
-    #[error("hash mismatch: expected {expected}, got {actual}")]
-    HashMismatch { expected: String, actual: String },
+    #[error(
+        "hash mismatch when extracting {url} to {destination}: expected {expected}, got {actual}"
+    )]
+    HashMismatch {
+        url: String,
+        destination: String,
+        expected: String,
+        actual: String,
+    },
 
     #[error("could not create the destination path: {0}")]
     CouldNotCreateDestination(#[source] std::io::Error),

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -30,23 +30,10 @@ pub fn extract_tar_bz2(
 ) -> Result<ExtractResult, ExtractError> {
     std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
 
-    // Wrap the reading in additional readers that will compute the hashes of the file while its
-    // being read.
-    let sha256_reader = rattler_digest::HashingReader::<_, rattler_digest::Sha256>::new(reader);
-    let mut md5_reader =
-        rattler_digest::HashingReader::<_, rattler_digest::Md5>::new(sha256_reader);
-
-    // Unpack the archive
-    stream_tar_bz2(&mut md5_reader).unpack(destination)?;
-
-    // Read the file to the end to make sure the hash is properly computed.
-    std::io::copy(&mut md5_reader, &mut std::io::sink())?;
-
-    // Get the hashes
-    let (sha256_reader, md5) = md5_reader.finalize();
-    let (_, sha256) = sha256_reader.finalize();
-
-    Ok(ExtractResult { sha256, md5 })
+    process_with_hashing(reader, |reader| {
+        stream_tar_bz2(reader).unpack(destination)?;
+        Ok(())
+    })
 }
 
 /// Extracts the contents of a `.conda` package archive.
@@ -58,16 +45,29 @@ pub fn extract_conda_via_streaming(
     std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
 
     // Wrap the reading in additional readers that will compute the hashes of the file while its
-    // being read.
+    // being read, and count the total size.
     let sha256_reader = rattler_digest::HashingReader::<_, rattler_digest::Sha256>::new(reader);
     let mut md5_reader =
         rattler_digest::HashingReader::<_, rattler_digest::Md5>::new(sha256_reader);
+    let mut size_reader = SizeCountingReader::new(&mut md5_reader);
 
     // Iterate over all entries in the zip-file and extract them one-by-one
-    while let Some(file) = read_zipfile_from_stream(&mut md5_reader)? {
+    while let Some(file) = read_zipfile_from_stream(&mut size_reader)? {
         extract_zipfile(file, destination)?;
     }
-    compute_hashes(md5_reader)
+    // Read the file to the end to make sure the hash is properly computed
+    std::io::copy(&mut size_reader, &mut std::io::sink())?;
+
+    // Get the size and hashes
+    let (_, total_size) = size_reader.finalize();
+    let (sha256_reader, md5) = md5_reader.finalize();
+    let (_, sha256) = sha256_reader.finalize();
+
+    Ok(ExtractResult {
+        sha256,
+        md5,
+        total_size,
+    })
 }
 
 /// Extracts the contents of a .conda package archive by fully reading the stream and then decompressing
@@ -81,24 +81,19 @@ pub fn extract_conda_via_buffering(
     }
     std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
 
-    // Create a SpooledTempFile with a 5MB limit
-    let mut temp_file = SpooledTempFile::new(5 * 1024 * 1024);
-    let sha256_reader = rattler_digest::HashingReader::<_, rattler_digest::Sha256>::new(reader);
-    let mut md5_reader =
-        rattler_digest::HashingReader::<_, rattler_digest::Md5>::new(sha256_reader);
+    process_with_hashing(reader, |reader| {
+        // Create a SpooledTempFile with a 5MB limit
+        let mut temp_file = SpooledTempFile::new(5 * 1024 * 1024);
+        copy(reader, &mut temp_file)?;
+        temp_file.seek(SeekFrom::Start(0))?;
+        let mut archive = ZipArchive::new(temp_file)?;
 
-    copy(&mut md5_reader, &mut temp_file)?;
-    temp_file.seek(SeekFrom::Start(0))?;
-    let mut archive = ZipArchive::new(temp_file)?;
-
-    for i in 0..archive.len() {
-        let file = archive.by_index(i)?;
-        extract_zipfile(file, destination)?;
-    }
-    // Read the file to the end to make sure the hash is properly computed.
-    std::io::copy(&mut md5_reader, &mut std::io::sink())?;
-
-    compute_hashes(md5_reader)
+        for i in 0..archive.len() {
+            let file = archive.by_index(i)?;
+            extract_zipfile(file, destination)?;
+        }
+        Ok(())
+    })
 }
 
 fn extract_zipfile<R: std::io::Read>(
@@ -128,15 +123,56 @@ fn extract_zipfile<R: std::io::Read>(
     Ok(())
 }
 
-fn compute_hashes<R: Read>(
-    mut md5_reader: HashingReader<HashingReader<R, rattler_digest::Sha256>, rattler_digest::Md5>,
-) -> Result<ExtractResult, ExtractError> {
-    // Read the file to the end to make sure the hash is properly computed.
-    std::io::copy(&mut md5_reader, &mut std::io::sink())?;
+// Define a custom reader to track file size
+struct SizeCountingReader<R: Read> {
+    inner: R,
+    size: u64,
+}
 
-    // Get the hashes
+impl<R: Read> SizeCountingReader<R> {
+    fn new(inner: R) -> Self {
+        Self { inner, size: 0 }
+    }
+
+    fn finalize(self) -> (R, u64) {
+        (self.inner, self.size)
+    }
+}
+
+impl<R: Read> Read for SizeCountingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let bytes_read = self.inner.read(buf)?;
+        self.size += bytes_read as u64;
+        Ok(bytes_read)
+    }
+}
+
+/// Helper function to compute hashes and size while processing a tar archive
+fn process_with_hashing<E, F>(reader: impl Read, processor: F) -> Result<ExtractResult, E>
+where
+    E: From<std::io::Error>,
+    F: FnOnce(&mut dyn Read) -> Result<(), E>,
+{
+    // Wrap the reading in additional readers that will compute the hashes of the file while its
+    // being read, and count the total size.
+    let sha256_reader = rattler_digest::HashingReader::<_, rattler_digest::Sha256>::new(reader);
+    let mut md5_reader =
+        rattler_digest::HashingReader::<_, rattler_digest::Md5>::new(sha256_reader);
+    let mut size_reader = SizeCountingReader::new(&mut md5_reader);
+
+    processor(&mut size_reader)?;
+
+    // Read the file to the end to make sure the hash is properly computed
+    std::io::copy(&mut size_reader, &mut std::io::sink())?;
+
+    // Get the size and hashes
+    let (_, total_size) = size_reader.finalize();
     let (sha256_reader, md5) = md5_reader.finalize();
     let (_, sha256) = sha256_reader.finalize();
 
-    Ok(ExtractResult { sha256, md5 })
+    Ok(ExtractResult {
+        sha256,
+        md5,
+        total_size,
+    })
 }

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -2,7 +2,6 @@
 //! [`std::io::Read`] trait.
 
 use super::{ExtractError, ExtractResult};
-use rattler_digest::HashingReader;
 use std::io::{copy, Seek, SeekFrom};
 use std::mem::ManuallyDrop;
 use std::{ffi::OsStr, io::Read, path::Path};


### PR DESCRIPTION
### Description

When experiencing hash mismatch errors, it's quite difficult to debug them due to the lack of information in the error message. I've added a few extra fields in the error message like:
* The `url` we tried to download from
* The `destination` we tried to download to
* The `total_size` of the file we downloaded

As part of this PR, I've unified the way hashes were calculated by removing the `compute_hashes` function and replaced it with `process_with_hashing`, which makes the other functions more neat.