### PR TITLE
fix(menuinst): correct environment variable quoting on Linux

### DIFF
--- a/crates/rattler_menuinst/src/linux.rs
+++ b/crates/rattler_menuinst/src/linux.rs
@@ -306,7 +306,7 @@ impl LinuxMenu {
             let activation_env = activator.run_activation(activation_variables, None)?;
 
             for (k, v) in activation_env {
-                envs.push(format!(r#"{k}="{v}""#));
+                envs.push(format!(r#""{k}={v}""#));
             }
         }
 


### PR DESCRIPTION
## Summary
• Fix environment variable quoting in Linux menuinst to properly quote entire assignment
• Changes from `CONDA_PREFIX="/path"` format to `"CONDA_PREFIX=/path"` format
• Ensures compatibility with Linux desktop entry standards

🤖 Generated with [Claude Code](https://claude.ai/code)