### PR TITLE
perf(rattler): reduce overhead if transaction is empty

### DIFF
--- a/crates/rattler/src/install/clobber_registry.rs
+++ b/crates/rattler/src/install/clobber_registry.rs
@@ -422,6 +422,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         // execute transaction
@@ -476,6 +477,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let install_driver = InstallDriver::builder()
@@ -544,6 +546,7 @@ mod tests {
                 python_info: None,
                 current_python_info: None,
                 platform: Platform::current(),
+                unchanged: vec![],
             };
 
             // execute transaction
@@ -628,6 +631,7 @@ mod tests {
                 python_info: None,
                 current_python_info: None,
                 platform: Platform::current(),
+                unchanged: vec![],
             };
 
             // execute transaction
@@ -684,6 +688,7 @@ mod tests {
                 python_info: None,
                 current_python_info: None,
                 platform: Platform::current(),
+                unchanged: vec![],
             };
 
             let install_driver = InstallDriver::builder()
@@ -735,6 +740,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         // execute transaction
@@ -790,6 +796,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let install_driver = InstallDriver::builder()
@@ -842,6 +849,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         // execute transaction
@@ -886,6 +894,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let install_driver = InstallDriver::builder()
@@ -926,6 +935,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         // execute transaction
@@ -983,6 +993,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let prefix_records = PrefixRecord::collect_from_prefix(target_prefix.path()).unwrap();
@@ -1016,6 +1027,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let prefix_records = PrefixRecord::collect_from_prefix(target_prefix.path()).unwrap();
@@ -1061,6 +1073,7 @@ mod tests {
             python_info: Some(python_info.clone()),
             current_python_info: Some(python_info.clone()),
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         // execute transaction
@@ -1115,6 +1128,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         // execute transaction
@@ -1146,6 +1160,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let install_driver = InstallDriver::builder()
@@ -1184,6 +1199,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         // execute transaction
@@ -1218,6 +1234,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let install_driver = InstallDriver::builder()
@@ -1270,6 +1287,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         // execute transaction
@@ -1302,6 +1320,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let install_driver = InstallDriver::builder()
@@ -1348,6 +1367,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let install_driver = InstallDriver::builder().with_prefix_records(&[]).finish();
@@ -1398,6 +1418,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: vec![],
         };
 
         let install_driver = InstallDriver::builder().with_prefix_records(&[]).finish();

--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -383,8 +383,6 @@ impl Installer {
             target_platform,
         )?;
 
-        dbg!(transaction.unchanged_packages());
-
         // Create a mapping from package names to requested specs
         let spec_mapping = self
             .requested_specs

--- a/crates/rattler/src/install/link_script.rs
+++ b/crates/rattler/src/install/link_script.rs
@@ -263,6 +263,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: Vec::new(),
         };
 
         let packages_dir = tempfile::tempdir().unwrap();
@@ -290,6 +291,7 @@ mod tests {
             python_info: None,
             current_python_info: None,
             platform: Platform::current(),
+            unchanged: Vec::new(),
         };
 
         execute_transaction(

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -193,7 +193,9 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
 
             // Skip ignored packages - they should be left in their current state
             if ignored.contains(name) {
-                unchanged.push(old_record);
+                if let Some(old_record) = old_record {
+                    unchanged.push(old_record);
+                }
             } else if let Some(old_record) = old_record {
                 if !describe_same_content(record.as_ref(), old_record.as_ref())
                     || reinstall.contains(&record.as_ref().name)

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -34,7 +34,8 @@ pub enum TransactionOperation<Old, New> {
     /// Reinstall a package. This can happen if the Python version changed in
     /// the environment, we need to relink all noarch python packages in
     /// that case.
-    /// Includes old and new because certain fields like the channel/url may have changed between installations
+    /// Includes old and new because certain fields like the channel/url may
+    /// have changed between installations
     Reinstall {
         /// The old record to remove
         old: Old,
@@ -91,6 +92,9 @@ pub struct Transaction<Old, New> {
 
     /// The target platform of the transaction
     pub platform: Platform,
+
+    /// The records that are not touched by the transaction.
+    pub unchanged: Vec<Old>,
 }
 
 impl<Old, New> Transaction<Old, New> {
@@ -100,6 +104,12 @@ impl<Old, New> Transaction<Old, New> {
         self.operations
             .iter()
             .filter_map(TransactionOperation::record_to_remove)
+    }
+
+    /// Return an iterator over the records that are not touched by the
+    /// transcation
+    pub fn unchanged_packages(&self) -> &[Old] {
+        &self.unchanged
     }
 
     /// Returns the number of records to install.
@@ -125,9 +135,10 @@ impl<Old: AsRef<New>, New> Transaction<Old, New> {
 
 impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New> {
     /// Constructs a [`Transaction`] by taking the current situation and diffing
-    /// that against the desired situation. You can specify a set of package names
-    /// that should be reinstalled even if their content has not changed. You can
-    /// also specify a set of package names that should be ignored (left untouched).
+    /// that against the desired situation. You can specify a set of package
+    /// names that should be reinstalled even if their content has not
+    /// changed. You can also specify a set of package names that should be
+    /// ignored (left untouched).
     pub fn from_current_and_desired<
         CurIter: IntoIterator<Item = Old>,
         NewIter: IntoIterator<Item = New>,
@@ -181,20 +192,15 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
 
         // Figure out the operations to perform, but keep the order of the original
         // "desired" iterator. Skip ignored packages entirely.
+        let mut unchanged = Vec::new();
         for record in desired_iter {
             let name = &record.as_ref().name;
+            let old_record = current_map.remove(name);
 
             // Skip ignored packages - they should be left in their current state
             if ignored.contains(name) {
-                // Remove from current_map to avoid affecting further logic,
-                // but don't add any operations for this package
-                current_map.remove(name);
-                continue;
-            }
-
-            let old_record = current_map.remove(name);
-
-            if let Some(old_record) = old_record {
+                unchanged.push(old_record);
+            } else if let Some(old_record) = old_record {
                 if !describe_same_content(record.as_ref(), old_record.as_ref())
                     || reinstall.contains(&record.as_ref().name)
                 {
@@ -210,8 +216,10 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
                         old: old_record,
                         new: record,
                     });
+                } else {
+                    // if the content is the same, we dont need to do anything
+                    unchanged.push(old_record);
                 }
-                // if the content is the same, we dont need to do anything
             } else {
                 operations.push(TransactionOperation::Install(record));
             }
@@ -222,6 +230,7 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
             python_info: desired_python_info,
             current_python_info,
             platform,
+            unchanged,
         })
     }
 }
@@ -272,12 +281,12 @@ fn describe_same_content(from: &PackageRecord, to: &PackageRecord) -> bool {
 mod tests {
     use std::collections::HashSet;
 
+    use assert_matches::assert_matches;
     use rattler_conda_types::{prefix::Prefix, Platform};
 
     use crate::install::{
         test_utils::download_and_get_prefix_record, Transaction, TransactionOperation,
     };
-    use assert_matches::assert_matches;
 
     #[tokio::test]
     async fn test_reinstall_package() {
@@ -321,7 +330,8 @@ mod tests {
 
         let name = prefix_record.repodata_record.package_record.name.clone();
 
-        // Test case 1: Package is in both current and desired, but ignored - should result in no operations
+        // Test case 1: Package is in both current and desired, but ignored - should
+        // result in no operations
         let ignored_packages = Some(HashSet::from_iter(vec![name.clone()]));
         let transaction = Transaction::from_current_and_desired(
             vec![prefix_record.clone()],
@@ -335,7 +345,8 @@ mod tests {
         // Should have no operations because the package is ignored
         assert!(transaction.operations.is_empty());
 
-        // Test case 2: Package is in current but not desired, and ignored - should not be removed
+        // Test case 2: Package is in current but not desired, and ignored - should not
+        // be removed
         let ignored_packages = Some(HashSet::from_iter(vec![name.clone()]));
         let transaction = Transaction::from_current_and_desired(
             vec![prefix_record.clone()],
@@ -349,7 +360,8 @@ mod tests {
         // Should have no operations because the package is ignored (not removed)
         assert!(transaction.operations.is_empty());
 
-        // Test case 3: Package is not in current but in desired, and ignored - should not be installed
+        // Test case 3: Package is not in current but in desired, and ignored - should
+        // not be installed
         let ignored_packages = Some(HashSet::from_iter(vec![name.clone()]));
         let transaction = Transaction::from_current_and_desired(
             Vec::<rattler_conda_types::PrefixRecord>::new(), // empty current

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -107,7 +107,7 @@ impl<Old, New> Transaction<Old, New> {
     }
 
     /// Return an iterator over the records that are not touched by the
-    /// transcation
+    /// transaction
     pub fn unchanged_packages(&self) -> &[Old] {
         &self.unchanged
     }


### PR DESCRIPTION
This PR moves the construction of several objects after checking if the transaction is empty. This should make installing of empty transaction much faster.