### PR TITLE
draft: perf: skip shell if no activation scripts or conda prefix (#1696)

### DIFF
--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -619,6 +619,10 @@ impl<T: Shell + Clone> Activator<T> {
         variables: ActivationVariables,
         environment: Option<HashMap<&OsStr, &OsStr>>,
     ) -> Result<HashMap<String, String>, ActivationError> {
+        if variables.conda_prefix.is_none() && self.activation_scripts.is_empty() {
+            return Ok(variables.current_env);
+        }
+
         let activation_script = self.activation(variables)?.script;
 
         // Create a script that starts by emitting all environment variables, then runs


### PR DESCRIPTION
### Description

This is a draft PR for discussion of #1696. 

For now, `run_activation` simply returns `variables.current_env` directly 
when there is no conda prefix and no activation scripts, skipping the shell.

Opening this PR to discuss whether this approach is acceptable and how 
we might handle deterministic environment diffs in these cases.
