### PR TITLE
fix(hardening): Look for TOCTOU issues in the code base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,8 +5641,10 @@ version = "0.1.0"
 dependencies = [
  "fs-err",
  "libc",
+ "rattler_fs_safety",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "ambient-id"
 version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1247,48 @@ name = "cache_control"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee"
+
+[[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "cast"
@@ -2488,6 +2536,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs4"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,6 +3426,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,6 +3864,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
@@ -5319,6 +5400,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rattler_fs_safety"
+version = "0.1.0"
+dependencies = [
+ "cap-fs-ext",
+ "cap-std",
+ "libc",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rattler_git"
 version = "0.1.2"
 dependencies = [
@@ -6199,6 +6291,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -8684,6 +8786,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33"
 dependencies = [
  "windows 0.48.0",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5208,6 +5208,7 @@ dependencies = [
  "rattler_cache",
  "rattler_conda_types",
  "rattler_digest",
+ "rattler_fs_safety",
  "rattler_lock",
  "rattler_menuinst",
  "rattler_networking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5495,6 +5495,7 @@ dependencies = [
  "pep508_rs",
  "rattler_conda_types",
  "rattler_digest",
+ "rattler_fs_safety",
  "rattler_solve",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ blake2 = "0.10.6"
 bytes = "1.10.1"
 bzip2 = "0.6.0"
 cache_control = "0.2.0"
+cap-fs-ext = "3.4"
+cap-std = "3.4"
 cfg-if = "1.0"
 chrono = { version = "0.4.41", default-features = false, features = [
   "std",
@@ -207,6 +209,7 @@ rattler_cache = { path = "crates/rattler_cache", version = "=0.7.1", default-fea
 rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.46.1", default-features = false }
 rattler_config = { path = "crates/rattler_config", version = "=0.3.12", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.2.4", default-features = false }
+rattler_fs_safety = { path = "crates/rattler_fs_safety", version = "=0.1.0", default-features = false }
 rattler_git = { path = "crates/rattler_git", version = "=0.1.2", default-features = false }
 rattler_index = { path = "crates/rattler_index", version = "=0.28.2", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.3.2", default-features = false }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -40,6 +40,7 @@ parking_lot = { workspace = true }
 rattler_cache = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_digest = { workspace = true }
+rattler_fs_safety = { workspace = true }
 rattler_networking = { workspace = true }
 rattler_shell = { workspace = true }
 rattler_package_streaming = { workspace = true, features = ["reqwest"] }

--- a/crates/rattler/src/install/entry_point.rs
+++ b/crates/rattler/src/install/entry_point.rs
@@ -5,9 +5,9 @@ use rattler_conda_types::{
     prefix_record::{PathType, PathsEntry},
     Platform,
 };
-use rattler_digest::HashingWriter;
-use rattler_digest::Sha256;
-use std::{fs::File, io, io::Write, path::Path};
+use rattler_digest::{compute_bytes_digest, Sha256};
+use rattler_fs_safety::atomic_write;
+use std::{io, path::Path};
 
 use super::Prefix;
 
@@ -56,7 +56,7 @@ pub fn create_windows_python_entry_point(
     )?;
     let script_contents =
         python_entry_point_template(target_prefix, true, entry_point, python_info);
-    let (hash, size) = write_and_hash(&script_path, script_contents)?;
+    let (hash, size) = write_and_hash(&script_path, script_contents, None)?;
 
     // Construct a path to where we will create the python launcher executable.
     let relative_path_script_exe = python_info
@@ -65,10 +65,8 @@ pub fn create_windows_python_entry_point(
 
     // Include the bytes of the launcher directly in the binary so we can write it to disk.
     let launcher_bytes = get_windows_launcher(target_platform);
-    std::fs::write(
-        target_dir.path().join(&relative_path_script_exe),
-        launcher_bytes,
-    )?;
+    let exe_path = target_dir.path().join(&relative_path_script_exe);
+    atomic_write(&exe_path, launcher_bytes, None)?;
 
     let fixed_launcher_digest = rattler_digest::parse_digest_from_hex::<rattler_digest::Sha256>(
         "28b001bb9a72ae7a24242bfab248d767a1ac5dec981c672a3944f7a072375e9a",
@@ -127,14 +125,12 @@ pub fn create_unix_python_entry_point(
     )?;
     let script_contents =
         python_entry_point_template(target_prefix, false, entry_point, python_info);
-    let (hash, size) = write_and_hash(&script_path, script_contents)?;
-
-    // Make the script executable. This is only supported on Unix based filesystems.
-    #[cfg(unix)]
-    std::fs::set_permissions(
-        script_path,
-        std::os::unix::fs::PermissionsExt::from_mode(0o775),
-    )?;
+    // Mode `0o775` is applied via `fchmod` on the open
+    // temporary-file fd inside `atomic_write_in_dir` (Unix
+    // only); the script never exists at `script_path` with the
+    // wrong permissions.
+    let mode = if cfg!(unix) { Some(0o775) } else { None };
+    let (hash, size) = write_and_hash(&script_path, script_contents, mode)?;
 
     Ok(PathsEntry {
         relative_path,
@@ -188,12 +184,19 @@ pub fn python_entry_point_template(
     )
 }
 
-/// Writes the given bytes to a file and records the hash, as well as the size of the file.
-fn write_and_hash(path: &Path, contents: impl AsRef<[u8]>) -> io::Result<(Output<Sha256>, usize)> {
+/// Atomically writes `contents` to `path` and records the
+/// sha256 + size of the bytes. `mode` (Unix only) is applied
+/// via `fchmod` on the still-open temporary-file fd before the
+/// rename, so the final path never exists with the wrong
+/// permissions.
+fn write_and_hash(
+    path: &Path,
+    contents: impl AsRef<[u8]>,
+    mode: Option<u32>,
+) -> io::Result<(Output<Sha256>, usize)> {
     let bytes = contents.as_ref();
-    let mut writer = HashingWriter::<_, Sha256>::new(File::create(path)?);
-    writer.write_all(bytes)?;
-    let (_, hash) = writer.finalize();
+    atomic_write(path, bytes, mode)?;
+    let hash = compute_bytes_digest::<Sha256>(bytes);
     Ok((hash, bytes.len()))
 }
 

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -105,6 +105,14 @@ pub enum LinkFileError {
     #[error("symlink target escapes the target prefix")]
     SymlinkTargetEscapesPrefix,
 
+    /// A package-supplied relative path (the source-side
+    /// `paths.json::relative_path` or the destination-side path
+    /// computed by the clobber registry) would escape the prefix
+    /// directory after lexical normalisation. Refused before any
+    /// filesystem operation; the prefix is left untouched.
+    #[error("relative path escapes the prefix: {0}")]
+    RelativePathEscapesPrefix(PathBuf),
+
     /// No Python version was specified when installing a noarch package.
     #[error("cannot install noarch python files because there is no python version specified ")]
     MissingPythonInfo,
@@ -164,6 +172,30 @@ pub fn link_file(
     modification_time: filetime::FileTime,
     external_symlink_policy: ExternalSymlinkPolicy,
 ) -> Result<Option<LinkedFile>, LinkFileError> {
+    // Validate the package-supplied paths before joining them.
+    // Both originate from `paths.json` (directly or via the
+    // clobber registry's renaming) and are therefore controlled
+    // by whoever built the `.conda` archive. A malicious package
+    // could ship `relative_path = "../../../etc/cron.d/x"` and
+    // have the linker hardlink (or write through) into the
+    // user's `cron.d`. The lexical guard here rejects any input
+    // that resolves outside `package_dir` / `target_dir.path()`
+    // before touching the filesystem.
+    if rattler_fs_safety::validate_relative_inside(package_dir, &path_json_entry.relative_path)
+        .is_err()
+    {
+        return Err(LinkFileError::RelativePathEscapesPrefix(
+            path_json_entry.relative_path.clone(),
+        ));
+    }
+    if rattler_fs_safety::validate_relative_inside(target_dir.path(), &destination_relative_path)
+        .is_err()
+    {
+        return Err(LinkFileError::RelativePathEscapesPrefix(
+            destination_relative_path,
+        ));
+    }
+
     let source_path = package_dir.join(&path_json_entry.relative_path);
 
     let destination_path = target_dir.path().join(&destination_relative_path);
@@ -999,6 +1031,84 @@ mod test {
         assert_eq!(
             dest_mtime, modification_time,
             "patched file should have modification_time ({modification_time}), not source mtime ({source_time})",
+        );
+    }
+
+    /// A package shipping `paths.json::relative_path = "../../etc/x"`
+    /// must be rejected before any filesystem operation. Ditto for
+    /// the destination-side path computed by the clobber registry.
+    #[test]
+    fn test_link_file_rejects_relative_path_escape() {
+        use super::AppleCodeSignBehavior;
+        use rattler_conda_types::package::{PathType, PathsEntry};
+        use rattler_conda_types::prefix::Prefix;
+        use std::path::PathBuf;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let package_dir = temp_dir.path().join("package");
+        fs::create_dir_all(&package_dir).unwrap();
+        let target_dir = Prefix::create(temp_dir.path().join("target")).unwrap();
+        let modification_time = filetime::FileTime::from_unix_time(0, 0);
+
+        let escaping = PathsEntry {
+            relative_path: PathBuf::from("../../etc/cron.d/x"),
+            no_link: false,
+            path_type: PathType::HardLink,
+            prefix_placeholder: None,
+            sha256: None,
+            size_in_bytes: None,
+        };
+
+        let err = super::link_file(
+            &escaping,
+            PathBuf::from("safe_destination.txt"),
+            &package_dir,
+            &target_dir,
+            target_dir.path().to_str().unwrap(),
+            true,
+            true,
+            true,
+            Platform::Linux64,
+            AppleCodeSignBehavior::DoNothing,
+            modification_time,
+            ExternalSymlinkPolicy::Deny,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, super::LinkFileError::RelativePathEscapesPrefix(_)),
+            "{err:?}"
+        );
+
+        // Also verify the destination-side check -- clobber-rename
+        // produces the destination relative path, which is just as
+        // attacker-controllable.
+        let benign = PathsEntry {
+            relative_path: PathBuf::from("config.py"),
+            no_link: false,
+            path_type: PathType::HardLink,
+            prefix_placeholder: None,
+            sha256: None,
+            size_in_bytes: None,
+        };
+        fs::write(package_dir.join("config.py"), "ok\n").unwrap();
+        let err = super::link_file(
+            &benign,
+            PathBuf::from("../../etc/cron.d/x"),
+            &package_dir,
+            &target_dir,
+            target_dir.path().to_str().unwrap(),
+            true,
+            true,
+            true,
+            Platform::Linux64,
+            AppleCodeSignBehavior::DoNothing,
+            modification_time,
+            ExternalSymlinkPolicy::Deny,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, super::LinkFileError::RelativePathEscapesPrefix(_)),
+            "{err:?}"
         );
     }
 

--- a/crates/rattler_fs_safety/Cargo.toml
+++ b/crates/rattler_fs_safety/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "rattler_fs_safety"
+version = "0.1.0"
+edition.workspace = true
+authors = ["Tobias Hunger <tobias.hunger@prefix.dev>"]
+description = "Symlink-resistant filesystem helpers shared across rattler crates."
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+readme.workspace = true
+
+[dependencies]
+cap-std = { workspace = true }
+cap-fs-ext = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+  "Wdk_Foundation",
+  "Wdk_Storage_FileSystem",
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_Storage_FileSystem",
+  "Win32_System_IO",
+  "Win32_System_Threading",
+] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/rattler_fs_safety/src/lib.rs
+++ b/crates/rattler_fs_safety/src/lib.rs
@@ -27,12 +27,14 @@
 //!   refusing to follow a symlink at the final component. Used
 //!   for `.lock` files and any short-lived metadata file the
 //!   daemon writes inside a shared cache root.
-//! * [`atomic_write_in`] / [`atomic_write_in_dir`] -- writes
-//!   `bytes` to a temp file in the parent, optionally `fchmod`s
-//!   the still-open fd to `mode`, then renames over `name`.
-//!   Caller never sees a half-written file at the final path;
-//!   the chmod happens on the fd, not on the path, so a
-//!   co-tenant can't race a symlink between create and chmod.
+//! * [`atomic_write_in`] / [`atomic_write_in_dir`] /
+//!   [`atomic_write`] -- writes `bytes` to a temp file in the
+//!   parent, optionally `fchmod`s the still-open fd to `mode`,
+//!   then renames over `name`. Caller never sees a half-written
+//!   file at the final path; the chmod happens on the fd, not
+//!   on the path, so a co-tenant can't race a symlink between
+//!   create and chmod. [`atomic_write`] takes a full
+//!   destination `&Path` and splits it for you.
 //! * [`validate_relative_inside`] -- lexically normalises a
 //!   candidate relative path and refuses anything that would
 //!   escape `root`. For use against archive-supplied
@@ -534,6 +536,33 @@ pub fn atomic_write_in_dir(
     atomic_write_in(&dir, name, bytes, mode)
 }
 
+/// Atomically write `bytes` to `path`, replacing any existing
+/// entry on success.
+///
+/// Convenience wrapper around [`atomic_write_in_dir`] that
+/// splits `path` into its parent directory and final component
+/// for you. Returns [`io::ErrorKind::InvalidInput`] if `path`
+/// has no parent (e.g. `""`) or no final component (e.g. `"/"`,
+/// `"."`, `".."`).
+///
+/// See [`atomic_write_in`] for the TOCTOU model and the
+/// semantics of `mode`.
+pub fn atomic_write(path: &Path, bytes: &[u8], mode: Option<u32>) -> io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path has no parent: {path:?}"),
+        )
+    })?;
+    let name = path.file_name().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path has no final component: {path:?}"),
+        )
+    })?;
+    atomic_write_in_dir(parent, name, bytes, mode)
+}
+
 /// Lexically normalise `candidate` and verify the result lives
 /// strictly inside `root`. Returns the normalised path on
 /// success, an [`io::ErrorKind::PermissionDenied`] error
@@ -683,6 +712,25 @@ mod tests {
             .map(|e| e.file_name())
             .collect();
         assert_eq!(entries, vec![std::ffi::OsString::from("entry")]);
+    }
+
+    #[test]
+    fn atomic_write_path_form_splits_and_writes() {
+        let root = td();
+        let target = root.path().join("entry");
+        atomic_write(&target, b"hi", None).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"hi");
+    }
+
+    #[test]
+    fn atomic_write_path_form_rejects_pathless_input() {
+        // Two failure shapes: `""` (no parent) and `"/"` (no
+        // final component). Both must surface as `InvalidInput`
+        // rather than panic or be silently accepted.
+        let err = atomic_write(Path::new(""), b"x", None).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        let err = atomic_write(Path::new("/"), b"x", None).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[cfg(unix)]

--- a/crates/rattler_fs_safety/src/lib.rs
+++ b/crates/rattler_fs_safety/src/lib.rs
@@ -1,0 +1,852 @@
+//! Symlink-resistant filesystem helpers shared across rattler
+//! crates.
+//!
+//! The helpers here all operate against a [`cap_std::fs::Dir`]
+//! capability. cap-std refuses path-component traversal that
+//! escapes the directory, so the only remaining attack surface is
+//! the **final component** of a path -- the helpers wrap that with
+//! explicit symlink rejection so callers don't have to remember.
+//!
+//! Two flavors of opener/writer are exposed:
+//!
+//! * `*_in(&Dir, …)` -- the primary form. Callers open the parent
+//!   directory once via [`Dir::open_ambient_dir`] and reuse the
+//!   handle. The whole open / write / fchmod / rename sequence
+//!   stays anchored to that one capability, so an attacker can't
+//!   race a symlink swap of an intermediate path component
+//!   between successive helper calls.
+//! * `*_in_dir(&Path, …)` -- convenience wrapper that opens the
+//!   `Dir` itself on every call. Fine for one-shot writes;
+//!   prefer the `_in` form inside hot loops or when several
+//!   helpers act on the same directory.
+//!
+//! The full helper set:
+//!
+//! * [`open_no_follow_in`] / [`open_no_follow`] -- opens an
+//!   existing or newly-created regular file inside the parent,
+//!   refusing to follow a symlink at the final component. Used
+//!   for `.lock` files and any short-lived metadata file the
+//!   daemon writes inside a shared cache root.
+//! * [`atomic_write_in`] / [`atomic_write_in_dir`] -- writes
+//!   `bytes` to a temp file in the parent, optionally `fchmod`s
+//!   the still-open fd to `mode`, then renames over `name`.
+//!   Caller never sees a half-written file at the final path;
+//!   the chmod happens on the fd, not on the path, so a
+//!   co-tenant can't race a symlink between create and chmod.
+//! * [`validate_relative_inside`] -- lexically normalises a
+//!   candidate relative path and refuses anything that would
+//!   escape `root`. For use against archive-supplied
+//!   `paths.json::relative_path`, menuinst manifest dest paths,
+//!   and similar attacker-influenced strings *before* they're
+//!   joined to a trusted root.
+
+use std::ffi::OsStr;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+// Re-exported so callers can build [`open_no_follow`] arguments
+// (and use cap-std `Dir`s for their own anchored writes) without
+// taking a direct dependency on cap-std.
+pub use cap_std::ambient_authority;
+pub use cap_std::fs::{Dir, DirBuilder, File, OpenOptions, OpenOptionsExt, Permissions};
+#[cfg(unix)]
+pub use cap_std::fs::{DirBuilderExt, PermissionsExt};
+
+#[cfg(windows)]
+mod windows_sec;
+
+/// Open `name` inside `dir` while refusing to follow a symlink at
+/// the final component.
+///
+/// `dir` is a [`Dir`] capability, so any `..` or absolute-path
+/// traversal in `name` is rejected by cap-std before we look. The
+/// symlink rejection guards the *final* component: even a
+/// same-directory symlink (e.g. `<entry>.lock` →
+/// `<other_entry>.lock`) is refused, since the caller asked to
+/// open `name`, not whatever `name` redirects to.
+///
+/// The "don't follow" decision is pushed into the open syscall
+/// itself -- cap-std translates `FollowSymlinks::No` into
+/// `O_NOFOLLOW` on POSIX and the reparse-point-aware equivalent
+/// on Windows -- so the check and the open are a single atomic
+/// kernel call. There is no TOCTOU window where a co-tenant could
+/// swap a regular file for a symlink between an `lstat` and the
+/// `open`.
+///
+/// Symlink refusals are remapped to
+/// [`io::ErrorKind::PermissionDenied`] (the kernel reports them
+/// as `ELOOP`/`EMLINK`/`EFTYPE` depending on platform) so callers
+/// don't have to branch on platform-specific error kinds.
+pub fn open_no_follow_in(dir: &Dir, name: &OsStr, opts: &OpenOptions) -> io::Result<File> {
+    use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+
+    // Reject multi-component names. cap-std's path walk only
+    // applies `FollowSymlinks::No` to the *final* component; an
+    // intermediate component that happens to be a symlink is
+    // dereferenced, which would let a co-tenant race the
+    // intermediate target. By forcing `name` to a single
+    // component we collapse the whole open into one `openat`
+    // syscall against `dir` and there are no intermediate
+    // components to race.
+    ensure_single_component(name)?;
+
+    // Clone the caller's options so the rest of their flags
+    // (read/write/create/...) are preserved while we force the
+    // final-component symlink behavior off.
+    let mut opts = opts.clone();
+    opts.follow(FollowSymlinks::No);
+
+    dir.open_with(name, &opts).map_err(|err| {
+        if is_symlink_refusal(&err) {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("refusing to follow symlink: {name:?}"),
+            )
+        } else {
+            err
+        }
+    })
+}
+
+/// Reject any `name` that isn't a single, normal path component.
+///
+/// The helpers in this crate are designed to operate on the final
+/// component of a path: that's the only component cap-std walks
+/// with `O_NOFOLLOW`, and the only one `renameat` doesn't
+/// follow-through-symlinks on the destination side. A caller who
+/// passes `"a/b"` would re-introduce both of those races. The
+/// check also catches empty names, `.`, `..`, absolute paths, and
+/// (on Windows) backslash separators by virtue of how
+/// `Path::components` classifies them.
+fn ensure_single_component(name: &OsStr) -> io::Result<()> {
+    let mut comps = Path::new(name).components();
+    let first = comps.next();
+    let rest = comps.next();
+    match (first, rest) {
+        (Some(Component::Normal(c)), None) if c == name => Ok(()),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("name must be a single path component: {name:?}"),
+        )),
+    }
+}
+
+/// Path-based wrapper around [`open_no_follow_in`] that opens
+/// `parent` as a [`Dir`] capability for a single call. Use the
+/// `_in` form when issuing several anchored operations against
+/// the same directory.
+pub fn open_no_follow(parent: &Path, name: &OsStr, opts: &OpenOptions) -> io::Result<File> {
+    let dir = Dir::open_ambient_dir(parent, ambient_authority())?;
+    open_no_follow_in(&dir, name, opts)
+}
+
+/// `DirBuilder` configured for owner-only mode (`0o700`) on Unix,
+/// defaults elsewhere. Used to atomically `mkdirat` a private
+/// tempdir so no `umask`-dependent window exposes the entry.
+fn private_dir_builder() -> DirBuilder {
+    #[cfg(unix)]
+    {
+        let mut b = DirBuilder::new();
+        b.mode(0o700);
+        b
+    }
+    #[cfg(not(unix))]
+    {
+        DirBuilder::new()
+    }
+}
+
+/// True if `err` is the kernel reporting that `O_NOFOLLOW` (or its
+/// platform equivalent) tripped on a symlink at the final component.
+///
+/// The error codes match cap-primitives' own classification in
+/// `open_unchecked.rs` so the mapping stays in sync with whatever
+/// cap-std considers a "symlink refusal".
+#[cfg(unix)]
+fn is_symlink_refusal(err: &io::Error) -> bool {
+    let Some(raw) = err.raw_os_error() else {
+        return false;
+    };
+    #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd")))]
+    {
+        raw == libc::ELOOP
+    }
+    #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    {
+        raw == libc::EMLINK
+    }
+    #[cfg(target_os = "netbsd")]
+    {
+        raw == libc::EFTYPE
+    }
+}
+
+/// On Windows we match `ERROR_STOPPED_ON_SYMLINK` and
+/// `ERROR_CANT_ACCESS_FILE`, the two reparse-specific codes the
+/// kernel raises when the final-component reparse check trips.
+/// Other errors pass through unchanged so callers still see e.g.
+/// `NotFound` or `AlreadyExists` with their natural kind.
+#[cfg(windows)]
+fn is_symlink_refusal(err: &io::Error) -> bool {
+    windows_sec::is_symlink_refusal(err)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn is_symlink_refusal(_err: &io::Error) -> bool {
+    false
+}
+
+/// Atomically write `bytes` to `name` inside `dir`, replacing any
+/// existing entry on success. If `mode` is `Some` (Unix only),
+/// the file is `fchmod`-ed to that mode via the still-open fd
+/// before publish. If `mode` is `None`, the file is published
+/// with owner-only mode `0o600`.
+///
+/// **TOCTOU model.** The helper is robust against a co-tenant
+/// with write access to `dir`. All tempfile work happens inside
+/// a per-call private subdirectory of `dir`: on Unix it is
+/// `mkdirat`-ed with mode `0o700` and stat-verified to belong to
+/// the current effective uid; on Windows it is created via
+/// `NtCreateFile` with `OBJECT_ATTRIBUTES.RootDirectory =
+/// dir.HANDLE` and an explicit `PROTECTED` owner-only
+/// `SECURITY_DESCRIPTOR`, so placement and DACL are atomic with
+/// respect to both intermediate-component substitution and
+/// parent DACL inheritance. Either way, no other process can
+/// populate or substitute the tempfile. The final publish is an
+/// fd-anchored rename -- `renameat` on Unix,
+/// `SetFileInformationByHandle(FileRenameInfoEx)` with
+/// `RootDirectory = dir.HANDLE` on Windows -- so the destination
+/// is identified entirely by the caller's directory handle plus
+/// the single-component `name`, with no path resolution that an
+/// attacker could redirect.
+///
+/// On Windows the `mode` parameter is ignored. The published
+/// file always carries a `PROTECTED` owner-only DACL, applied
+/// atomically at create time by `NtCreateFile` -- there is no
+/// post-write permission tweak and no window during which the
+/// file is visible with looser access.
+///
+/// Failure modes leave `dir/name` untouched. The temp directory
+/// is cleaned up either explicitly after the rename (best
+/// effort) or by [`TempDir`]'s `Drop` if any earlier step
+/// failed.
+pub fn atomic_write_in(dir: &Dir, name: &OsStr, bytes: &[u8], mode: Option<u32>) -> io::Result<()> {
+    use std::io::Write;
+
+    // Reject multi-component names: a `name` like `"foo/bar"`
+    // would make the final `renameat` traverse `foo`, which the
+    // kernel follows through any symlink a co-tenant placed
+    // there. The helper's contract is "name is a single
+    // component within `dir`".
+    ensure_single_component(name)?;
+
+    let tmp = TempDir::new_in(dir, ".rattler-write-", &private_dir_builder())?;
+
+    // Create the payload anchored to `tmp`'s handle so neither
+    // the directory traversal nor the create itself goes through
+    // a path the kernel re-resolves.
+    //
+    // * Unix: `tmp.open_with` is `openat(tmp_fd, "payload",
+    //   O_CREAT|O_EXCL|O_RDWR, 0o600)`.
+    // * Windows: `create_owner_only_file` uses `NtCreateFile`
+    //   with `OBJECT_ATTRIBUTES.RootDirectory = tmp.HANDLE`,
+    //   `FILE_CREATE`, and a `PROTECTED` owner-only
+    //   `SECURITY_DESCRIPTOR`. The access mask requests
+    //   `FILE_GENERIC_WRITE | DELETE` so we can write bytes and
+    //   then publish via the fd-anchored rename without
+    //   reopening.
+    let payload_name = OsStr::new("payload");
+    #[cfg(windows)]
+    let mut payload = windows_sec::create_owner_only_file(&tmp, payload_name)?;
+    #[cfg(not(windows))]
+    let mut payload = {
+        let mut opts = OpenOptions::new();
+        opts.write(true).create_new(true);
+        #[cfg(unix)]
+        opts.mode(0o600);
+        tmp.open_with(payload_name, &opts)?
+    };
+
+    payload.write_all(bytes)?;
+    payload.sync_all()?;
+
+    #[cfg(unix)]
+    if let Some(mode) = mode {
+        // `fchmod` on the still-open fd -- no path resolution,
+        // no race window.
+        payload.set_permissions(Permissions::from_mode(mode))?;
+    }
+    #[cfg(not(unix))]
+    let _ = mode;
+
+    // Atomically publish.
+    //
+    // On Windows we use a fd-anchored rename via
+    // `SetFileInformationByHandle(FileRenameInfoEx)` with
+    // `RootDirectory = dir.HANDLE` and `Flags =
+    // REPLACE_IF_EXISTS | POSIX_SEMANTICS`. The kernel never
+    // resolves the destination by path, so an attacker who
+    // substitutes anything along `dir`'s ambient path cannot
+    // redirect the publish. `payload` is held open across the
+    // call (`DELETE` access in its open mask lets that work).
+    //
+    // On Unix `tmp.rename(payload_name, dir, name)` is already
+    // an fd-anchored cross-directory `renameat`.
+    #[cfg(windows)]
+    {
+        windows_sec::rename_via_handle(&payload, dir, name)?;
+        drop(payload);
+    }
+    #[cfg(not(windows))]
+    {
+        drop(payload);
+        tmp.rename(payload_name, dir, name)?;
+    }
+
+    // The rename above is the linearization point. Drop of
+    // `tmp` runs the best-effort `remove_open_dir_all` cleanup;
+    // any failure there is silently swallowed because the
+    // atomic write has already succeeded and callers must not
+    // see a spurious error that would prompt a retry.
+    drop(tmp);
+
+    Ok(())
+}
+
+/// A directory created inside a parent `Dir`, accessible only
+/// through this handle and removed on `Drop`.
+///
+/// `TempDir` is the reusable building block behind
+/// [`atomic_write_in`]: a private workspace where attacker-
+/// uncontrolled tempfiles can be created and renamed out from.
+/// Compared to `cap_tempfile::TempDir`, it locks down both
+/// placement and permissions atomically at creation:
+///
+/// * **Unix:** `mkdirat` via the caller-supplied [`DirBuilder`]
+///   (pass `DirBuilder::new().mode(0o700)` for owner-only). The
+///   directory is then stat-verified post-`openat` to confirm
+///   `meta.uid() == geteuid()`, which catches a co-tenant who
+///   renamed our subdirectory away between `mkdirat` and
+///   `openat`: only `root` can `chown`, so the substituted dir
+///   fails the check.
+/// * **Windows:** `NtCreateFile` with `FILE_CREATE`,
+///   `RootDirectory = parent.HANDLE`, and an explicit
+///   `SECURITY_DESCRIPTOR` carrying `SE_DACL_PROTECTED` and a
+///   single inheritable allow-ACE for the current user's SID.
+///   The kernel resolves the name relative to the parent handle
+///   (no path resolution, no intermediate-component race) and
+///   applies the security descriptor as part of the create
+///   (no inherit-then-harden window). A `GetSecurityInfo`
+///   ownership check on the resulting handle backs the
+///   filesystem layer (FAT ignores ACLs; this catches that).
+///
+/// The `prefix` argument is prepended to a per-call random
+/// suffix to form the directory name; choose a value that
+/// identifies the call site so leftover directories (if cleanup
+/// ever fails) are traceable. Random-suffix collisions are
+/// retried with a fresh name, bounded so a co-tenant who guesses
+/// the name space cannot indefinitely deny service.
+///
+/// `TempDir` derefs to [`Dir`], so the usual `open_with` /
+/// `rename` / `create_dir` methods are available directly.
+pub struct TempDir {
+    /// `None` once `close` has been called, so `Drop` becomes a
+    /// no-op.
+    dir: Option<Dir>,
+}
+
+impl TempDir {
+    /// Create a new temp directory inside `parent`. The directory
+    /// is named `{prefix}{random_suffix}` and the [`DirBuilder`]
+    /// controls how the underlying `mkdirat` is performed (pass
+    /// `DirBuilder::new().mode(0o700)` on Unix to get a private
+    /// directory).
+    pub fn new_in(parent: &Dir, prefix: &str, builder: &DirBuilder) -> io::Result<Self> {
+        // `builder` is only consulted on platforms whose
+        // capability layer takes the mkdir mode at creation time
+        // (Unix). On Windows the equivalent -- the per-call
+        // SECURITY_DESCRIPTOR -- is built inside
+        // `windows_sec::create_owner_only_subdir`.
+        #[cfg(windows)]
+        let _ = builder;
+        // Bounded retries on `AlreadyExists` so a co-tenant who
+        // can predict our naming scheme can't hang us
+        // indefinitely by pre-creating the next ~N names.
+        for _ in 0..16 {
+            let name = random_suffix(prefix);
+
+            #[cfg(windows)]
+            let attempt =
+                windows_sec::create_owner_only_subdir(parent, std::ffi::OsStr::new(&name));
+
+            #[cfg(not(windows))]
+            let attempt = parent.create_dir_with(&name, builder).and_then(|()| {
+                parent.open_dir(&name).inspect_err(|_| {
+                    // We created the directory but couldn't open
+                    // it. Best-effort path-based cleanup so we
+                    // don't leak the entry. If a co-tenant
+                    // substituted the entry before our
+                    // `remove_dir`, the rmdir either succeeds
+                    // (their dir was empty) or fails silently (we
+                    // leak their dir, not ours).
+                    let _ = parent.remove_dir(&name);
+                })
+            });
+
+            match attempt {
+                Ok(dir) => {
+                    Self::verify_owner(&dir).inspect_err(|_| {
+                        let _ = dir.try_clone().and_then(Dir::remove_open_dir_all);
+                        #[cfg(not(windows))]
+                        let _ = parent.remove_dir_all(&name);
+                    })?;
+                    return Ok(Self { dir: Some(dir) });
+                }
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a tempdir name after 16 attempts",
+        ))
+    }
+
+    /// Confirm the opened directory is still owned by the current
+    /// process identity. Catches the substitution race between
+    /// `mkdirat` and `openat` where a co-tenant with write access
+    /// to the parent renames our subdirectory away and puts theirs
+    /// in its place.
+    ///
+    /// On Unix this is `geteuid() == meta.uid()` -- `mkdir` always
+    /// sets the owner to the caller's uid, and only `root` can
+    /// `chown`. On Windows it's `EqualSid(owner, our_token_sid)`
+    /// read via `GetSecurityInfo` on the open handle, which has
+    /// the analogous property: a freshly created object's owner
+    /// SID is the creator's token SID.
+    #[cfg(unix)]
+    fn verify_owner(dir: &Dir) -> io::Result<()> {
+        use cap_std::fs::MetadataExt;
+        let meta = dir.dir_metadata()?;
+        // SAFETY: `geteuid` takes no arguments and is documented
+        // by POSIX to always succeed.
+        let our_uid = unsafe { libc::geteuid() };
+        if meta.uid() != our_uid {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "tempdir was substituted between mkdir and open",
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    fn verify_owner(dir: &Dir) -> io::Result<()> {
+        windows_sec::verify_owner(dir)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn verify_owner(_dir: &Dir) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Consume the handle and remove the directory (including
+    /// any remaining contents).
+    ///
+    /// Use this when cleanup failure matters to the caller. The
+    /// implicit `Drop` swallows errors, which is the right
+    /// behavior when the meaningful work has already happened
+    /// (a successful `rename` out of the directory, say), but
+    /// the wrong behavior when the directory's removal is the
+    /// thing the caller is waiting on.
+    pub fn close(mut self) -> io::Result<()> {
+        match self.dir.take() {
+            Some(dir) => dir.remove_open_dir_all(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl std::ops::Deref for TempDir {
+    type Target = Dir;
+    fn deref(&self) -> &Dir {
+        self.dir
+            .as_ref()
+            .expect("TempDir accessed after close consumed it")
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        if let Some(dir) = self.dir.take() {
+            let _ = dir.remove_open_dir_all();
+        }
+    }
+}
+
+/// Build a per-call tempdir name as `{prefix}{hash}-{counter}`,
+/// where `hash` is a 64-bit digest of the process id, a
+/// sub-second timestamp, and a monotonic counter; `counter` is
+/// also appended visibly so leftover directories (if cleanup
+/// ever fails) can be traced back to a specific call.
+///
+/// The hash uses a [`RandomState`] cached in a process-wide
+/// [`OnceLock`]. The seed is drawn from the OS RNG on first use
+/// and reused for every subsequent call: a fresh
+/// `RandomState::new()` per call would draw entropy
+/// unnecessarily, while a fixed-key [`DefaultHasher`] would let
+/// a co-tenant who knows the Rust version compute our hashes
+/// from the (predictable) `pid`/`nanos`/`counter` inputs. The
+/// cached seed keeps the function deterministic *within* the
+/// process while making the suffix unpredictable from outside.
+fn random_suffix(prefix: &str) -> String {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::OnceLock;
+
+    static SEED: OnceLock<RandomState> = OnceLock::new();
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut h = SEED.get_or_init(RandomState::new).build_hasher();
+    h.write_u32(std::process::id());
+    h.write_u32(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.subsec_nanos()),
+    );
+    h.write_u64(counter);
+    format!("{prefix}{:016x}-{counter:x}", h.finish())
+}
+
+/// Path-based wrapper around [`atomic_write_in`] that opens
+/// `parent` as a [`Dir`] capability for a single call. Use the
+/// `_in` form when issuing several anchored operations against
+/// the same directory.
+pub fn atomic_write_in_dir(
+    parent: &Path,
+    name: &OsStr,
+    bytes: &[u8],
+    mode: Option<u32>,
+) -> io::Result<()> {
+    let dir = Dir::open_ambient_dir(parent, ambient_authority())?;
+    atomic_write_in(&dir, name, bytes, mode)
+}
+
+/// Lexically normalise `candidate` and verify the result lives
+/// strictly inside `root`. Returns the normalised path on
+/// success, an [`io::ErrorKind::PermissionDenied`] error
+/// otherwise.
+///
+/// "Lexically" means we don't touch the filesystem -- this is for
+/// pre-validation of attacker-supplied relative paths (archive
+/// `paths.json::relative_path`, menuinst manifest dest, etc.)
+/// before they're handed to a higher-trust opener. A `..`
+/// component, an absolute path, an empty component, or anything
+/// that would resolve outside `root` after lexical normalisation
+/// is rejected.
+///
+/// **Lexical only.** This check guarantees nothing about
+/// *intermediate* path components on disk: a validated
+/// `pkg/bin/exe` can still escape `root` if `pkg/` happens to be
+/// a symlink pointing at `/etc`. Open the result through a
+/// [`Dir`] capability rooted at `root` (e.g. via
+/// [`open_no_follow_in`], or by walking with cap-std's `Dir`
+/// methods) so cap-std refuses any symlink encountered along the
+/// way. Passing the joined `PathBuf` directly to
+/// [`std::fs::File::open`] *does not* close that gap.
+pub fn validate_relative_inside(root: &Path, candidate: &Path) -> io::Result<PathBuf> {
+    if candidate.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("absolute path rejected: {candidate:?}"),
+        ));
+    }
+
+    let mut normalised = PathBuf::new();
+    for component in candidate.components() {
+        match component {
+            Component::Normal(part) => normalised.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalised.pop() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("path escapes root: {candidate:?}"),
+                    ));
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("absolute or prefix component rejected: {candidate:?}"),
+                ));
+            }
+        }
+    }
+
+    if normalised.as_os_str().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("empty relative path rejected: {candidate:?}"),
+        ));
+    }
+
+    Ok(root.join(normalised))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn td() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn open_no_follow_opens_regular_file() {
+        let root = td();
+        std::fs::write(root.path().join("hello"), b"hi").unwrap();
+        let file = open_no_follow(
+            root.path(),
+            OsStr::new("hello"),
+            OpenOptions::new().read(true),
+        )
+        .unwrap();
+        let meta = file.metadata().unwrap();
+        assert!(meta.is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_no_follow_refuses_symlink() {
+        let root = td();
+        std::fs::write(root.path().join("real"), b"x").unwrap();
+        std::os::unix::fs::symlink("real", root.path().join("link")).unwrap();
+
+        let err = open_no_follow(
+            root.path(),
+            OsStr::new("link"),
+            OpenOptions::new().read(true),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied, "{err}");
+    }
+
+    #[test]
+    fn open_no_follow_creates_when_options_allow() {
+        let root = td();
+        let file = open_no_follow(
+            root.path(),
+            OsStr::new("new"),
+            OpenOptions::new().write(true).create(true),
+        )
+        .unwrap();
+        drop(file);
+        assert!(root.path().join("new").is_file());
+    }
+
+    #[test]
+    fn atomic_write_replaces_atomically() {
+        let root = td();
+        let target = root.path().join("entry");
+        std::fs::write(&target, b"old").unwrap();
+
+        atomic_write_in_dir(root.path(), OsStr::new("entry"), b"new", None).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"new");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_defaults_to_owner_only_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = td();
+        atomic_write_in_dir(root.path(), OsStr::new("entry"), b"x", None).unwrap();
+        let mode = std::fs::metadata(root.path().join("entry"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_leaves_no_temp_subdirs() {
+        let root = td();
+        atomic_write_in_dir(root.path(), OsStr::new("entry"), b"payload", None).unwrap();
+
+        let entries: Vec<_> = std::fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name())
+            .collect();
+        assert_eq!(entries, vec![std::ffi::OsString::from("entry")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_applies_mode_via_fchmod() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = td();
+        atomic_write_in_dir(root.path(), OsStr::new("entry"), b"x", Some(0o600)).unwrap();
+        let mode = std::fs::metadata(root.path().join("entry"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn helpers_reject_multi_component_names() {
+        // A name containing a separator would re-introduce
+        // path-traversal TOCTOU on intermediate components: cap-std
+        // only NOFOLLOWs the final component, and `renameat`
+        // follows intermediate symlinks on the destination side.
+        // Both entry points must refuse such names.
+        let root = td();
+        let dir = Dir::open_ambient_dir(root.path(), ambient_authority()).unwrap();
+
+        let cases: &[&OsStr] = &[
+            OsStr::new("a/b"),
+            OsStr::new(""),
+            OsStr::new("."),
+            OsStr::new(".."),
+            OsStr::new("./foo"),
+        ];
+        for name in cases {
+            let err = open_no_follow_in(&dir, name, OpenOptions::new().read(true).create(true))
+                .unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput, "open: {name:?}");
+
+            let err = atomic_write_in(&dir, name, b"x", None).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput, "write: {name:?}");
+        }
+    }
+
+    #[test]
+    fn dir_anchored_helpers_share_one_capability() {
+        // Smoke test: open the parent `Dir` once and reuse it for
+        // both an atomic write and a no-follow open. Demonstrates
+        // the intended `*_in` calling pattern and proves the
+        // `Dir` capability survives across helper calls.
+        use std::io::Read;
+        let root = td();
+        let dir = Dir::open_ambient_dir(root.path(), ambient_authority()).unwrap();
+
+        atomic_write_in(&dir, OsStr::new("entry"), b"payload", None).unwrap();
+
+        let mut file =
+            open_no_follow_in(&dir, OsStr::new("entry"), OpenOptions::new().read(true)).unwrap();
+        let mut got = Vec::new();
+        file.read_to_end(&mut got).unwrap();
+        assert_eq!(got, b"payload");
+    }
+
+    #[test]
+    fn validate_accepts_relative_descendant() {
+        let root = Path::new("/cache");
+        let p = validate_relative_inside(root, Path::new("a/b/c")).unwrap();
+        assert_eq!(p, Path::new("/cache/a/b/c"));
+    }
+
+    #[test]
+    fn validate_collapses_curdir() {
+        let root = Path::new("/cache");
+        let p = validate_relative_inside(root, Path::new("./a/./b")).unwrap();
+        assert_eq!(p, Path::new("/cache/a/b"));
+    }
+
+    #[test]
+    fn validate_allows_balanced_parent() {
+        let root = Path::new("/cache");
+        let p = validate_relative_inside(root, Path::new("a/../b")).unwrap();
+        assert_eq!(p, Path::new("/cache/b"));
+    }
+
+    #[test]
+    fn validate_rejects_absolute() {
+        let err =
+            validate_relative_inside(Path::new("/cache"), Path::new("/etc/passwd")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn validate_rejects_escape() {
+        let err =
+            validate_relative_inside(Path::new("/cache"), Path::new("../etc/passwd")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn validate_rejects_deep_escape() {
+        let err =
+            validate_relative_inside(Path::new("/cache"), Path::new("a/b/../../../x")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn validate_rejects_empty() {
+        let err = validate_relative_inside(Path::new("/cache"), Path::new("")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn validate_rejects_curdir_only() {
+        let err = validate_relative_inside(Path::new("/cache"), Path::new(".")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_atomic_write_published_file_is_owner_protected() {
+        let root = td();
+        atomic_write_in_dir(root.path(), OsStr::new("entry"), b"payload", None).unwrap();
+
+        // The file is created via NtCreateFile with an explicit
+        // PROTECTED owner-only SECURITY_DESCRIPTOR, so both the
+        // owner SID and the SE_DACL_PROTECTED bit survive the
+        // rename onto the (potentially permissive) target dir.
+        let file = std::fs::File::open(root.path().join("entry")).unwrap();
+        let owner = super::windows_sec::read_owner_sid(&file).unwrap();
+        let ours = super::windows_sec::owner_sid().unwrap();
+        assert_eq!(owner.as_slice(), ours);
+        assert!(super::windows_sec::dacl_is_protected(&file).unwrap());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_tempdir_dir_is_owner_protected() {
+        // The tempdir is the load-bearing object: its
+        // SE_DACL_PROTECTED bit is what stops the parent's
+        // ambient ACEs from leaking into the payload's
+        // inheritance chain. If this assertion regresses, the
+        // whole crate's Windows TOCTOU model is undermined.
+        let root = td();
+        let parent = Dir::open_ambient_dir(root.path(), ambient_authority()).unwrap();
+        let tmp = TempDir::new_in(&parent, "test-", &DirBuilder::new()).unwrap();
+
+        let owner = super::windows_sec::read_owner_sid(&*tmp).unwrap();
+        let ours = super::windows_sec::owner_sid().unwrap();
+        assert_eq!(owner.as_slice(), ours);
+
+        assert!(super::windows_sec::dacl_is_protected(&*tmp).unwrap());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_is_symlink_refusal_matches_reparse_codes() {
+        use windows_sys::Win32::Foundation::{ERROR_CANT_ACCESS_FILE, ERROR_STOPPED_ON_SYMLINK};
+        assert!(super::windows_sec::is_symlink_refusal(
+            &io::Error::from_raw_os_error(ERROR_STOPPED_ON_SYMLINK as i32)
+        ));
+        assert!(super::windows_sec::is_symlink_refusal(
+            &io::Error::from_raw_os_error(ERROR_CANT_ACCESS_FILE as i32)
+        ));
+        assert!(!super::windows_sec::is_symlink_refusal(&io::Error::from(
+            io::ErrorKind::NotFound
+        )));
+    }
+}

--- a/crates/rattler_fs_safety/src/windows_sec.rs
+++ b/crates/rattler_fs_safety/src/windows_sec.rs
@@ -1,0 +1,592 @@
+//! Windows security primitives that back the platform-portable
+//! helpers in [`crate`]. Provides the analogues of the Unix
+//! `openat`+`mkdir 0o700` atomic creation and `geteuid()`-based
+//! ownership check.
+//!
+//! Four building blocks:
+//!
+//! * [`owner_sid`] -- process-cached current-user SID, drawn once
+//!   from the access token via `OpenProcessToken` +
+//!   `GetTokenInformation(TokenUser)`.
+//! * [`create_owner_only_subdir`] -- fd-anchored atomic mkdir
+//!   relative to a parent `Dir`'s handle, with a `PROTECTED` DACL
+//!   granting only the current user. Implemented through
+//!   `NtCreateFile` with `OBJECT_ATTRIBUTES.RootDirectory` set to
+//!   the parent and an explicit `SECURITY_DESCRIPTOR` -- there is
+//!   no Win32 equivalent, but `NtCreateFile` is stable.
+//! * [`rename_via_handle`] -- fd-anchored rename using
+//!   `SetFileInformationByHandle(FileRenameInfoEx)` with
+//!   `RootDirectory` set to the destination directory's handle.
+//!   No path resolution happens; the destination name is single-
+//!   component (enforced upstream).
+//! * [`verify_owner`] -- defence-in-depth check that the kernel
+//!   honoured our requested owner SID on the freshly-created
+//!   directory. Useful on filesystems that don't support
+//!   security descriptors (FAT) and as a backstop against future
+//!   kernel/cap-std changes.
+//!
+//! Why this design closes the remaining TOCTOU windows:
+//! `NtCreateFile` with `RootDirectory` is the only way to do a
+//! true fd-anchored `mkdirat`/`openat` on Windows -- every Win32
+//! `CreateFileW` / `CreateDirectoryW` path goes through fresh
+//! name resolution. By passing the parent handle in
+//! `OBJECT_ATTRIBUTES.RootDirectory` and supplying the security
+//! descriptor in the same call, the create is atomic with respect
+//! to both placement (no intermediate-component race) and
+//! permissions (no inherit-then-harden window).
+
+use std::ffi::OsStr;
+use std::io;
+use std::mem::{size_of, MaybeUninit};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::ptr;
+use std::sync::OnceLock;
+
+use cap_std::fs::Dir;
+use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
+use windows_sys::Wdk::Storage::FileSystem::{
+    NtCreateFile, FILE_CREATE, FILE_DIRECTORY_FILE, FILE_NON_DIRECTORY_FILE,
+    FILE_OPEN_REPARSE_POINT, FILE_SYNCHRONOUS_IO_NONALERT,
+};
+use windows_sys::Win32::Foundation::{
+    LocalFree, RtlNtStatusToDosError, ERROR_CANT_ACCESS_FILE, ERROR_INSUFFICIENT_BUFFER,
+    ERROR_STOPPED_ON_SYMLINK, GENERIC_READ, HANDLE, NTSTATUS, OBJ_CASE_INSENSITIVE, STATUS_SUCCESS,
+    UNICODE_STRING,
+};
+use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT};
+use windows_sys::Win32::Security::{
+    AddAccessAllowedAceEx, CopySid, EqualSid, GetLengthSid, GetTokenInformation, InitializeAcl,
+    IsValidSid, TokenUser, ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, CONTAINER_INHERIT_ACE,
+    OBJECT_INHERIT_ACE, OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID,
+    SECURITY_DESCRIPTOR, SE_DACL_PRESENT, SE_DACL_PROTECTED, TOKEN_QUERY, TOKEN_USER,
+};
+#[cfg(test)]
+use windows_sys::Win32::Security::{GetSecurityDescriptorControl, DACL_SECURITY_INFORMATION};
+use windows_sys::Win32::Storage::FileSystem::{
+    FileRenameInfoEx, SetFileInformationByHandle, DELETE, FILE_GENERIC_WRITE, FILE_RENAME_INFO,
+    FILE_SHARE_READ, FILE_SHARE_WRITE,
+};
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
+
+/// Access mask used when opening the payload file via
+/// [`create_owner_only_file`]. `FILE_GENERIC_WRITE` lets us write
+/// the bytes; `DELETE` is required so the fd-anchored
+/// [`rename_via_handle`] can publish the file without reopening.
+const PAYLOAD_ACCESS_MASK: u32 = FILE_GENERIC_WRITE | DELETE;
+
+/// `FILE_ALL_ACCESS` = `STANDARD_RIGHTS_ALL | SYNCHRONIZE | 0x1FF`.
+/// Hardcoded to avoid pulling in another windows-sys constant
+/// just for the ACE rights mask.
+const FILE_ALL_ACCESS: u32 = 0x001F_01FF;
+
+/// `SECURITY_DESCRIPTOR_REVISION = 1`. Hardcoded to avoid pulling
+/// in the `Win32_System_SystemServices` feature for a single
+/// constant whose value has been stable since Windows NT 3.1.
+const SECURITY_DESCRIPTOR_REVISION_1: u8 = 1;
+
+/// `FILE_RENAME_FLAG_REPLACE_IF_EXISTS | FILE_RENAME_FLAG_POSIX_SEMANTICS`.
+/// POSIX semantics make the rename atomic with respect to other
+/// handles on the destination (matches what `renameat` does on
+/// Unix). Hardcoded to avoid the `Win32_System_WindowsProgramming`
+/// feature.
+const FILE_RENAME_FLAGS: u32 = 0x1 | 0x2;
+
+/// Process-cached owner SID. Returns a slice valid for the
+/// remaining process lifetime.
+pub(crate) fn owner_sid() -> io::Result<&'static [u8]> {
+    static SID: OnceLock<Vec<u8>> = OnceLock::new();
+    if let Some(sid) = SID.get() {
+        return Ok(sid.as_slice());
+    }
+    let sid = compute_owner_sid()?;
+    // If another thread won the race the freshly-computed `sid`
+    // is dropped and we return the winner's. Both SIDs must be
+    // equal for the current process, so this is harmless.
+    Ok(SID.get_or_init(|| sid).as_slice())
+}
+
+fn compute_owner_sid() -> io::Result<Vec<u8>> {
+    // SAFETY: GetCurrentProcess returns a pseudo-handle that does
+    // not need to be closed.
+    let proc_handle = unsafe { GetCurrentProcess() };
+
+    let mut raw_token: HANDLE = ptr::null_mut();
+    // SAFETY: proc_handle is the current-process pseudo-handle;
+    // raw_token is a valid out-pointer.
+    let ok = unsafe { OpenProcessToken(proc_handle, TOKEN_QUERY, &mut raw_token) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: OpenProcessToken returned a real handle we now own.
+    let token = unsafe { OwnedHandle::from_raw_handle(raw_token.cast()) };
+    let token_handle = token.as_raw_handle() as HANDLE;
+
+    // Size-discovery probe: a zero-length buffer is documented to
+    // fail with ERROR_INSUFFICIENT_BUFFER and write the required
+    // length to `needed`.
+    let mut needed: u32 = 0;
+    // SAFETY: token_handle is a valid token handle from above;
+    // null+0 is the documented size-discovery form; `needed` is a
+    // valid out-pointer.
+    let probe =
+        unsafe { GetTokenInformation(token_handle, TokenUser, ptr::null_mut(), 0, &mut needed) };
+    if probe != 0 {
+        return Err(io::Error::other(
+            "GetTokenInformation unexpectedly succeeded with zero buffer",
+        ));
+    }
+    let probe_err = io::Error::last_os_error();
+    if probe_err.raw_os_error() != Some(ERROR_INSUFFICIENT_BUFFER as i32) {
+        return Err(probe_err);
+    }
+
+    let mut buf = vec![0u8; needed as usize];
+    // SAFETY: buf is `needed` bytes long; `needed` was set by the
+    // probe above.
+    let ok = unsafe {
+        GetTokenInformation(
+            token_handle,
+            TokenUser,
+            buf.as_mut_ptr().cast(),
+            needed,
+            &mut needed,
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // SAFETY: GetTokenInformation succeeded, so the start of buf
+    // holds a valid TOKEN_USER.
+    let token_user = unsafe { &*buf.as_ptr().cast::<TOKEN_USER>() };
+    let sid = token_user.User.Sid;
+
+    // SAFETY: sid was provided by the kernel inside `buf`.
+    if unsafe { IsValidSid(sid) } == 0 {
+        return Err(io::Error::other("token user SID is invalid"));
+    }
+    // SAFETY: sid was just validated.
+    let sid_len = unsafe { GetLengthSid(sid) } as usize;
+    let mut out = vec![0u8; sid_len];
+    // SAFETY: out is sid_len bytes long; CopySid writes at most
+    // that many bytes into a valid SID-shaped buffer.
+    let ok = unsafe { CopySid(sid_len as u32, out.as_mut_ptr().cast(), sid) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(out)
+}
+
+/// fd-anchored atomic mkdir. Creates a directory named `name`
+/// inside `parent`'s handle with a `PROTECTED` DACL whose ACE is
+/// inheritable, so any file created inside it later (via
+/// [`create_owner_only_file`]) starts with the same locked-down
+/// access. The kernel applies the security descriptor as part of
+/// the create call -- there is no inherit-then-harden window.
+///
+/// `FILE_CREATE` is exclusive: if anything exists at `name`
+/// (file, dir, symlink, junction), the call fails.
+/// `FILE_OPEN_REPARSE_POINT` is set defensively so that any
+/// reparse point that does appear there is opened as the link
+/// itself rather than followed -- combined with `FILE_CREATE` it
+/// means we either succeed atomically or return an error; we
+/// never silently traverse an attacker reparse point.
+pub(crate) fn create_owner_only_subdir(parent: &Dir, name: &OsStr) -> io::Result<Dir> {
+    let handle = create_owner_only_object(
+        parent,
+        name,
+        GENERIC_READ | DELETE,
+        FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT,
+        OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE,
+    )?;
+    // SAFETY: NtCreateFile returned a valid HANDLE we now own.
+    let std_file = unsafe { std::fs::File::from_raw_handle(handle.cast()) };
+    Ok(Dir::from_std_file(std_file))
+}
+
+/// fd-anchored atomic file create. Same model as
+/// [`create_owner_only_subdir`] but for a regular file: the file
+/// is created inside `parent`'s handle with `FILE_CREATE` (no
+/// overwrite) and a `PROTECTED` DACL granting only the current
+/// user. The access mask is [`PAYLOAD_ACCESS_MASK`] so the
+/// caller can write bytes and rename via [`rename_via_handle`]
+/// without reopening.
+///
+/// Returns a [`std::fs::File`] rather than a `cap_std::fs::File`
+/// because the caller (`atomic_write_in`) only needs `Write` /
+/// `sync_all` / `AsRawHandle` on it, and going through cap-std
+/// would re-introduce a path-based open.
+pub(crate) fn create_owner_only_file(parent: &Dir, name: &OsStr) -> io::Result<std::fs::File> {
+    let handle = create_owner_only_object(
+        parent,
+        name,
+        PAYLOAD_ACCESS_MASK,
+        FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT,
+        // No inheritance flags: files have no children, so the
+        // ACE flags are 0. The DACL is still `PROTECTED`, which
+        // is what locks down the file regardless of what the
+        // (post-rename) parent's ambient ACL looks like.
+        0,
+    )?;
+    // SAFETY: NtCreateFile returned a valid HANDLE we now own.
+    Ok(unsafe { std::fs::File::from_raw_handle(handle.cast()) })
+}
+
+/// Shared `NtCreateFile`-with-`FILE_CREATE` body for the
+/// directory and file helpers above. Builds a `PROTECTED`
+/// owner-only `SECURITY_DESCRIPTOR` whose single allow-ACE
+/// carries `ace_flags` (set to inheritance bits for directories,
+/// `0` for files) and applies it at create time so the new
+/// object's effective DACL is exactly that ACE.
+fn create_owner_only_object(
+    parent: &Dir,
+    name: &OsStr,
+    desired_access: u32,
+    create_options: u32,
+    ace_flags: u32,
+) -> io::Result<HANDLE> {
+    let parent_handle = parent.as_raw_handle() as HANDLE;
+    let sid = owner_sid()?;
+
+    let mut acl = build_owner_only_acl(sid, ace_flags)?;
+    let acl_ptr = acl.as_mut_ptr().cast::<ACL>();
+
+    // Hand-construct the SECURITY_DESCRIPTOR. `SE_DACL_PRESENT`
+    // says the DACL pointer is meaningful; `SE_DACL_PROTECTED`
+    // blocks the default merge-with-parent-inheritable-ACEs that
+    // NT would otherwise do at create time, so the new object's
+    // effective DACL is exactly our one allow-ACE.
+    let sd = SECURITY_DESCRIPTOR {
+        Revision: SECURITY_DESCRIPTOR_REVISION_1,
+        Sbz1: 0,
+        Control: SE_DACL_PRESENT | SE_DACL_PROTECTED,
+        Owner: sid.as_ptr() as PSID,
+        Group: ptr::null_mut(),
+        Sacl: ptr::null_mut(),
+        Dacl: acl_ptr,
+    };
+
+    let wide: Vec<u16> = name.encode_wide().collect();
+    let name_bytes = wide
+        .len()
+        .checked_mul(2)
+        .ok_or_else(|| io::Error::other("name too long"))?;
+    let name_bytes_u16 =
+        u16::try_from(name_bytes).map_err(|_e| io::Error::other("name too long"))?;
+
+    let unicode_name = UNICODE_STRING {
+        Length: name_bytes_u16,
+        MaximumLength: name_bytes_u16,
+        Buffer: wide.as_ptr() as *mut u16,
+    };
+
+    let object_attrs = OBJECT_ATTRIBUTES {
+        Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
+        RootDirectory: parent_handle,
+        ObjectName: &unicode_name,
+        Attributes: OBJ_CASE_INSENSITIVE,
+        SecurityDescriptor: &sd,
+        SecurityQualityOfService: ptr::null(),
+    };
+
+    let mut new_handle: HANDLE = ptr::null_mut();
+    let mut iosb = MaybeUninit::<IO_STATUS_BLOCK>::zeroed();
+
+    // SAFETY: `new_handle` and `iosb` are valid out-pointers;
+    // `object_attrs`, `unicode_name`, `sd`, `acl`, and `wide` all
+    // live through the call. No EA buffer.
+    let status = unsafe {
+        NtCreateFile(
+            &mut new_handle,
+            desired_access,
+            &object_attrs,
+            iosb.as_mut_ptr(),
+            ptr::null(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            FILE_CREATE,
+            create_options,
+            ptr::null(),
+            0,
+        )
+    };
+
+    if status != STATUS_SUCCESS {
+        return Err(nt_status_to_io_error(status));
+    }
+
+    Ok(new_handle)
+}
+
+/// fd-anchored rename. Moves the file behind `src`'s handle to
+/// `dest_name` inside `dest_dir`'s handle. No path resolution:
+/// the destination is identified entirely by the
+/// `dest_dir.HANDLE` + `dest_name` pair, so an attacker who
+/// substitutes the destination directory along its ambient path
+/// cannot redirect the rename. `src` must have been opened with
+/// `DELETE` access (see [`PAYLOAD_ACCESS_MASK`]).
+///
+/// POSIX semantics: if the destination exists, it is replaced
+/// atomically; concurrent handles on the old destination are not
+/// invalidated, matching `renameat` semantics on Unix.
+pub(crate) fn rename_via_handle<S: AsRawHandle>(
+    src: &S,
+    dest_dir: &Dir,
+    dest_name: &OsStr,
+) -> io::Result<()> {
+    let src_handle = src.as_raw_handle() as HANDLE;
+    let dest_handle = dest_dir.as_raw_handle() as HANDLE;
+
+    let wide: Vec<u16> = dest_name.encode_wide().collect();
+    let name_bytes = wide
+        .len()
+        .checked_mul(2)
+        .ok_or_else(|| io::Error::other("rename destination name too long"))?;
+    let name_bytes_u32 = u32::try_from(name_bytes)
+        .map_err(|_e| io::Error::other("rename destination name too long"))?;
+
+    // FILE_RENAME_INFO's `FileName` is a flexible array trailing
+    // a fixed header. The struct as declared reserves 2 bytes for
+    // it; the kernel reads `FileNameLength` bytes starting at the
+    // FileName offset, so the buffer total is
+    // `offset_of(FileName) + name_bytes`.
+    let header_size = std::mem::offset_of!(FILE_RENAME_INFO, FileName);
+    let total = header_size
+        .checked_add(name_bytes)
+        .ok_or_else(|| io::Error::other("rename buffer overflow"))?;
+    let total_u32 =
+        u32::try_from(total).map_err(|_e| io::Error::other("rename buffer too large"))?;
+
+    // Vec<u8> doesn't guarantee enough alignment for HANDLE on
+    // 64-bit. Vec<u64> gives 8-byte alignment which covers every
+    // field of FILE_RENAME_INFO.
+    let qwords = total.div_ceil(size_of::<u64>());
+    let mut buf: Vec<u64> = vec![0; qwords];
+    let info_ptr = buf.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+
+    // SAFETY: `info_ptr` points to `total` zeroed bytes; we
+    // initialise every field before the kernel reads them.
+    unsafe {
+        (*info_ptr).Anonymous.Flags = FILE_RENAME_FLAGS;
+        (*info_ptr).RootDirectory = dest_handle;
+        (*info_ptr).FileNameLength = name_bytes_u32;
+        let filename_dst = (info_ptr.cast::<u8>()).add(header_size).cast::<u16>();
+        ptr::copy_nonoverlapping(wide.as_ptr(), filename_dst, wide.len());
+    }
+
+    // SAFETY: `src_handle` is owned by `src` and has DELETE
+    // access; `info_ptr` points to a fully initialised
+    // FILE_RENAME_INFO sized `total_u32` bytes.
+    let ok = unsafe {
+        SetFileInformationByHandle(src_handle, FileRenameInfoEx, info_ptr.cast(), total_u32)
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Read the kernel object's owner SID via `GetSecurityInfo` and
+/// confirm it matches the current process's token SID. With
+/// [`create_owner_only_subdir`] the kernel sets ownership
+/// atomically at create time, so this is defence-in-depth: it
+/// catches filesystems that ignore security descriptors (FAT) and
+/// any future regression where the kernel/cap-std diverged from
+/// the expected ownership semantics.
+pub(crate) fn verify_owner(dir: &Dir) -> io::Result<()> {
+    let our_sid = owner_sid()?;
+
+    let mut sd: PSECURITY_DESCRIPTOR = ptr::null_mut();
+    let mut owner: PSID = ptr::null_mut();
+    let raw = dir.as_raw_handle() as HANDLE;
+
+    // SAFETY: raw is a valid HANDLE owned by `dir`; the
+    // out-pointers are valid; the descriptor allocated by
+    // GetSecurityInfo is released by SecurityDescriptorGuard.
+    let rc = unsafe {
+        GetSecurityInfo(
+            raw,
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION,
+            &mut owner,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut sd,
+        )
+    };
+    let _guard = SecurityDescriptorGuard(sd);
+    if rc != 0 {
+        return Err(io::Error::from_raw_os_error(rc as i32));
+    }
+
+    // SAFETY: `owner` was populated by GetSecurityInfo and points
+    // into the descriptor held by `_guard`; `our_sid` is the
+    // cached process SID.
+    let equal = unsafe { EqualSid(owner, our_sid.as_ptr() as PSID) } != 0;
+    if !equal {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "directory ownership does not match current process",
+        ));
+    }
+    Ok(())
+}
+
+/// Build an ACL with a single allow-ACE for `sid` carrying
+/// `ace_flags`. Callers pass `OBJECT_INHERIT_ACE |
+/// CONTAINER_INHERIT_ACE` for directories whose ACE should
+/// propagate to children, or `0` for files (which have no
+/// children and therefore no use for inheritance flags).
+fn build_owner_only_acl(sid: &[u8], ace_flags: u32) -> io::Result<Vec<u8>> {
+    if sid.len() < size_of::<u32>() {
+        return Err(io::Error::other("owner SID too small"));
+    }
+    let ace_size = size_of::<ACCESS_ALLOWED_ACE>() + sid.len() - size_of::<u32>();
+    let acl_size = size_of::<ACL>() + ace_size;
+    let acl_size_u32 =
+        u32::try_from(acl_size).map_err(|_e| io::Error::other("computed ACL size exceeds u32"))?;
+
+    let mut buf = vec![0u8; acl_size];
+    let acl_ptr = buf.as_mut_ptr().cast::<ACL>();
+
+    // SAFETY: buf is `acl_size` bytes long; ACL_REVISION is the
+    // documented revision constant.
+    let ok = unsafe { InitializeAcl(acl_ptr, acl_size_u32, ACL_REVISION) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // SAFETY: `acl_ptr` is a freshly initialised ACL with room
+    // for one ACE referencing a SID of `sid.len()` bytes; `sid`
+    // points to a validated SID.
+    let ok = unsafe {
+        AddAccessAllowedAceEx(
+            acl_ptr,
+            ACL_REVISION,
+            ace_flags,
+            FILE_ALL_ACCESS,
+            sid.as_ptr() as PSID,
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(buf)
+}
+
+/// Convert an `NTSTATUS` value to an [`io::Error`] by routing
+/// through `RtlNtStatusToDosError`. This gives callers a
+/// recognisable Win32 error kind (e.g. `AlreadyExists` for
+/// `STATUS_OBJECT_NAME_COLLISION`) without each call site having
+/// to know the NT codes.
+fn nt_status_to_io_error(status: NTSTATUS) -> io::Error {
+    // SAFETY: RtlNtStatusToDosError is a pure function; no
+    // pointer arguments.
+    let win32 = unsafe { RtlNtStatusToDosError(status) };
+    io::Error::from_raw_os_error(win32 as i32)
+}
+
+/// True if `err` is the Windows kernel reporting that a final
+/// reparse point (symlink/junction) was refused. The exact
+/// surface varies across configurations, so we match the two
+/// reparse-specific codes and let everything else fall through
+/// unchanged.
+pub(crate) fn is_symlink_refusal(err: &io::Error) -> bool {
+    matches!(
+        err.raw_os_error(),
+        Some(code)
+            if code as u32 == ERROR_STOPPED_ON_SYMLINK
+                || code as u32 == ERROR_CANT_ACCESS_FILE
+    )
+}
+
+/// `LocalFree`s the `PSECURITY_DESCRIPTOR` returned by
+/// `GetSecurityInfo` on drop.
+struct SecurityDescriptorGuard(PSECURITY_DESCRIPTOR);
+
+impl Drop for SecurityDescriptorGuard {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            // SAFETY: pointer was allocated by GetSecurityInfo
+            // via LocalAlloc.
+            unsafe { LocalFree(self.0.cast()) };
+        }
+    }
+}
+
+/// Read the owner SID of the file or directory behind `handle`.
+/// Test-only inspector; production code uses [`verify_owner`]
+/// which compares without copying.
+#[cfg(test)]
+pub(crate) fn read_owner_sid<H: AsRawHandle>(handle: &H) -> io::Result<Vec<u8>> {
+    let raw = handle.as_raw_handle() as HANDLE;
+    let mut sd: PSECURITY_DESCRIPTOR = ptr::null_mut();
+    let mut owner: PSID = ptr::null_mut();
+    // SAFETY: same contract as `verify_owner`.
+    let rc = unsafe {
+        GetSecurityInfo(
+            raw,
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION,
+            &mut owner,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut sd,
+        )
+    };
+    let _guard = SecurityDescriptorGuard(sd);
+    if rc != 0 {
+        return Err(io::Error::from_raw_os_error(rc as i32));
+    }
+    // SAFETY: `owner` was populated by GetSecurityInfo and is
+    // valid for the duration of `_guard`.
+    let len = unsafe { GetLengthSid(owner) } as usize;
+    let mut out = vec![0u8; len];
+    // SAFETY: `out` is `len` bytes long; `owner` is a valid SID.
+    let ok = unsafe { CopySid(len as u32, out.as_mut_ptr().cast(), owner) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(out)
+}
+
+/// True if the DACL on `handle`'s object has the
+/// `SE_DACL_PROTECTED` control bit set (i.e. no inheritable ACEs
+/// from the parent apply). Test-only.
+#[cfg(test)]
+pub(crate) fn dacl_is_protected<H: AsRawHandle>(handle: &H) -> io::Result<bool> {
+    let raw = handle.as_raw_handle() as HANDLE;
+    let mut sd: PSECURITY_DESCRIPTOR = ptr::null_mut();
+    // SAFETY: out-pointers are valid; descriptor allocated by the
+    // kernel is freed by `_guard`.
+    let rc = unsafe {
+        GetSecurityInfo(
+            raw,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut sd,
+        )
+    };
+    let _guard = SecurityDescriptorGuard(sd);
+    if rc != 0 {
+        return Err(io::Error::from_raw_os_error(rc as i32));
+    }
+    let mut control: u16 = 0;
+    let mut revision: u32 = 0;
+    // SAFETY: sd is valid for the duration of `_guard`; both
+    // out-pointers are valid.
+    let ok = unsafe { GetSecurityDescriptorControl(sd, &mut control, &mut revision) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok((control & SE_DACL_PROTECTED) != 0)
+}

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -17,6 +17,7 @@ indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 rattler_conda_types = { workspace = true, default-features = false }
 rattler_digest = { workspace = true, default-features = false }
+rattler_fs_safety = { workspace = true }
 rattler_solve = { workspace = true, default-features = false, features = ["serde"] }
 file_url = { workspace = true }
 pep508_rs = { workspace = true }

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -604,10 +604,18 @@ impl LockFile {
         parse::from_str_with_base_directory(source, base_dir)
     }
 
-    /// Writes the conda lock to a file
+    /// Writes the conda lock to a file via a temporary-file +
+    /// rename, so a concurrent reader never sees a torn YAML
+    /// document.
     pub fn to_path(&self, path: &Path) -> Result<(), std::io::Error> {
-        let file = std::fs::File::create(path)?;
-        serde_yaml::to_writer(file, self).map_err(std::io::Error::other)
+        let parent = path
+            .parent()
+            .ok_or_else(|| std::io::Error::other("lockfile path has no parent"))?;
+        let name = path
+            .file_name()
+            .ok_or_else(|| std::io::Error::other("lockfile path has no final component"))?;
+        let bytes = serde_yaml::to_string(self).map_err(std::io::Error::other)?;
+        rattler_fs_safety::atomic_write_in_dir(parent, name, bytes.as_bytes(), None)
     }
 
     /// Writes the conda lock to a string

--- a/crates/rattler_prefix_guard/Cargo.toml
+++ b/crates/rattler_prefix_guard/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 
 [dependencies]
 fs-err = { workspace = true, features = ["tokio"] }
+rattler_fs_safety = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "rt"] }
@@ -23,3 +24,7 @@ windows-sys = { workspace = true, features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
 ] }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/rattler_prefix_guard/src/lib.rs
+++ b/crates/rattler_prefix_guard/src/lib.rs
@@ -5,15 +5,17 @@
 //!
 //! Under MIT license.
 
-use std::fs::{File, OpenOptions};
+use std::ffi::OsStr;
+use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
+use rattler_fs_safety::{open_no_follow, OpenOptions};
 use serde::{Deserialize, Serialize};
 
 pub use sys::{lock_exclusive, try_lock_exclusive, unlock};
 
-const GUARD_PATH: &str = ".guard";
+const GUARD_FILE: &str = ".guard";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -118,34 +120,43 @@ impl Drop for AsyncWriteGuard {
 }
 
 pub struct AsyncPrefixGuard {
-    guard_path: PathBuf,
+    prefix: PathBuf,
 }
 
 impl AsyncPrefixGuard {
     /// Constructs a new guard for the given prefix but does not perform any
     /// locking operations yet.
     pub async fn new(prefix: &Path) -> io::Result<Self> {
-        let guard_path = prefix.join(GUARD_PATH);
+        // Ensure that the prefix directory exists; the guard file
+        // itself is created (atomically, with NOFOLLOW) when
+        // `write` is called.
+        fs_err::tokio::create_dir_all(prefix).await?;
 
-        // Ensure that the directory exists
-        fs_err::tokio::create_dir_all(guard_path.parent().unwrap()).await?;
-
-        Ok(Self { guard_path })
+        Ok(Self {
+            prefix: prefix.to_path_buf(),
+        })
     }
 
     /// Locks the guard for writing and returns a write guard which can be used
     /// to unlock it.
     pub async fn write(self) -> io::Result<AsyncWriteGuard> {
-        let guard_path = self.guard_path.clone();
+        let prefix = self.prefix;
 
-        // Open the file and acquire the lock (in a blocking task)
+        // Open the file and acquire the lock (in a blocking task).
+        // `open_no_follow` refuses to follow a symlink at the
+        // final component, so a co-tenant on a shared cache root
+        // can't redirect this open at e.g. `~/.bashrc`.
         let file = tokio::task::spawn_blocking(move || -> io::Result<File> {
-            let file = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create(true)
-                .truncate(false)
-                .open(&guard_path)?;
+            let cap_file = open_no_follow(
+                &prefix,
+                OsStr::new(GUARD_FILE),
+                OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false),
+            )?;
+            let file = cap_file.into_std();
 
             lock_exclusive(&file)?;
 
@@ -295,5 +306,28 @@ mod sys {
                 Ok(())
             }
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// A co-tenant who plants `<prefix>/.guard` as a symlink to a
+    /// sensitive file (here: a victim file in another tempdir) must
+    /// not be able to redirect the guard's truncate-on-write at it.
+    #[tokio::test]
+    async fn write_refuses_symlinked_guard_file() {
+        let prefix_dir = tempfile::tempdir().unwrap();
+        let victim_dir = tempfile::tempdir().unwrap();
+        let victim = victim_dir.path().join("victim");
+        std::fs::write(&victim, b"keep").unwrap();
+
+        std::os::unix::fs::symlink(&victim, prefix_dir.path().join(GUARD_FILE)).unwrap();
+
+        let guard = AsyncPrefixGuard::new(prefix_dir.path()).await.unwrap();
+        let err = guard.write().await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied, "{err}");
+        assert_eq!(std::fs::read(&victim).unwrap(), b"keep");
     }
 }


### PR DESCRIPTION
### Description

I want to get to a point where I can share package caches between users. For that the backend code needs to be more hardened to all kinds of mischief people can come up with.

Here is a first round of TOCTOU and similar issues in Claude found in rattler, trying to close the window where an attacker could potentially sneak in a symlink into unexpected places or get a file descriptor to something that will then get more restrictive permissions applied.

The biggest addition is a rattler_fs_safety crate that tries to have some common and safe filesystem helpers.

The rest is pretty small and and self-contained changes, often using rattler_safe_fs.

### How Has This Been Tested?

Tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.