### PR TITLE
fix(menuinst): improve linux

### DIFF
--- a/crates/rattler_menuinst/src/linux.rs
+++ b/crates/rattler_menuinst/src/linux.rs
@@ -661,7 +661,7 @@ mod tests {
     };
     use tempfile::TempDir;
 
-    use crate::{schema::MenuInstSchema, test::test_data, render::PlaceholderString};
+    use crate::{render::PlaceholderString, schema::MenuInstSchema, test::test_data};
 
     use super::{Directories, LinuxMenu};
 
@@ -828,7 +828,7 @@ mod tests {
     fn test_command_without_activation() {
         let dirs = FakeDirectories::new();
         let fake_prefix = FakePrefix::new("spyder/menu.json");
-        
+
         let item = fake_prefix.schema.menu_items[0].clone();
         let linux = item.platforms.linux.unwrap();
         let mut command = item.command.merge(linux.base);
@@ -858,7 +858,7 @@ mod tests {
     fn test_command_with_activation() {
         let dirs = FakeDirectories::new();
         let fake_prefix = FakePrefix::new("spyder/menu.json");
-        
+
         let item = fake_prefix.schema.menu_items[0].clone();
         let linux = item.platforms.linux.unwrap();
         let mut command = item.command.merge(linux.base);
@@ -891,7 +891,7 @@ mod tests {
     fn test_command_with_precommand() {
         let dirs = FakeDirectories::new();
         let fake_prefix = FakePrefix::new("spyder/menu.json");
-        
+
         let item = fake_prefix.schema.menu_items[0].clone();
         let linux = item.platforms.linux.unwrap();
         let mut command = item.command.merge(linux.base);
@@ -922,7 +922,7 @@ mod tests {
     fn test_command_with_complex_arguments() {
         let dirs = FakeDirectories::new();
         let fake_prefix = FakePrefix::new("spyder/menu.json");
-        
+
         let item = fake_prefix.schema.menu_items[0].clone();
         let linux = item.platforms.linux.unwrap();
         let mut command = item.command.merge(linux.base);

--- a/crates/rattler_menuinst/src/snapshots/rattler_menuinst__linux__tests__installation.snap
+++ b/crates/rattler_menuinst/src/snapshots/rattler_menuinst__linux__tests__installation.snap
@@ -6,7 +6,7 @@ expression: desktop_file_content
 Type=Application
 Encoding=UTF-8
 Name=Spyder 6 (test-env)
-Exec=bash -c '<PREFIX>/bin/spyder %F'
+Exec=<PREFIX>/bin/spyder '%F'
 Terminal=false
 Icon=<PREFIX>/Menu/spyder.png
 Comment=Scientific PYthon Development EnviRonment


### PR DESCRIPTION
This fixes a couple of problems with our linux menuinst implementation:

- `bash -c` is only need if pre-command is used to chain with `&&`, I dropped it since it makes it harder for launchers to parse `%F` and similar
- The pre-command is supposed to be used *before* the environment is activated, so I fixed that
- fix quoting
- clean up code a bit

I tested it locally with `pixi global` and Zed and it works for me. Also added a couple of tests.