### PR TITLE
fix: menuinst on linux with `%` command

### DIFF
--- a/crates/rattler_menuinst/src/linux.rs
+++ b/crates/rattler_menuinst/src/linux.rs
@@ -310,7 +310,13 @@ impl LinuxMenu {
             .command
             .iter()
             .map(|s| s.resolve(&self.placeholders))
-            .map(|part| Ok(shlex::try_quote(&part)?.into_owned()))
+            .map(|part| {
+                if part.starts_with("%") {
+                    Ok(part)
+                } else {
+                    Ok(shlex::try_quote(&part)?.into_owned())
+                }
+            })
             .collect::<Result<Vec<_>, MenuInstError>>()?
             .join(" ");
 
@@ -876,7 +882,7 @@ mod tests {
 
         let result = linux_menu.command().unwrap();
         let normalized_result = result.replace(fake_prefix.prefix().to_str().unwrap(), "<PREFIX>");
-        insta::assert_snapshot!(normalized_result, @"<PREFIX>/bin/spyder '%F'");
+        insta::assert_snapshot!(normalized_result, @"<PREFIX>/bin/spyder %F");
     }
 
     #[test]
@@ -940,7 +946,7 @@ mod tests {
 
         let result = linux_menu.command().unwrap();
         let normalized_result = result.replace(fake_prefix.prefix().to_str().unwrap(), "<PREFIX>");
-        insta::assert_snapshot!(normalized_result, @r#"bash -c "echo 'setup' && <PREFIX>/bin/spyder '%F'""#);
+        insta::assert_snapshot!(normalized_result, @r#"bash -c "echo 'setup' && <PREFIX>/bin/spyder %F""#);
     }
 
     #[test]

--- a/crates/rattler_menuinst/src/snapshots/rattler_menuinst__linux__tests__installation.snap
+++ b/crates/rattler_menuinst/src/snapshots/rattler_menuinst__linux__tests__installation.snap
@@ -6,7 +6,7 @@ expression: desktop_file_content
 Type=Application
 Encoding=UTF-8
 Name=Spyder 6 (test-env)
-Exec=<PREFIX>/bin/spyder '%F'
+Exec=<PREFIX>/bin/spyder %F
 Terminal=false
 Icon=<PREFIX>/Menu/spyder.png
 Comment=Scientific PYthon Development EnviRonment


### PR DESCRIPTION
While quoting each argument is reasonable in general, unfortunately nautilus cannot deal with quoted special arguments like "%f". This PR changes behaviour so that these arguments are not quoted. I tested this locally with Pixi and it works as expected.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

@lucascolley 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
