### PR TITLE
feat: ability to ignore packages in the installer

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -289,6 +289,7 @@ pub async fn create(opt: Opt) -> anyhow::Result<()> {
             installed_packages,
             required_packages,
             None,
+            None, // ignored packages
             install_platform,
         )?;
 

--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -1162,18 +1162,23 @@ mod tests {
         // Step 2: Try to "remove" the package by installing an empty environment, but ignore the package
         let package_name = repo_record.package_record.name.clone();
         let ignored_packages = HashSet::from_iter(vec![package_name]);
-        let installer_with_ignored = Installer::new()
-            .with_ignored_packages(ignored_packages);
+        let installer_with_ignored = Installer::new().with_ignored_packages(ignored_packages);
 
         // Install empty environment (should remove all packages, except ignored ones)
         let result = installer_with_ignored
             .install(&target_prefix, Vec::<RepoDataRecord>::new())
             .await;
 
-        assert!(result.is_ok(), "Installation with ignored packages should succeed");
+        assert!(
+            result.is_ok(),
+            "Installation with ignored packages should succeed"
+        );
 
         // Verify the ignored package is still there
-        assert!(meta_file_path.exists(), "Ignored package should still be installed");
+        assert!(
+            meta_file_path.exists(),
+            "Ignored package should still be installed"
+        );
 
         // Verify transaction was empty (no operations performed)
         let installation_result = result.unwrap();

--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -1169,12 +1169,12 @@ mod tests {
         let result = installer_with_ignored
             .install(&target_prefix, Vec::<RepoDataRecord>::new())
             .await;
-        
+
         assert!(result.is_ok(), "Installation with ignored packages should succeed");
 
         // Verify the ignored package is still there
         assert!(meta_file_path.exists(), "Ignored package should still be installed");
-        
+
         // Verify transaction was empty (no operations performed)
         let installation_result = result.unwrap();
         assert!(

--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -61,6 +61,7 @@ pub struct Installer {
     apple_code_sign_behavior: AppleCodeSignBehavior,
     alternative_target_prefix: Option<PathBuf>,
     reinstall_packages: Option<HashSet<PackageName>>,
+    ignored_packages: Option<HashSet<PackageName>>,
     requested_specs: Option<Vec<MatchSpec>>,
     // TODO: Determine upfront if these are possible.
     link_options: LinkOptions,
@@ -243,6 +244,25 @@ impl Installer {
         self
     }
 
+    /// Set the packages that should be ignored (left untouched) during installation.
+    /// Ignored packages will not be removed, installed, or updated.
+    #[must_use]
+    pub fn with_ignored_packages(self, ignored: HashSet<PackageName>) -> Self {
+        Self {
+            ignored_packages: Some(ignored),
+            ..self
+        }
+    }
+
+    /// Set the packages that should be ignored (left untouched) during installation.
+    /// Ignored packages will not be removed, installed, or updated.
+    /// This function is similar to [`Self::with_ignored_packages`], but
+    /// modifies an existing instance.
+    pub fn set_ignored_packages(&mut self, ignored: HashSet<PackageName>) -> &mut Self {
+        self.ignored_packages = Some(ignored);
+        self
+    }
+
     /// Sets the packages that are currently installed in the prefix. If this
     /// is not set, the installation process will first figure this out.
     ///
@@ -377,6 +397,7 @@ impl Installer {
             installed.clone(),
             records.into_iter().collect::<Vec<_>>(),
             self.reinstall_packages,
+            self.ignored_packages,
             target_platform,
         )?;
 
@@ -1122,6 +1143,43 @@ mod tests {
         assert!(
             updated_record.requested_specs.is_empty(),
             "Updated installation without specs should clear requested_specs"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_install_with_ignored_packages() {
+        let (_temp_dir, target_prefix) = create_test_environment();
+        let repo_record = create_dummy_repo_record();
+
+        // Step 1: Install the package first
+        let installer = Installer::new();
+        install_and_verify_success(installer, &target_prefix, repo_record.clone()).await;
+
+        // Verify the package was installed
+        let meta_file_path = get_meta_file_path(&target_prefix, &repo_record);
+        assert!(meta_file_path.exists(), "Package should be installed");
+
+        // Step 2: Try to "remove" the package by installing an empty environment, but ignore the package
+        let package_name = repo_record.package_record.name.clone();
+        let ignored_packages = HashSet::from_iter(vec![package_name]);
+        let installer_with_ignored = Installer::new()
+            .with_ignored_packages(ignored_packages);
+
+        // Install empty environment (should remove all packages, except ignored ones)
+        let result = installer_with_ignored
+            .install(&target_prefix, Vec::<RepoDataRecord>::new())
+            .await;
+        
+        assert!(result.is_ok(), "Installation with ignored packages should succeed");
+
+        // Verify the ignored package is still there
+        assert!(meta_file_path.exists(), "Ignored package should still be installed");
+        
+        // Verify transaction was empty (no operations performed)
+        let installation_result = result.unwrap();
+        assert!(
+            installation_result.transaction.operations.is_empty(),
+            "No operations should be performed on ignored packages"
         );
     }
 

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -183,15 +183,15 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
         // "desired" iterator. Skip ignored packages entirely.
         for record in desired_iter {
             let name = &record.as_ref().name;
-            
+
             // Skip ignored packages - they should be left in their current state
             if ignored.contains(name) {
-                // Remove from current_map to avoid affecting further logic, 
+                // Remove from current_map to avoid affecting further logic,
                 // but don't add any operations for this package
                 current_map.remove(name);
                 continue;
             }
-            
+
             let old_record = current_map.remove(name);
 
             if let Some(old_record) = old_record {
@@ -320,7 +320,7 @@ mod tests {
         .await;
 
         let name = prefix_record.repodata_record.package_record.name.clone();
-        
+
         // Test case 1: Package is in both current and desired, but ignored - should result in no operations
         let ignored_packages = Some(HashSet::from_iter(vec![name.clone()]));
         let transaction = Transaction::from_current_and_desired(

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -340,7 +340,7 @@ mod tests {
         let transaction = Transaction::from_current_and_desired(
             vec![prefix_record.clone()],
             Vec::<rattler_conda_types::RepoDataRecord>::new(), // empty desired
-            None, // reinstall
+            None,                                              // reinstall
             ignored_packages,
             Platform::current(),
         )

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -126,7 +126,8 @@ impl<Old: AsRef<New>, New> Transaction<Old, New> {
 impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New> {
     /// Constructs a [`Transaction`] by taking the current situation and diffing
     /// that against the desired situation. You can specify a set of package names
-    /// that should be reinstalled even if their content has not changed.
+    /// that should be reinstalled even if their content has not changed. You can
+    /// also specify a set of package names that should be ignored (left untouched).
     pub fn from_current_and_desired<
         CurIter: IntoIterator<Item = Old>,
         NewIter: IntoIterator<Item = New>,
@@ -134,6 +135,7 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
         current: CurIter,
         desired: NewIter,
         reinstall: Option<HashSet<PackageName>>,
+        ignored: Option<HashSet<PackageName>>,
         platform: Platform,
     ) -> Result<Self, TransactionError>
     where
@@ -153,6 +155,7 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
 
         let mut operations = Vec::new();
         let reinstall = reinstall.unwrap_or_default();
+        let ignored = ignored.unwrap_or_default();
 
         let mut current_map = current_iter
             .clone()
@@ -165,9 +168,10 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
             .collect::<HashSet<_>>();
 
         // Remove all current packages that are not in desired (but keep order of
-        // current)
+        // current), except for ignored packages which should be left untouched
         for record in current_iter {
-            if !desired_names.contains(&record.as_ref().name) {
+            let package_name = &record.as_ref().name;
+            if !desired_names.contains(package_name) && !ignored.contains(package_name) {
                 operations.push(TransactionOperation::Remove(record));
             }
         }
@@ -176,9 +180,18 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
         operations.reverse();
 
         // Figure out the operations to perform, but keep the order of the original
-        // "desired" iterator
+        // "desired" iterator. Skip ignored packages entirely.
         for record in desired_iter {
             let name = &record.as_ref().name;
+            
+            // Skip ignored packages - they should be left in their current state
+            if ignored.contains(name) {
+                // Remove from current_map to avoid affecting further logic, 
+                // but don't add any operations for this package
+                current_map.remove(name);
+                continue;
+            }
+            
             let old_record = current_map.remove(name);
 
             if let Some(old_record) = old_record {
@@ -283,6 +296,7 @@ mod tests {
             vec![prefix_record.clone()],
             vec![prefix_record.clone()],
             Some(HashSet::from_iter(vec![name])),
+            None, // ignored packages
             Platform::current(),
         )
         .unwrap();
@@ -291,5 +305,62 @@ mod tests {
             transaction.operations[0],
             TransactionOperation::Change { .. }
         );
+    }
+
+    #[tokio::test]
+    async fn test_ignored_packages() {
+        let environment_dir = tempfile::TempDir::new().unwrap();
+        let prefix_record = download_and_get_prefix_record(
+            &Prefix::create(environment_dir.path()).unwrap(),
+            "https://conda.anaconda.org/conda-forge/win-64/ruff-0.0.171-py310h298983d_0.conda"
+                .parse()
+                .unwrap(),
+            "25c755b97189ee066576b4ae3999d5e7ff4406d236b984742194e63941838dcd",
+        )
+        .await;
+
+        let name = prefix_record.repodata_record.package_record.name.clone();
+        
+        // Test case 1: Package is in both current and desired, but ignored - should result in no operations
+        let ignored_packages = Some(HashSet::from_iter(vec![name.clone()]));
+        let transaction = Transaction::from_current_and_desired(
+            vec![prefix_record.clone()],
+            vec![prefix_record.repodata_record.clone()],
+            None, // reinstall
+            ignored_packages,
+            Platform::current(),
+        )
+        .unwrap();
+
+        // Should have no operations because the package is ignored
+        assert!(transaction.operations.is_empty());
+
+        // Test case 2: Package is in current but not desired, and ignored - should not be removed
+        let ignored_packages = Some(HashSet::from_iter(vec![name.clone()]));
+        let transaction = Transaction::from_current_and_desired(
+            vec![prefix_record.clone()],
+            Vec::<rattler_conda_types::RepoDataRecord>::new(), // empty desired
+            None, // reinstall
+            ignored_packages,
+            Platform::current(),
+        )
+        .unwrap();
+
+        // Should have no operations because the package is ignored (not removed)
+        assert!(transaction.operations.is_empty());
+
+        // Test case 3: Package is not in current but in desired, and ignored - should not be installed
+        let ignored_packages = Some(HashSet::from_iter(vec![name.clone()]));
+        let transaction = Transaction::from_current_and_desired(
+            Vec::<rattler_conda_types::PrefixRecord>::new(), // empty current
+            vec![prefix_record.repodata_record.clone()],
+            None, // reinstall
+            ignored_packages,
+            Platform::current(),
+        )
+        .unwrap();
+
+        // Should have no operations because the package is ignored (not installed)
+        assert!(transaction.operations.is_empty());
     }
 }

--- a/crates/rattler/src/install/unlink.rs
+++ b/crates/rattler/src/install/unlink.rs
@@ -258,6 +258,7 @@ mod tests {
             vec![prefix_record.clone()],
             Vec::<RepoDataRecord>::new().into_iter(),
             None,
+            None, // ignored packages
             Platform::current(),
         )
         .unwrap();
@@ -322,6 +323,7 @@ mod tests {
             vec![prefix_record.clone()],
             Vec::<RepoDataRecord>::new().into_iter(),
             None,
+            None, // ignored packages
             Platform::current(),
         )
         .unwrap();

--- a/py-rattler/rattler/install/installer.py
+++ b/py-rattler/rattler/install/installer.py
@@ -17,6 +17,7 @@ async def install(
     cache_dir: Optional[os.PathLike[str]] = None,
     installed_packages: Optional[List[PrefixRecord]] = None,
     reinstall_packages: Optional[set[str]] = None,
+    ignored_packages: Optional[set[str]] = None,
     platform: Optional[Platform] = None,
     execute_link_scripts: bool = False,
     show_progress: bool = True,
@@ -66,6 +67,8 @@ async def install(
                 If `None` is specified then the `target_prefix` will be scanned for installed
                 packages.
         reinstall_packages: A list of package names that should be reinstalled.
+        ignored_packages: A list of package names that should be ignored (left untouched).
+                These packages will not be removed, installed, or updated.
         platform: Target platform to create and link the
                 environment. Defaults to current platform.
         execute_link_scripts: whether to execute the post-link and pre-unlink scripts
@@ -84,6 +87,7 @@ async def install(
         cache_dir=cache_dir,
         installed_packages=installed_packages,
         reinstall_packages=reinstall_packages,
+        ignored_packages=ignored_packages,
         platform=platform._inner if platform is not None else None,
         client=client._client if client is not None else None,
         execute_link_scripts=execute_link_scripts,


### PR DESCRIPTION
This PR adds the ability to ignore packages, so to basically keep them around in the prefix even though they are no longer requested. This is useful to add the ability to do a partial prefix installation or re-installation.
