### PR TITLE
fix: only run AWS s3 test on main

### DIFF
--- a/.github/workflows/e2e-s3-tests.yml
+++ b/.github/workflows/e2e-s3-tests.yml
@@ -49,8 +49,8 @@ jobs:
   e2e-aws-s3-test:
     name: E2E Upload/Index/Download [AWS S3]
     runs-on: ubuntu-latest
-    # Only run on main branch to avoid creating too many test buckets
-    # if: github.ref == 'refs/heads/main'
+    # As a security precaution, only run this job on main branch. The AWS credentials are also only valid on the main branch.
+    if: github.ref == 'refs/heads/main'
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Only run the S3 e2e tests on the main branch for security reasons. We dont want people to be able to create S3 buckets using a pull-request.