### PR TITLE
feat: move variant parsing from rattler-build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,6 +1717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3400,6 +3406,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minijinja"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f264d75233323f4b7d2f03aefe8a990690cdebfbfe26ea86bcbaec5e9ac990"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,6 +4142,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -4971,6 +4996,23 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "rattler_variants"
+version = "0.1.0"
+dependencies = [
+ "fs-err",
+ "indexmap 2.11.3",
+ "miette",
+ "minijinja",
+ "pretty_assertions",
+ "rattler_conda_types",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "strum",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -7652,6 +7694,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ md-5 = "0.10.6"
 memchr = "2.7.4"
 memmap2 = "0.9.5"
 miette = "7.6.0"
+minijinja = "2.12.0"
 netrc-rs = "0.1.2"
 nom = "8.0.0"
 nom-language = "0.1.0"
@@ -200,6 +201,7 @@ rattler_shell = { path = "crates/rattler_shell", version = "=0.25.0", default-fe
 rattler_solve = { path = "crates/rattler_solve", version = "=3.0.3", default-features = false }
 rattler_upload = { path = "crates/rattler_upload", version = "=0.3.1", default-features = false }
 rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.5", default-features = false }
+rattler_variants = { path = "crates/rattler_variants", version = "=0.1.0" }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/rattler_variants/Cargo.toml
+++ b/crates/rattler_variants/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "rattler_variants"
+version = "0.1.0"
+edition = "2021"
+authors = ["Prefix.dev"]
+license = "BSD-3-Clause"
+description = "Utilities for parsing conda variant configuration files"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+miette = { workspace = true }
+fs-err = { workspace = true }
+indexmap = { workspace = true }
+minijinja = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
+rattler_conda_types = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = "1.4.0"

--- a/crates/rattler_variants/src/context.rs
+++ b/crates/rattler_variants/src/context.rs
@@ -1,0 +1,92 @@
+use crate::{normalized_key::NormalizedKey, variant_value::VariantValue};
+use rattler_conda_types::Platform;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use strum::IntoEnumIterator as _;
+
+/// Context information required when rendering variant configuration files.
+#[derive(Debug, Clone, Serialize)]
+pub struct VariantContext {
+    pub target_platform: Platform,
+    pub host_platform: Platform,
+    pub build_platform: Platform,
+    #[serde(skip)]
+    pub variant: BTreeMap<NormalizedKey, VariantValue>,
+}
+
+impl VariantContext {
+    pub fn new(
+        target_platform: Platform,
+        host_platform: Platform,
+        build_platform: Platform,
+    ) -> Self {
+        Self {
+            target_platform,
+            host_platform,
+            build_platform,
+            variant: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_variant(mut self, variant: BTreeMap<NormalizedKey, VariantValue>) -> Self {
+        self.variant = variant;
+        self
+    }
+
+    pub fn variant(&self) -> &BTreeMap<NormalizedKey, VariantValue> {
+        &self.variant
+    }
+
+    pub(crate) fn as_json_context(&self) -> serde_json::Value {
+        use serde_json::json;
+
+        let mut ctx = serde_json::Map::new();
+        ctx.insert(
+            "target_platform".to_string(),
+            json!(self.target_platform.to_string()),
+        );
+        ctx.insert(
+            "host_platform".to_string(),
+            json!(self.host_platform.to_string()),
+        );
+        ctx.insert(
+            "build_platform".to_string(),
+            json!(self.build_platform.to_string()),
+        );
+        ctx.insert(
+            "unix".to_string(),
+            serde_json::Value::Bool(self.host_platform.is_unix()),
+        );
+
+        for platform in Platform::iter() {
+            if let Some(only_platform) = platform.only_platform() {
+                let key = only_platform.to_string();
+                ctx.insert(
+                    key,
+                    serde_json::Value::Bool(
+                        self.host_platform.only_platform() == Some(only_platform),
+                    ),
+                );
+            }
+
+            if let Some(arch) = platform.arch() {
+                let key = arch.to_string();
+                ctx.insert(
+                    key,
+                    serde_json::Value::Bool(self.host_platform.arch() == Some(arch)),
+                );
+            }
+        }
+
+        let mut variant_map = serde_json::Map::new();
+        for (key, value) in &self.variant {
+            variant_map.insert(key.normalize(), value.to_json());
+        }
+        ctx.insert(
+            "variant".to_string(),
+            serde_json::Value::Object(variant_map),
+        );
+
+        serde_json::Value::Object(ctx)
+    }
+}

--- a/crates/rattler_variants/src/lib.rs
+++ b/crates/rattler_variants/src/lib.rs
@@ -1,0 +1,9 @@
+mod context;
+mod normalized_key;
+mod parser;
+mod variant_value;
+
+pub use context::VariantContext;
+pub use normalized_key::NormalizedKey;
+pub use parser::{Pin, VariantConfig, VariantConfigError};
+pub use variant_value::VariantValue;

--- a/crates/rattler_variants/src/normalized_key.rs
+++ b/crates/rattler_variants/src/normalized_key.rs
@@ -1,0 +1,47 @@
+use rattler_conda_types::PackageName;
+use serde::{Deserialize, Serialize};
+use std::hash::Hash;
+
+/// A key in a variant configuration. Keys are normalized by replacing '-', '_' and '.' with '_'.
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct NormalizedKey(pub String);
+
+impl NormalizedKey {
+    /// Returns the normalized form of the key.
+    pub fn normalize(&self) -> String {
+        self.0
+            .chars()
+            .map(|c| match c {
+                '-' | '_' | '.' => '_',
+                x => x,
+            })
+            .collect()
+    }
+}
+
+impl Serialize for NormalizedKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.normalize().serialize(serializer)
+    }
+}
+
+impl From<String> for NormalizedKey {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for NormalizedKey {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<&PackageName> for NormalizedKey {
+    fn from(package: &PackageName) -> Self {
+        package.as_normalized().into()
+    }
+}

--- a/crates/rattler_variants/src/parser.rs
+++ b/crates/rattler_variants/src/parser.rs
@@ -204,11 +204,7 @@ fn render_string(
 }
 
 fn preprocess_template(input: &str) -> String {
-    if input.contains("${{") {
-        input.replace("${{", "{{").replace("}}", "}}")
-    } else {
-        input.to_string()
-    }
+    input.replace("${{", "{{")
 }
 
 fn evaluate_selector(

--- a/crates/rattler_variants/src/parser.rs
+++ b/crates/rattler_variants/src/parser.rs
@@ -1,0 +1,442 @@
+use crate::{context::VariantContext, normalized_key::NormalizedKey, variant_value::VariantValue};
+use fs_err as fs;
+use miette::Diagnostic;
+use minijinja::Environment;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+pub const CONDA_BUILD_CONFIG_FILE: &str = "conda_build_config.yaml";
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+/// Represents a pin configuration for a package.
+pub struct Pin {
+    /// The maximum pin (a string like "x.x.x").
+    pub max_pin: Option<String>,
+    /// The minimum pin (a string like "x.x.x").
+    pub min_pin: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct VariantConfig {
+    pin_run_as_build: Option<BTreeMap<String, Pin>>,
+    zip_keys: Option<Vec<Vec<NormalizedKey>>>,
+    variants: BTreeMap<NormalizedKey, Vec<VariantValue>>,
+}
+
+impl VariantConfig {
+    pub fn from_files(
+        files: &[PathBuf],
+        context: &VariantContext,
+    ) -> Result<Self, VariantConfigError> {
+        let mut final_config = VariantConfig::default();
+        for filename in files {
+            let config = if filename.file_name() == Some(CONDA_BUILD_CONFIG_FILE.as_ref()) {
+                load_conda_build_config(filename, context)?
+            } else {
+                load_variant_file(filename, context)?
+            };
+            final_config.merge(config);
+        }
+
+        final_config.insert_platforms(context);
+        Ok(final_config)
+    }
+
+    fn merge(&mut self, other: VariantConfig) {
+        self.variants.extend(other.variants);
+        match (&mut self.pin_run_as_build, other.pin_run_as_build) {
+            (Some(existing), Some(new)) => existing.extend(new.into_iter()),
+            (None, Some(new)) => self.pin_run_as_build = Some(new),
+            _ => {}
+        }
+        if other.zip_keys.is_some() {
+            self.zip_keys = other.zip_keys;
+        }
+    }
+
+    fn insert_platforms(&mut self, context: &VariantContext) {
+        self.variants.insert(
+            NormalizedKey::from("target_platform"),
+            vec![VariantValue::from(context.target_platform.to_string())],
+        );
+        self.variants.insert(
+            NormalizedKey::from("build_platform"),
+            vec![VariantValue::from(context.build_platform.to_string())],
+        );
+    }
+
+    pub fn pin_run_as_build(&self) -> Option<&BTreeMap<String, Pin>> {
+        self.pin_run_as_build.as_ref()
+    }
+
+    pub fn zip_keys(&self) -> Option<&Vec<Vec<NormalizedKey>>> {
+        self.zip_keys.as_ref()
+    }
+
+    pub fn variants(&self) -> &BTreeMap<NormalizedKey, Vec<VariantValue>> {
+        &self.variants
+    }
+}
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum VariantConfigError {
+    #[error("Could not open file ({0}): {1}")]
+    Io(PathBuf, #[source] std::io::Error),
+    #[error("Could not parse variant config file ({0}): {1}")]
+    Parse(PathBuf, #[source] serde_yaml::Error),
+    #[error("Invalid variant config structure in {0}: {1}")]
+    InvalidStructure(PathBuf, String),
+    #[error("Failed to evaluate selector '{1}' in {0}: {2}")]
+    Selector(PathBuf, String, String),
+    #[error("Failed to evaluate template in {0}: {1}")]
+    Template(PathBuf, String),
+}
+
+fn load_variant_file(
+    path: &Path,
+    context: &VariantContext,
+) -> Result<VariantConfig, VariantConfigError> {
+    let contents =
+        fs::read_to_string(path).map_err(|err| VariantConfigError::Io(path.to_path_buf(), err))?;
+
+    let mut env = Environment::new();
+    env.set_trim_blocks(true);
+    env.set_lstrip_blocks(true);
+    env.add_function("environ_get", |name: String, default: Option<String>| {
+        let value = std::env::var(&name).unwrap_or_else(|_| default.unwrap_or_default());
+        Ok(minijinja::value::Value::from(value))
+    });
+
+    let ctx = context.as_json_context();
+    let yaml_value: serde_yaml::Value = serde_yaml::from_str(&contents)
+        .map_err(|err| VariantConfigError::Parse(path.to_path_buf(), err))?;
+    let flattened = flatten_selectors(yaml_value, path, &env, &ctx)?;
+    build_variant_config(path, flattened)
+}
+
+fn flatten_selectors(
+    value: serde_yaml::Value,
+    path: &Path,
+    env: &Environment<'_>,
+    ctx: &serde_json::Value,
+) -> Result<serde_yaml::Value, VariantConfigError> {
+    match value {
+        serde_yaml::Value::Mapping(map) => {
+            let mut result = serde_yaml::Mapping::new();
+            for (key, value) in map {
+                let key_str = match key {
+                    serde_yaml::Value::String(s) => s,
+                    other => {
+                        return Err(VariantConfigError::InvalidStructure(
+                            path.to_path_buf(),
+                            format!("expected string key but found {other:?}"),
+                        ))
+                    }
+                };
+
+                if let Some(condition) = key_str
+                    .strip_prefix("sel(")
+                    .and_then(|s| s.strip_suffix(')'))
+                {
+                    if evaluate_selector(condition, path, env, ctx)? {
+                        let nested = flatten_selectors(value, path, env, ctx)?;
+                        merge_mapping(path, &mut result, nested)?;
+                    }
+                    continue;
+                }
+
+                let rendered_key = render_string(path, env, ctx, &key_str)?;
+                let flattened_value = flatten_selectors(value, path, env, ctx)?;
+                result.insert(serde_yaml::Value::String(rendered_key), flattened_value);
+            }
+            Ok(serde_yaml::Value::Mapping(result))
+        }
+        serde_yaml::Value::Sequence(seq) => {
+            let mut result = Vec::new();
+            for item in seq {
+                let flattened_item = flatten_selectors(item, path, env, ctx)?;
+                if !flattened_item.is_null() {
+                    result.push(flattened_item);
+                }
+            }
+            Ok(serde_yaml::Value::Sequence(result))
+        }
+        serde_yaml::Value::String(s) => {
+            let rendered = render_string(path, env, ctx, &s)?;
+            Ok(serde_yaml::Value::String(rendered))
+        }
+        other => Ok(other),
+    }
+}
+
+fn merge_mapping(
+    path: &Path,
+    dest: &mut serde_yaml::Mapping,
+    value: serde_yaml::Value,
+) -> Result<(), VariantConfigError> {
+    match value {
+        serde_yaml::Value::Mapping(map) => {
+            for (key, value) in map {
+                dest.insert(key, value);
+            }
+            Ok(())
+        }
+        serde_yaml::Value::Null => Ok(()),
+        other => Err(VariantConfigError::InvalidStructure(
+            path.to_path_buf(),
+            format!("selector must evaluate to a mapping, found {other:?}"),
+        )),
+    }
+}
+
+fn render_string(
+    path: &Path,
+    env: &Environment<'_>,
+    ctx: &serde_json::Value,
+    input: &str,
+) -> Result<String, VariantConfigError> {
+    let template = preprocess_template(input);
+    env.render_str(&template, ctx)
+        .map_err(|err| VariantConfigError::Template(path.to_path_buf(), err.to_string()))
+        .map(|s| s.trim().to_string())
+}
+
+fn preprocess_template(input: &str) -> String {
+    if input.contains("${{") {
+        input.replace("${{", "{{").replace("}}", "}}")
+    } else {
+        input.to_string()
+    }
+}
+
+fn evaluate_selector(
+    condition: &str,
+    path: &Path,
+    env: &Environment<'_>,
+    ctx: &serde_json::Value,
+) -> Result<bool, VariantConfigError> {
+    let template = format!("{{% if {} %}}true{{% else %}}false{{% endif %}}", condition);
+    let rendered = env.render_str(&template, ctx).map_err(|err| {
+        VariantConfigError::Selector(path.to_path_buf(), condition.to_string(), err.to_string())
+    })?;
+    Ok(rendered.trim() == "true")
+}
+
+fn build_variant_config(
+    path: &Path,
+    value: serde_yaml::Value,
+) -> Result<VariantConfig, VariantConfigError> {
+    if value.is_null() {
+        return Ok(VariantConfig::default());
+    }
+
+    let raw: RawVariantFile = serde_yaml::from_value(value)
+        .map_err(|err| VariantConfigError::Parse(path.to_path_buf(), err))?;
+
+    let mut variants = BTreeMap::new();
+    for (key, entry) in raw.entries {
+        match entry {
+            serde_yaml::Value::Sequence(items) => {
+                let mut values = Vec::new();
+                for item in items {
+                    values.push(convert_scalar(path, &key, item)?);
+                }
+                variants.insert(NormalizedKey::from(key), values);
+            }
+            serde_yaml::Value::Null => {}
+            serde_yaml::Value::Bool(_)
+            | serde_yaml::Value::Number(_)
+            | serde_yaml::Value::String(_) => {
+                let value = convert_scalar(path, &key, entry)?;
+                variants.insert(NormalizedKey::from(key), vec![value]);
+            }
+            other => {
+                return Err(VariantConfigError::InvalidStructure(
+                    path.to_path_buf(),
+                    format!("expected a list of values for key, found {other:?}"),
+                ));
+            }
+        }
+    }
+
+    let zip_keys = raw.zip_keys.map(|keys| {
+        keys.into_iter()
+            .map(|inner| inner.into_iter().map(NormalizedKey::from).collect())
+            .collect()
+    });
+
+    Ok(VariantConfig {
+        pin_run_as_build: raw.pin_run_as_build,
+        zip_keys,
+        variants,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct RawVariantFile {
+    #[serde(default)]
+    pin_run_as_build: Option<BTreeMap<String, Pin>>,
+    #[serde(default)]
+    zip_keys: Option<Vec<Vec<String>>>,
+    #[serde(flatten)]
+    entries: BTreeMap<String, serde_yaml::Value>,
+}
+
+fn convert_scalar(
+    path: &Path,
+    key: &str,
+    value: serde_yaml::Value,
+) -> Result<VariantValue, VariantConfigError> {
+    match value {
+        serde_yaml::Value::Bool(b) => Ok(VariantValue::Bool(b)),
+        serde_yaml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(VariantValue::Integer(i))
+            } else if let Some(f) = n.as_f64() {
+                Ok(VariantValue::Float(f))
+            } else {
+                Err(VariantConfigError::InvalidStructure(
+                    path.to_path_buf(),
+                    format!("unsupported numeric value for key {key}"),
+                ))
+            }
+        }
+        serde_yaml::Value::String(s) => Ok(VariantValue::String(s)),
+        other => Err(VariantConfigError::InvalidStructure(
+            path.to_path_buf(),
+            format!("expected scalar value for key {key}, found {other:?}"),
+        )),
+    }
+}
+
+fn load_conda_build_config(
+    path: &Path,
+    context: &VariantContext,
+) -> Result<VariantConfig, VariantConfigError> {
+    let mut input =
+        fs::read_to_string(path).map_err(|err| VariantConfigError::Io(path.to_path_buf(), err))?;
+
+    let mut env = Environment::new();
+    env.add_function("environ_get", |name: String, default: Option<String>| {
+        let value = std::env::var(&name).unwrap_or_else(|_| default.unwrap_or_default());
+        Ok(minijinja::value::Value::from(value))
+    });
+
+    input = input.replace("os.environ.get", "environ_get");
+    input = input.replace(".startswith", " is startingwith");
+
+    let ctx = context.as_json_context();
+    let mut lines = Vec::new();
+    for line in input.lines() {
+        let parsed = ParsedLine::from_str(line);
+        if let Some(condition) = parsed.condition {
+            if !evaluate_selector(condition, path, &env, &ctx)? {
+                continue;
+            }
+        }
+        lines.push(parsed.content.to_string());
+    }
+
+    let out = lines.join(
+        "
+",
+    );
+    let yaml_value: serde_yaml::Value = serde_yaml::from_str(&out)
+        .map_err(|err| VariantConfigError::Parse(path.to_path_buf(), err))?;
+
+    let filtered = match yaml_value {
+        serde_yaml::Value::Mapping(map) => {
+            let filtered = map
+                .into_iter()
+                .filter(|(_, v)| !v.is_null())
+                .collect::<serde_yaml::Mapping>();
+            serde_yaml::Value::Mapping(filtered)
+        }
+        other => other,
+    };
+
+    build_variant_config(path, filtered)
+}
+
+#[derive(Debug)]
+struct ParsedLine<'a> {
+    content: &'a str,
+    condition: Option<&'a str>,
+}
+
+impl<'a> ParsedLine<'a> {
+    fn from_str(line: &'a str) -> ParsedLine<'a> {
+        match line.split_once('#') {
+            Some((content, cond)) => ParsedLine {
+                content: content.trim_end(),
+                condition: cond
+                    .trim()
+                    .strip_prefix('[')
+                    .and_then(|s| s.strip_suffix(']'))
+                    .map(str::trim),
+            },
+            None => ParsedLine {
+                content: line.trim_end(),
+                condition: None,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rattler_conda_types::Platform;
+
+    fn context() -> VariantContext {
+        VariantContext::new(Platform::Linux64, Platform::Linux64, Platform::Linux64)
+    }
+
+    #[test]
+    fn applies_selector_condition() {
+        let yaml = r#"
+sel(linux):
+  python:
+    - "3.10"
+sel(win):
+  python:
+    - "3.9"
+"#;
+        let path = Path::new("sel.yaml");
+        let env = Environment::new();
+        let ctx = context().as_json_context();
+        let value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let flattened = flatten_selectors(value, path, &env, &ctx).unwrap();
+        let config = build_variant_config(path, flattened).unwrap();
+        let python = config
+            .variants()
+            .get(&NormalizedKey::from("python"))
+            .unwrap();
+        assert_eq!(python, &vec![VariantValue::String("3.10".into())]);
+    }
+
+    #[test]
+    fn parses_basic_variant_file() {
+        let yaml = r#"
+python:
+  - "3.10"
+  - "3.11"
+zip_keys:
+  - [python, numpy]
+numpy:
+  - "1.26"
+  - "1.26"
+"#;
+        let path = Path::new("test.yaml");
+        let env = Environment::new();
+        let ctx = context().as_json_context();
+        let value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let flattened = flatten_selectors(value, path, &env, &ctx).unwrap();
+        let config = build_variant_config(path, flattened).unwrap();
+        assert_eq!(config.variants().len(), 2);
+        assert_eq!(config.zip_keys().unwrap().len(), 1);
+    }
+}

--- a/crates/rattler_variants/src/parser.rs
+++ b/crates/rattler_variants/src/parser.rs
@@ -47,7 +47,7 @@ impl VariantConfig {
     fn merge(&mut self, other: VariantConfig) {
         self.variants.extend(other.variants);
         match (&mut self.pin_run_as_build, other.pin_run_as_build) {
-            (Some(existing), Some(new)) => existing.extend(new.into_iter()),
+            (Some(existing), Some(new)) => existing.extend(new),
             (None, Some(new)) => self.pin_run_as_build = Some(new),
             _ => {}
         }
@@ -217,7 +217,7 @@ fn evaluate_selector(
     env: &Environment<'_>,
     ctx: &serde_json::Value,
 ) -> Result<bool, VariantConfigError> {
-    let template = format!("{{% if {} %}}true{{% else %}}false{{% endif %}}", condition);
+    let template = format!("{{% if {condition} %}}true{{% else %}}false{{% endif %}}");
     let rendered = env.render_str(&template, ctx).map_err(|err| {
         VariantConfigError::Selector(path.to_path_buf(), condition.to_string(), err.to_string())
     })?;

--- a/crates/rattler_variants/src/parser.rs
+++ b/crates/rattler_variants/src/parser.rs
@@ -20,8 +20,15 @@ pub struct Pin {
 
 #[derive(Debug, Clone, Default)]
 pub struct VariantConfig {
+    /// Pin run dependencies by using the versions from the build dependencies
+    /// (and applying the pin).
     pin_run_as_build: Option<BTreeMap<String, Pin>>,
+
+    /// The zip keys are used to "zip" together variants to create specific
+    /// combinations.
     zip_keys: Option<Vec<Vec<NormalizedKey>>>,
+    /// The variants are a mapping of package names to a list of versions. Each
+    /// version represents a variant for the build matrix.
     variants: BTreeMap<NormalizedKey, Vec<VariantValue>>,
 }
 

--- a/crates/rattler_variants/src/variant_value.rs
+++ b/crates/rattler_variants/src/variant_value.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Represents a value in the variant configuration.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum VariantValue {
+    Bool(bool),
+    Integer(i64),
+    Float(f64),
+    String(String),
+}
+
+impl VariantValue {
+    /// Convert this value into a `serde_json::Value` so it can be passed to Jinja.
+    pub fn to_json(&self) -> serde_json::Value {
+        match self {
+            VariantValue::Bool(b) => serde_json::Value::Bool(*b),
+            VariantValue::Integer(i) => serde_json::Value::Number((*i).into()),
+            VariantValue::Float(f) => serde_json::Value::Number(
+                serde_json::Number::from_f64(*f).unwrap_or_else(|| serde_json::Number::from(0)),
+            ),
+            VariantValue::String(s) => serde_json::Value::String(s.clone()),
+        }
+    }
+}
+
+impl fmt::Display for VariantValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VariantValue::Bool(b) => write!(f, "{}", b),
+            VariantValue::Integer(i) => write!(f, "{}", i),
+            VariantValue::Float(fl) => write!(f, "{}", fl),
+            VariantValue::String(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl From<&str> for VariantValue {
+    fn from(value: &str) -> Self {
+        VariantValue::String(value.to_string())
+    }
+}
+
+impl From<String> for VariantValue {
+    fn from(value: String) -> Self {
+        VariantValue::String(value)
+    }
+}
+
+impl From<bool> for VariantValue {
+    fn from(value: bool) -> Self {
+        VariantValue::Bool(value)
+    }
+}
+
+impl From<i64> for VariantValue {
+    fn from(value: i64) -> Self {
+        VariantValue::Integer(value)
+    }
+}
+
+impl From<f64> for VariantValue {
+    fn from(value: f64) -> Self {
+        VariantValue::Float(value)
+    }
+}

--- a/crates/rattler_variants/src/variant_value.rs
+++ b/crates/rattler_variants/src/variant_value.rs
@@ -28,10 +28,10 @@ impl VariantValue {
 impl fmt::Display for VariantValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            VariantValue::Bool(b) => write!(f, "{}", b),
-            VariantValue::Integer(i) => write!(f, "{}", i),
-            VariantValue::Float(fl) => write!(f, "{}", fl),
-            VariantValue::String(s) => write!(f, "{}", s),
+            VariantValue::Bool(b) => write!(f, "{b}"),
+            VariantValue::Integer(i) => write!(f, "{i}"),
+            VariantValue::Float(fl) => write!(f, "{fl}"),
+            VariantValue::String(s) => write!(f, "{s}"),
         }
     }
 }


### PR DESCRIPTION
This adds a new crate called `rattler_variants`.
Most of it is directly moved from rattler-build.
The only bigger duplication is `VariantValue`.
In `rattler-build` we reused `Variable` that is used for variables in the `recipe.yaml`. Therefore, we have to add conversion functions on the rattler-build side.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
