### PR TITLE
feat(lock): store binary conda package locations verbatim

### DIFF
--- a/crates/rattler_lock/src/builder.rs
+++ b/crates/rattler_lock/src/builder.rs
@@ -126,7 +126,7 @@ struct UniqueBinaryIdentifier {
 impl<'a> From<&'a CondaBinaryData> for UniqueBinaryIdentifier {
     fn from(data: &'a CondaBinaryData) -> Self {
         Self {
-            location: data.location.clone(),
+            location: data.location.inner().clone(),
             normalized_name: data.package_record.name.as_normalized().to_string(),
             version: data.package_record.version.version().clone(),
             build: data.package_record.build.clone(),
@@ -1228,7 +1228,8 @@ mod test {
                 package_record: record,
                 location: UrlOrPath::Path(Utf8TypedPathBuf::from(format!(
                     "./{name}-1.0.0-build0.tar.bz2"
-                ))),
+                )))
+                .into(),
                 file_name: format!("{name}-1.0.0-build0.tar.bz2")
                     .parse::<DistArchiveIdentifier>()
                     .unwrap(),

--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use typed_path::Utf8TypedPathBuf;
 use url::Url;
 
-use crate::{SourceData, UrlOrPath, source::SourceLocation};
+use crate::{SourceData, UrlOrPath, Verbatim, source::SourceLocation};
 
 /// Represents a conda-build variant value.
 ///
@@ -90,7 +90,7 @@ impl CondaPackageData {
     /// Returns the location of the package.
     pub fn location(&self) -> &UrlOrPath {
         match self {
-            Self::Binary(data) => &data.location,
+            Self::Binary(data) => data.location.inner(),
             Self::Source(data) => &data.location,
         }
     }
@@ -168,7 +168,12 @@ pub struct CondaBinaryData {
     pub package_record: PackageRecord,
 
     /// The location of the package. This can be a URL or a local path.
-    pub location: UrlOrPath,
+    ///
+    /// Stored verbatim so a relative path round-trips through the lock file:
+    /// the `given` string is what was written on disk, while the inner value
+    /// is left relative for the consumer to resolve against the lock file's
+    /// base directory.
+    pub location: Verbatim<UrlOrPath>,
 
     /// The filename of the package.
     pub file_name: DistArchiveIdentifier,
@@ -589,8 +594,14 @@ impl From<RepoDataRecord> for CondaPackageData {
                 .channel
                 .and_then(|channel| Url::parse(&channel).ok())
                 .map(Into::into),
-            location,
+            location: Verbatim::new(location),
         }))
+    }
+}
+
+impl From<Url> for Verbatim<UrlOrPath> {
+    fn from(url: Url) -> Self {
+        Verbatim::new(UrlOrPath::from(url))
     }
 }
 

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -207,7 +207,11 @@ impl SelectorId {
     pub(crate) fn new(package: &LockedPackage) -> Self {
         match package {
             LockedPackage::Conda(CondaPackageData::Binary(data)) => {
-                Self::from_parts(SelectorKind::CondaBinary, data.location.as_str())
+                let location = data
+                    .location
+                    .given()
+                    .unwrap_or_else(|| data.location.inner().as_str());
+                Self::from_parts(SelectorKind::CondaBinary, location)
             }
             LockedPackage::Conda(CondaPackageData::Source(data)) => Self::from_parts(
                 SelectorKind::CondaSource,
@@ -1720,6 +1724,84 @@ packages:
                 package_pypi_keys.contains(selector_key),
                 "environment selector `pypi: {selector_key}` has no matching \
                  entry in the packages section (available: {package_pypi_keys:?})"
+            );
+        }
+
+        let reparsed = LockFile::from_str_with_base_directory(&rendered, Some(&base_dir)).unwrap();
+        let rerendered = reparsed.render_to_string().unwrap();
+        similar_asserts::assert_eq!(rendered, rerendered);
+    }
+
+    /// Verify that a binary conda package served from a local channel keeps a
+    /// relative `conda:` path verbatim across a roundtrip, and that the
+    /// environment selector still matches the `conda:` key in the packages
+    /// section. Regression coverage for prefix-dev/pixi#6322.
+    #[test]
+    fn test_relative_binary_conda_path_roundtrip() {
+        let lock_file_str = "\
+version: 7
+platforms:
+  - name: linux-64
+environments:
+  default:
+    channels:
+      - url: ../local-channel
+    packages:
+      linux-64:
+        - conda: ../local-channel/linux-64/my-dep-0.1.0-h0.conda
+packages:
+  - conda: ../local-channel/linux-64/my-dep-0.1.0-h0.conda
+    name: my-dep
+    version: 0.1.0
+    build: h0
+    subdir: linux-64
+";
+        let base_dir = test_path();
+        let lock_file =
+            LockFile::from_str_with_base_directory(lock_file_str, Some(&base_dir)).unwrap();
+
+        let platform = lock_file.platform("linux-64").unwrap();
+        let env = lock_file.environment(DEFAULT_ENVIRONMENT_NAME).unwrap();
+        let binary = env
+            .packages(platform)
+            .unwrap()
+            .filter_map(LockedPackage::as_conda)
+            .find_map(crate::CondaPackageData::as_binary)
+            .expect("binary conda package");
+
+        let relative = "../local-channel/linux-64/my-dep-0.1.0-h0.conda";
+        assert_eq!(
+            binary.location.given(),
+            Some(relative),
+            "relative binary conda path should be preserved verbatim"
+        );
+        assert!(
+            matches!(binary.location.inner(), crate::UrlOrPath::Path(path) if !path.is_absolute()),
+            "inner location should stay a relative path until the consumer resolves it"
+        );
+
+        // The environment selector `conda:` key must match the packages key,
+        // otherwise the package can't be located on reparse.
+        let rendered = lock_file.render_to_string().unwrap();
+        let yaml: serde_yaml::Value = serde_yaml::from_str(&rendered).unwrap();
+        let package_keys: std::collections::HashSet<&str> = yaml["packages"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .filter_map(|pkg| pkg["conda"].as_str())
+            .collect();
+        let selector_keys: Vec<&str> = yaml["environments"]["default"]["packages"]["linux-64"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .filter_map(|sel| sel["conda"].as_str())
+            .collect();
+        assert_eq!(selector_keys, vec![relative]);
+        for key in &selector_keys {
+            assert!(
+                package_keys.contains(key),
+                "environment selector `conda: {key}` has no matching packages entry \
+                 (available: {package_keys:?})"
             );
         }
 

--- a/crates/rattler_lock/src/parse/models/legacy.rs
+++ b/crates/rattler_lock/src/parse/models/legacy.rs
@@ -149,7 +149,7 @@ impl From<LegacyCondaPackageData> for CondaPackageData {
                     .expect("This file name must be valid here");
                 CondaPackageData::Binary(Box::new(CondaBinaryData {
                     package_record: data.package_record,
-                    location: data.location,
+                    location: crate::Verbatim::new(data.location),
                     file_name: file_id,
                     channel: data.channel,
                 }))

--- a/crates/rattler_lock/src/parse/models/v7/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/conda_package_data.rs
@@ -14,7 +14,7 @@ use serde_with::serde_as;
 use url::Url;
 
 use crate::{
-    CondaPackageData, ConversionError, UrlOrPath, VariantValue,
+    CondaPackageData, ConversionError, UrlOrPath, VariantValue, Verbatim,
     conda::CondaBinaryData,
     utils::derived_fields::{self, LocationDerivedFields},
 };
@@ -50,8 +50,12 @@ fn skip_variant_serialization(input: &Option<Cow<'_, BTreeMap<String, VariantVal
 #[derive(Serialize, Deserialize, Eq, PartialEq)]
 pub(crate) struct CondaPackageDataModel<'a> {
     /// The location of the package. This can be a URL or a path.
+    ///
+    /// Stored verbatim so a relative path round-trips: the `given` string is
+    /// re-emitted on serialization, while the inner value is left for the
+    /// consumer to resolve against the lock file's base directory.
     #[serde(rename = "conda")]
-    pub location: UrlOrPath,
+    pub location: Cow<'a, Verbatim<UrlOrPath>>,
 
     // Unique identifiers go to the top
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -134,7 +138,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaBinaryData {
     type Error = ConversionError;
 
     fn try_from(value: CondaPackageDataModel<'a>) -> Result<Self, Self::Error> {
-        let derived = LocationDerivedFields::new(&value.location);
+        let derived = LocationDerivedFields::new(value.location.inner());
         let build = value
             .build
             .map(Cow::into_owned)
@@ -199,6 +203,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaBinaryData {
         // Binary packages require a valid archive filename
         if value
             .location
+            .inner()
             .file_name()
             .is_none_or(|name| DistArchiveIdentifier::try_from_filename(name).is_none())
         {
@@ -216,7 +221,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaBinaryData {
         }?;
 
         Ok(CondaBinaryData {
-            location: value.location,
+            location: value.location.into_owned(),
             file_name,
             channel: value
                 .channel
@@ -239,7 +244,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaPackageData {
 impl<'a> From<&'a CondaBinaryData> for CondaPackageDataModel<'a> {
     fn from(value: &'a CondaBinaryData) -> Self {
         let package_record = &value.package_record;
-        let derived = LocationDerivedFields::new(&value.location);
+        let derived = LocationDerivedFields::new(value.location.inner());
         let derived_build_number =
             derived_fields::derive_build_number_from_build(&package_record.build).unwrap_or(0);
         let derived_noarch = derived_fields::derive_noarch_type(
@@ -254,7 +259,7 @@ impl<'a> From<&'a CondaBinaryData> for CondaPackageDataModel<'a> {
             .map(Cow::into_owned);
 
         Self {
-            location: value.location.clone(),
+            location: Cow::Borrowed(&value.location),
             name: (Some(package_record.name.as_source())
                 != derived.name.as_ref().map(PackageName::as_source))
             .then_some(Cow::Borrowed(&package_record.name)),


### PR DESCRIPTION
Change CondaBinaryData.location to Verbatim so a relative 'conda:' path round-trips through the lock file.

Relates to: prefix-dev/pixi#6322

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added sufficient tests to cover my changes.