### PR TITLE
feat: Implement indexed_timestamp field for package records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5094,6 +5094,7 @@ dependencies = [
  "rattler_conda_types",
  "serde",
  "serde_json",
+ "strum",
  "tempfile",
  "thiserror 2.0.18",
  "toml",

--- a/crates/rattler_conda_types/src/minimal_prefix_record.rs
+++ b/crates/rattler_conda_types/src/minimal_prefix_record.rs
@@ -236,6 +236,7 @@ impl MinimalPrefixRecord {
             constrains: Vec::new(),
             features: None,
             flags: Vec::new(),
+            indexed_timestamp: None,
             legacy_bz2_size: None,
             license: None,
             license_family: None,

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -448,7 +448,7 @@ pub struct PackageRecord {
 
     /// The time at which an indexing tool first added this artifact to the
     /// channel index. Set by indexing tools, never by build tools.
-    /// See <https://github.com/conda/ceps/pull/154>.
+    /// See the draft CEP: <https://github.com/conda/ceps/pull/154>.
     pub indexed_timestamp: Option<crate::utils::TimestampMs>,
 
     /// A deprecated md5 hash
@@ -1144,7 +1144,7 @@ mod test {
         insta::assert_snapshot!(json);
     }
 
-    // See https://github.com/conda/ceps/pull/154
+    // See the draft CEP: https://github.com/conda/ceps/pull/154
     #[test]
     fn test_indexed_timestamp_roundtrip() {
         // A record with `indexed_timestamp` round-trips through JSON.

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -446,6 +446,11 @@ pub struct PackageRecord {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub flags: Vec<Flag>,
 
+    /// The time at which an indexing tool first added this artifact to the
+    /// channel index. Set by indexing tools, never by build tools.
+    /// See <https://github.com/conda/ceps/pull/154>.
+    pub indexed_timestamp: Option<crate::utils::TimestampMs>,
+
     /// A deprecated md5 hash
     #[serde_as(as = "Option<SerializableHash::<rattler_digest::Md5>>")]
     pub legacy_bz2_md5: Option<Md5Hash>,
@@ -790,6 +795,7 @@ impl PackageRecord {
             depends: vec![],
             features: None,
             flags: vec![],
+            indexed_timestamp: None,
             legacy_bz2_md5: None,
             legacy_bz2_size: None,
             license: None,
@@ -1051,6 +1057,7 @@ impl PackageRecord {
             depends: index.depends,
             features: index.features,
             flags: index.flags,
+            indexed_timestamp: None,
             legacy_bz2_md5: None,
             legacy_bz2_size: None,
             license: index.license,
@@ -1135,6 +1142,46 @@ mod test {
         // serialize to json
         let json = serde_json::to_string_pretty(&repodata).unwrap();
         insta::assert_snapshot!(json);
+    }
+
+    // See https://github.com/conda/ceps/pull/154
+    #[test]
+    fn test_indexed_timestamp_roundtrip() {
+        // A record with `indexed_timestamp` round-trips through JSON.
+        let raw = r#"{
+            "build": "h123_0",
+            "build_number": 0,
+            "depends": [],
+            "indexed_timestamp": 1650000000000,
+            "name": "demo",
+            "subdir": "noarch",
+            "timestamp": 1640000000000,
+            "version": "1.0.0"
+        }"#;
+        let record: PackageRecord = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            record
+                .indexed_timestamp
+                .map(|timestamp| timestamp.timestamp_millis()),
+            Some(1_650_000_000_000)
+        );
+        let json = serde_json::to_value(&record).unwrap();
+        assert_eq!(json["indexed_timestamp"], 1_650_000_000_000_i64);
+
+        // A record without the field omits it on serialization.
+        let record: PackageRecord = serde_json::from_str(
+            r#"{
+            "build": "h123_0",
+            "build_number": 0,
+            "name": "demo",
+            "subdir": "noarch",
+            "version": "1.0.0"
+        }"#,
+        )
+        .unwrap();
+        assert_eq!(record.indexed_timestamp, None);
+        let json = serde_json::to_value(&record).unwrap();
+        assert!(json.get("indexed_timestamp").is_none());
     }
 
     // See https://github.com/conda/ceps/blob/main/cep-0042.md

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -26,6 +26,7 @@ indexmap = { workspace = true }
 rattler_conda_types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
 toml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }

--- a/crates/rattler_config/src/config/index.rs
+++ b/crates/rattler_config/src/config/index.rs
@@ -63,6 +63,57 @@ impl PackageRevisionAssignment {
     }
 }
 
+/// How `indexed_timestamp` is backfilled for records in existing repodata
+/// that lack the field. Newly indexed packages always get the current
+/// indexing time, regardless of this setting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BackfillIndexedTimestamps {
+    /// Seed missing values from the package's build `timestamp` (clamped to
+    /// the indexing time), falling back to the indexing time when the package
+    /// has no `timestamp`.
+    #[default]
+    FromCondaPackageTimestamp,
+    /// Seed missing values with the indexing time.
+    Now,
+    /// Leave records without an `indexed_timestamp` untouched.
+    Off,
+}
+
+impl BackfillIndexedTimestamps {
+    const FROM_CONDA_PACKAGE_TIMESTAMP: &str = "from-conda-package-timestamp";
+    const NOW: &str = "now";
+    const OFF: &str = "off";
+}
+
+impl FromStr for BackfillIndexedTimestamps {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            Self::FROM_CONDA_PACKAGE_TIMESTAMP => Ok(Self::FromCondaPackageTimestamp),
+            Self::NOW => Ok(Self::Now),
+            Self::OFF => Ok(Self::Off),
+            _ => Err(format!(
+                "invalid value `{s}`, expected one of `{}`, `{}`, `{}`",
+                Self::FROM_CONDA_PACKAGE_TIMESTAMP,
+                Self::NOW,
+                Self::OFF
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for BackfillIndexedTimestamps {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::FromCondaPackageTimestamp => Self::FROM_CONDA_PACKAGE_TIMESTAMP,
+            Self::Now => Self::NOW,
+            Self::Off => Self::OFF,
+        })
+    }
+}
+
 /// Index options that apply to a single channel.
 ///
 /// Every field is optional so that `IndexConfig` can layer multiple entries
@@ -90,6 +141,11 @@ pub struct IndexChannelConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub package_revision_assignment: Option<PackageRevisionAssignment>,
 
+    /// How `indexed_timestamp` is backfilled for records in existing repodata
+    /// that lack the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backfill_indexed_timestamps: Option<BackfillIndexedTimestamps>,
+
     /// `info.base_url` value written to generated repodata.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
@@ -106,6 +162,7 @@ impl IndexChannelConfig {
             && self.write_shards.is_none()
             && self.repodata_revisions.is_none()
             && self.package_revision_assignment.is_none()
+            && self.backfill_indexed_timestamps.is_none()
             && self.base_url.is_none()
             && self.channel_relations.is_none()
     }
@@ -121,6 +178,9 @@ impl IndexChannelConfig {
             package_revision_assignment: other
                 .package_revision_assignment
                 .or(self.package_revision_assignment),
+            backfill_indexed_timestamps: other
+                .backfill_indexed_timestamps
+                .or(self.backfill_indexed_timestamps),
             base_url: other.base_url.or_else(|| self.base_url.clone()),
             channel_relations: other
                 .channel_relations
@@ -417,6 +477,22 @@ base-url = "../packages/"
         );
         let resolved = cfg.resolve("s3://my-bucket-other/channel");
         assert!(resolved.base_url.is_none());
+    }
+
+    #[test]
+    fn parses_backfill_indexed_timestamps() {
+        let cfg = parse("backfill-indexed-timestamps = \"off\"\n");
+        assert_eq!(
+            cfg.default.backfill_indexed_timestamps,
+            Some(BackfillIndexedTimestamps::Off)
+        );
+        assert_eq!(
+            "from-conda-package-timestamp"
+                .parse::<BackfillIndexedTimestamps>()
+                .unwrap(),
+            BackfillIndexedTimestamps::FromCondaPackageTimestamp
+        );
+        assert!("invalid".parse::<BackfillIndexedTimestamps>().is_err());
     }
 
     #[test]

--- a/crates/rattler_config/src/config/index.rs
+++ b/crates/rattler_config/src/config/index.rs
@@ -66,8 +66,20 @@ impl PackageRevisionAssignment {
 /// How `indexed_timestamp` is backfilled for records in existing repodata
 /// that lack the field. Newly indexed packages always get the current
 /// indexing time, regardless of this setting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    Deserialize,
+    Serialize,
+    strum::Display,
+    strum::EnumString,
+)]
 #[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
 pub enum BackfillIndexedTimestamps {
     /// Seed missing values from the package's build `timestamp` (clamped to
     /// the indexing time), falling back to the indexing time when the package
@@ -78,40 +90,6 @@ pub enum BackfillIndexedTimestamps {
     Now,
     /// Leave records without an `indexed_timestamp` untouched.
     Off,
-}
-
-impl BackfillIndexedTimestamps {
-    const FROM_CONDA_PACKAGE_TIMESTAMP: &str = "from-conda-package-timestamp";
-    const NOW: &str = "now";
-    const OFF: &str = "off";
-}
-
-impl FromStr for BackfillIndexedTimestamps {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            Self::FROM_CONDA_PACKAGE_TIMESTAMP => Ok(Self::FromCondaPackageTimestamp),
-            Self::NOW => Ok(Self::Now),
-            Self::OFF => Ok(Self::Off),
-            _ => Err(format!(
-                "invalid value `{s}`, expected one of `{}`, `{}`, `{}`",
-                Self::FROM_CONDA_PACKAGE_TIMESTAMP,
-                Self::NOW,
-                Self::OFF
-            )),
-        }
-    }
-}
-
-impl std::fmt::Display for BackfillIndexedTimestamps {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            Self::FromCondaPackageTimestamp => Self::FROM_CONDA_PACKAGE_TIMESTAMP,
-            Self::Now => Self::NOW,
-            Self::Off => Self::OFF,
-        })
-    }
 }
 
 /// Index options that apply to a single channel.

--- a/crates/rattler_index/README.md
+++ b/crates/rattler_index/README.md
@@ -24,7 +24,15 @@ configures S3 credentials, concurrency, and per-channel index options under the
 
 When `--config` is omitted, `rattler-index` falls back to its built-in defaults
 (`write-zst = true`, `write-shards = true`, no advertised repodata revisions,
-`from-index-json` revision assignment, no channel metadata).
+`from-index-json` revision assignment, `from-conda-package-timestamp` backfill
+of `indexed_timestamp`, no channel metadata).
+
+Newly indexed packages are stamped with an `indexed_timestamp` — the time at
+which the indexing run added them to the channel index (see the
+[`indexed_timestamp` CEP](https://github.com/conda/ceps/pull/154)). Once
+assigned, the value is preserved across re-indexing runs, including runs with
+`--force`. Packages whose build `timestamp` lies in the future of the indexing
+time are rejected and fail the indexing run.
 
 ## Per-channel index configuration
 
@@ -78,6 +86,7 @@ Matching rules:
 | `write-shards` | boolean | Writes `repodata_shards.msgpack.zst` and shard files. Defaults to `true`. |
 | `repodata-revisions` | array | Repodata revisions to enable. Each entry is a string (`"v3"`, `"legacy"`). The indexer fills revision package counts and timestamps while writing repodata. |
 | `package-revision-assignment` | string | Controls which `repodata-revisions` bucket a freshly indexed package lands in. `from-index-json` (default) reads the revision from each package's `info/index.json`, so legacy packages stay in the legacy maps and v3-tagged packages go to the v3 bucket. `latest` is an opt-in override that forces every package into the newest configured revision — useful for migrating a whole channel onto v3 in one shot. A future revision-assignment mode will pick based on a package's timestamp so repodata can be deterministically recreated. |
+| `backfill-indexed-timestamps` | string | Controls how `indexed_timestamp` is backfilled for records in existing repodata that lack the field. `from-conda-package-timestamp` (default) seeds it from the package's build `timestamp` (clamped so it never exceeds the indexing time), falling back to the indexing time when the package has no `timestamp`. `now` seeds it with the indexing time. `off` leaves records without the field untouched. Newly indexed packages always get the current indexing time, and previously assigned values are never recomputed. Can be overridden on the command line with `--backfill-indexed-timestamps`. |
 | `base-url` | string | Writes `info.base_url` in generated `repodata.json` and sharded repodata metadata. May be relative or absolute. |
 | `channel-relations.base` | string | A single channel reference with higher priority than this channel, written to `info.channel_relations.base`. |
 | `channel-relations.overrides` | string | A single channel reference with lower priority than this channel, written to `info.channel_relations.overrides`. |

--- a/crates/rattler_index/README.md
+++ b/crates/rattler_index/README.md
@@ -29,7 +29,7 @@ of `indexed_timestamp`, no channel metadata).
 
 Newly indexed packages are stamped with an `indexed_timestamp` — the time at
 which the indexing run added them to the channel index (see the
-[`indexed_timestamp` CEP](https://github.com/conda/ceps/pull/154)). Once
+[draft CEP](https://github.com/conda/ceps/pull/154)). Once
 assigned, the value is preserved across re-indexing runs, including runs with
 `--force`. Packages whose build `timestamp` lies in the future of the indexing
 time are rejected and fail the indexing run.

--- a/crates/rattler_index/src/error.rs
+++ b/crates/rattler_index/src/error.rs
@@ -29,6 +29,19 @@ pub enum RepodataError {
     #[error(transparent)]
     Join(#[from] tokio::task::JoinError),
 
+    /// A package has a build timestamp in the future.
+    #[error(
+        "package {filename} has a build timestamp ({timestamp}) in the future of the indexing time ({indexing_time}); refusing to index"
+    )]
+    InvalidTimestamp {
+        /// The filename of the offending package.
+        filename: String,
+        /// The build timestamp of the package.
+        timestamp: jiff::Timestamp,
+        /// The time at which the indexing run started.
+        indexing_time: jiff::Timestamp,
+    },
+
     /// A generic error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -40,7 +40,7 @@ pub use rattler_conda_types::{
     RepodataRevision, RepodataRevisionInfo, RepodataRevisionMetadata, RepodataRevisions,
 };
 pub use rattler_config::config::index::{
-    IndexChannelConfig, IndexConfig, PackageRevisionAssignment,
+    BackfillIndexedTimestamps, IndexChannelConfig, IndexConfig, PackageRevisionAssignment,
 };
 use rattler_digest::Sha256Hash;
 use rattler_package_streaming::{
@@ -204,6 +204,9 @@ fn indexed_package_record_from_index_json<T: Read>(
         license: index.license,
         license_family: index.license_family,
         timestamp: index.timestamp,
+        // Assigned in `index_subdir_inner` based on the previous repodata; build
+        // tools never set this field.
+        indexed_timestamp: None,
         python_site_packages_path: index.python_site_packages_path,
         legacy_bz2_md5: None,
         legacy_bz2_size: None,
@@ -617,6 +620,7 @@ async fn index_subdir(
     write_shards: bool,
     repodata_revisions: Vec<RepodataRevisionInfo>,
     package_revision_assignment: PackageRevisionAssignment,
+    backfill_indexed_timestamps: BackfillIndexedTimestamps,
     channel_metadata: ChannelMetadata,
     repodata_patch: Option<PatchInstructions>,
     progress: Option<MultiProgress>,
@@ -640,6 +644,7 @@ async fn index_subdir(
             write_shards,
             repodata_revisions.clone(),
             package_revision_assignment,
+            backfill_indexed_timestamps,
             channel_metadata.clone(),
             repodata_patch.clone(),
             progress.clone(),
@@ -715,6 +720,7 @@ async fn index_subdir_inner(
     write_shards: bool,
     repodata_revisions: Vec<RepodataRevisionInfo>,
     package_revision_assignment: PackageRevisionAssignment,
+    backfill_indexed_timestamps: BackfillIndexedTimestamps,
     channel_metadata: ChannelMetadata,
     repodata_patch: Option<PatchInstructions>,
     progress: Option<MultiProgress>,
@@ -722,6 +728,15 @@ async fn index_subdir_inner(
     cache: cache::PackageRecordCache,
     precondition_checks: PreconditionChecks,
 ) -> Result<SubdirIndexStats, RepodataError> {
+    // The time at which the packages indexed by this run are considered to be
+    // added to the index. Captured once per attempt so all packages added in a
+    // single run share the same `indexed_timestamp`. Truncated to millisecond
+    // precision to match the wire format of the field.
+    let indexing_time = rattler_conda_types::utils::TimestampMs::from_timestamp_millis(
+        jiff::Timestamp::from_millisecond(jiff::Timestamp::now().as_millisecond())
+            .expect("current time is always a valid timestamp"),
+    );
+
     // Step 1: Collect ETags/metadata for all critical files upfront
     let metadata = RepodataMetadataCollection::new(
         &op,
@@ -735,37 +750,40 @@ async fn index_subdir_inner(
 
     // Step 2: Read any previous repodata.json files with conditional check.
     // This file already contains a lot of information about the packages that we
-    // can reuse.
+    // can reuse. Even with `force` (where all records are rebuilt from the
+    // package archives) the previous repodata is read so that previously
+    // assigned `indexed_timestamp` values can be carried over.
+    let previous_packages = load_previous_records(&op, subdir, &metadata, &repodata_patch).await?;
+
+    // Tracks which packages were already part of the channel index before this
+    // run, and their previously assigned `indexed_timestamp` (if any).
+    let prior_index_state: ahash::HashMap<
+        DistArchiveIdentifier,
+        Option<rattler_conda_types::utils::TimestampMs>,
+    > = previous_packages
+        .iter()
+        .map(|(identifier, package)| (identifier.clone(), package.record.indexed_timestamp))
+        .collect();
+
     let mut registered_packages: ahash::HashMap<DistArchiveIdentifier, IndexedPackageRecord> =
         if force {
             HashMap::default()
         } else {
-            let (repodata_path, read_metadata) = if repodata_patch.is_some() {
-                (
-                    format!("{subdir}/{REPODATA_FROM_PACKAGES}"),
-                    metadata.repodata_from_packages.as_ref().unwrap(),
-                )
-            } else {
-                (format!("{subdir}/{REPODATA}"), &metadata.repodata)
-            };
-
-            match crate::utils::read_with_metadata_check(&op, &repodata_path, read_metadata).await {
-                Ok(bytes) => match serde_json::from_slice::<RepoData>(&bytes.to_vec()) {
-                    Ok(repodata) => package_records_from_repodata(repodata),
-                    Err(err) => {
-                        tracing::warn!(
-                            "Failed to parse {repodata_path}: {err}. Not reusing content from this file"
-                        );
-                        HashMap::default()
-                    }
-                },
-                Err(err) if err.kind() == opendal::ErrorKind::NotFound => {
-                    tracing::info!("Could not find {repodata_path}. Creating new one.");
-                    HashMap::default()
-                }
-                Err(err) => return Err(err.into()),
-            }
+            previous_packages
         };
+
+    // Backfill `indexed_timestamp` for reused records that lack it. Records
+    // that already have a value are never touched.
+    for package in registered_packages.values_mut() {
+        if package.record.indexed_timestamp.is_none() {
+            package.record.indexed_timestamp = resolve_indexed_timestamp(
+                PriorIndexState::MissingIndexedTimestamp,
+                package.record.timestamp,
+                backfill_indexed_timestamps,
+                indexing_time,
+            );
+        }
+    }
 
     // List all the packages in the subdirectory.
     let uploaded_packages: HashSet<DistArchiveIdentifier> = op
@@ -901,7 +919,24 @@ async fn index_subdir_inner(
         subdir
     );
 
-    for (filename, record) in results {
+    for (filename, mut record) in results {
+        let prior = PriorIndexState::from_prior(prior_index_state.get(&filename));
+        if prior == PriorIndexState::New
+            && let Some(timestamp) = record.record.timestamp
+            && timestamp > indexing_time
+        {
+            return Err(RepodataError::InvalidTimestamp {
+                filename: filename.to_file_name(),
+                timestamp: timestamp.jiff_timestamp(),
+                indexing_time: indexing_time.jiff_timestamp(),
+            });
+        }
+        record.record.indexed_timestamp = resolve_indexed_timestamp(
+            prior,
+            record.record.timestamp,
+            backfill_indexed_timestamps,
+            indexing_time,
+        );
         registered_packages.insert(filename, record);
     }
 
@@ -970,6 +1005,95 @@ fn latest_repodata_revision(revisions: &[RepodataRevisionInfo]) -> RepodataRevis
         .map(|revision| revision.revision)
         .max()
         .unwrap_or(RepodataRevision::Legacy)
+}
+
+/// Reads the records of the previous repodata for a subdir, with a metadata
+/// (`ETag`) check against the metadata collected at the start of the run.
+/// A missing or unparsable file degrades to an empty map; other read errors
+/// (including a concurrent-modification mismatch) are propagated.
+async fn load_previous_records(
+    op: &Operator,
+    subdir: Platform,
+    metadata: &RepodataMetadataCollection,
+    repodata_patch: &Option<PatchInstructions>,
+) -> Result<ahash::HashMap<DistArchiveIdentifier, IndexedPackageRecord>, RepodataError> {
+    let (repodata_path, read_metadata) = if repodata_patch.is_some() {
+        (
+            format!("{subdir}/{REPODATA_FROM_PACKAGES}"),
+            metadata.repodata_from_packages.as_ref().unwrap(),
+        )
+    } else {
+        (format!("{subdir}/{REPODATA}"), &metadata.repodata)
+    };
+
+    match crate::utils::read_with_metadata_check(op, &repodata_path, read_metadata).await {
+        Ok(bytes) => match serde_json::from_slice::<RepoData>(&bytes.to_vec()) {
+            Ok(repodata) => Ok(package_records_from_repodata(repodata)),
+            Err(err) => {
+                tracing::warn!(
+                    "Failed to parse {repodata_path}: {err}. Not reusing content from this file"
+                );
+                Ok(HashMap::default())
+            }
+        },
+        Err(err) if err.kind() == opendal::ErrorKind::NotFound => {
+            tracing::info!("Could not find {repodata_path}. Creating new one.");
+            Ok(HashMap::default())
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// The state of a record with respect to the previous repodata of a subdir.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PriorIndexState {
+    /// The package was not part of the previous repodata.
+    New,
+    /// The package was pre-existing but has no `indexed_timestamp`.
+    MissingIndexedTimestamp,
+    /// The package was pre-existing with a previously assigned
+    /// `indexed_timestamp`.
+    IndexedAt(rattler_conda_types::utils::TimestampMs),
+}
+
+impl PriorIndexState {
+    fn from_prior(prior: Option<&Option<rattler_conda_types::utils::TimestampMs>>) -> Self {
+        match prior {
+            None => Self::New,
+            Some(None) => Self::MissingIndexedTimestamp,
+            Some(Some(timestamp)) => Self::IndexedAt(*timestamp),
+        }
+    }
+}
+
+/// Determines the `indexed_timestamp` for a record. A previously assigned
+/// value is immutable and always preserved.
+fn resolve_indexed_timestamp(
+    prior: PriorIndexState,
+    record_timestamp: Option<rattler_conda_types::utils::TimestampMs>,
+    backfill: BackfillIndexedTimestamps,
+    indexing_time: rattler_conda_types::utils::TimestampMs,
+) -> Option<rattler_conda_types::utils::TimestampMs> {
+    match prior {
+        // New packages are always stamped with the indexing time, regardless
+        // of the backfill mode.
+        PriorIndexState::New => Some(indexing_time),
+        PriorIndexState::IndexedAt(previous) => Some(previous),
+        PriorIndexState::MissingIndexedTimestamp => match backfill {
+            // The seeded value is clamped so it never exceeds the indexing
+            // time, and normalized to millisecond format as mandated by the
+            // CEP (the build timestamp may be in seconds format).
+            BackfillIndexedTimestamps::FromCondaPackageTimestamp => {
+                Some(record_timestamp.map_or(indexing_time, |timestamp| {
+                    rattler_conda_types::utils::TimestampMs::from_timestamp_millis(
+                        timestamp.min(indexing_time).jiff_timestamp(),
+                    )
+                }))
+            }
+            BackfillIndexedTimestamps::Now => Some(indexing_time),
+            BackfillIndexedTimestamps::Off => None,
+        },
+    }
 }
 
 fn package_records_from_repodata(
@@ -1353,6 +1477,9 @@ pub struct IndexFsConfig {
     pub repodata_revisions: Vec<RepodataRevisionInfo>,
     /// How packages are assigned to repodata revisions.
     pub package_revision_assignment: PackageRevisionAssignment,
+    /// How `indexed_timestamp` is backfilled for records in existing repodata
+    /// that lack the field.
+    pub backfill_indexed_timestamps: BackfillIndexedTimestamps,
     /// Whether to force the index to be written.
     pub force: bool,
     /// The maximum number of parallel tasks to run.
@@ -1378,6 +1505,7 @@ pub async fn index_fs_with_channel_metadata(
         write_shards,
         repodata_revisions,
         package_revision_assignment,
+        backfill_indexed_timestamps,
         force,
         max_parallel,
         multi_progress,
@@ -1396,6 +1524,7 @@ pub async fn index_fs_with_channel_metadata(
         write_shards,
         repodata_revisions,
         package_revision_assignment,
+        backfill_indexed_timestamps,
         force,
         max_parallel,
         multi_progress,
@@ -1425,6 +1554,9 @@ pub struct IndexS3Config {
     pub repodata_revisions: Vec<RepodataRevisionInfo>,
     /// How packages are assigned to repodata revisions.
     pub package_revision_assignment: PackageRevisionAssignment,
+    /// How `indexed_timestamp` is backfilled for records in existing repodata
+    /// that lack the field.
+    pub backfill_indexed_timestamps: BackfillIndexedTimestamps,
     /// Whether to force the index to be written.
     pub force: bool,
     /// The maximum number of parallel tasks to run.
@@ -1477,6 +1609,7 @@ pub async fn index_s3_with_channel_metadata(
         write_shards,
         repodata_revisions,
         package_revision_assignment,
+        backfill_indexed_timestamps,
         force,
         max_parallel,
         multi_progress,
@@ -1497,6 +1630,7 @@ pub async fn index_s3_with_channel_metadata(
         write_shards,
         repodata_revisions,
         package_revision_assignment,
+        backfill_indexed_timestamps,
         force,
         max_parallel,
         multi_progress,
@@ -1532,6 +1666,7 @@ pub async fn index(
     write_shards: bool,
     repodata_revisions: Vec<RepodataRevisionInfo>,
     package_revision_assignment: PackageRevisionAssignment,
+    backfill_indexed_timestamps: BackfillIndexedTimestamps,
     force: bool,
     max_parallel: usize,
     multi_progress: Option<MultiProgress>,
@@ -1545,6 +1680,7 @@ pub async fn index(
         write_shards,
         repodata_revisions,
         package_revision_assignment,
+        backfill_indexed_timestamps,
         force,
         max_parallel,
         multi_progress,
@@ -1565,6 +1701,7 @@ pub async fn index_with_channel_metadata(
     write_shards: bool,
     repodata_revisions: Vec<RepodataRevisionInfo>,
     package_revision_assignment: PackageRevisionAssignment,
+    backfill_indexed_timestamps: BackfillIndexedTimestamps,
     force: bool,
     max_parallel: usize,
     multi_progress: Option<MultiProgress>,
@@ -1647,6 +1784,7 @@ pub async fn index_with_channel_metadata(
             write_shards,
             repodata_revisions.clone(),
             package_revision_assignment,
+            backfill_indexed_timestamps,
             channel_metadata.clone(),
             repodata_patch
                 .as_ref()
@@ -1859,5 +1997,103 @@ mod tests {
         assert!(packages.is_empty());
         assert!(conda_packages.is_empty());
         assert!(v3.whl.contains_key(&identifier));
+    }
+
+    #[test]
+    fn resolve_indexed_timestamp_semantics() {
+        use rattler_conda_types::utils::TimestampMs;
+
+        let ms = |millis: i64| {
+            TimestampMs::from_timestamp_millis(jiff::Timestamp::from_millisecond(millis).unwrap())
+        };
+        let now = ms(1_700_000_000_000);
+        let past = ms(1_600_000_000_000);
+        let future = ms(1_800_000_000_000);
+        let previous = ms(1_650_000_000_000);
+
+        for backfill in [
+            BackfillIndexedTimestamps::FromCondaPackageTimestamp,
+            BackfillIndexedTimestamps::Now,
+            BackfillIndexedTimestamps::Off,
+        ] {
+            // New packages always get the indexing time, regardless of mode.
+            assert_eq!(
+                resolve_indexed_timestamp(PriorIndexState::New, Some(past), backfill, now),
+                Some(now)
+            );
+            assert_eq!(
+                resolve_indexed_timestamp(PriorIndexState::New, None, backfill, now),
+                Some(now)
+            );
+
+            // A previously assigned value is always preserved.
+            assert_eq!(
+                resolve_indexed_timestamp(
+                    PriorIndexState::IndexedAt(previous),
+                    Some(past),
+                    backfill,
+                    now
+                ),
+                Some(previous)
+            );
+        }
+
+        // Pre-existing records without a value are backfilled per mode.
+        assert_eq!(
+            resolve_indexed_timestamp(
+                PriorIndexState::MissingIndexedTimestamp,
+                Some(past),
+                BackfillIndexedTimestamps::FromCondaPackageTimestamp,
+                now
+            ),
+            Some(past)
+        );
+        // The seeded value is clamped to the indexing time.
+        assert_eq!(
+            resolve_indexed_timestamp(
+                PriorIndexState::MissingIndexedTimestamp,
+                Some(future),
+                BackfillIndexedTimestamps::FromCondaPackageTimestamp,
+                now
+            ),
+            Some(now)
+        );
+        // Without a build timestamp the indexing time is used.
+        assert_eq!(
+            resolve_indexed_timestamp(
+                PriorIndexState::MissingIndexedTimestamp,
+                None,
+                BackfillIndexedTimestamps::FromCondaPackageTimestamp,
+                now
+            ),
+            Some(now)
+        );
+        assert_eq!(
+            resolve_indexed_timestamp(
+                PriorIndexState::MissingIndexedTimestamp,
+                Some(past),
+                BackfillIndexedTimestamps::Now,
+                now
+            ),
+            Some(now)
+        );
+        assert_eq!(
+            resolve_indexed_timestamp(
+                PriorIndexState::MissingIndexedTimestamp,
+                Some(past),
+                BackfillIndexedTimestamps::Off,
+                now
+            ),
+            None
+        );
+        assert_eq!(
+            resolve_indexed_timestamp(
+                PriorIndexState::MissingIndexedTimestamp,
+                None,
+                BackfillIndexedTimestamps::Off,
+                now
+            ),
+            None
+        );
     }
 }

--- a/crates/rattler_index/src/main.rs
+++ b/crates/rattler_index/src/main.rs
@@ -8,7 +8,8 @@ use rattler_config::config::{
     concurrency::default_max_concurrent_solves, index::IndexChannelConfig,
 };
 use rattler_index::{
-    ChannelMetadata, IndexFsConfig, PackageRevisionAssignment, index_fs_with_channel_metadata,
+    BackfillIndexedTimestamps, ChannelMetadata, IndexFsConfig, PackageRevisionAssignment,
+    index_fs_with_channel_metadata,
 };
 #[cfg(feature = "s3")]
 use rattler_index::{IndexS3Config, PreconditionChecks, index_s3_with_channel_metadata};
@@ -61,6 +62,14 @@ struct Cli {
     /// that should be used for repodata patching. For more information, see `https://prefix.dev/blog/repodata_patching`.
     #[arg(long, global = true)]
     repodata_patch: Option<String>,
+
+    /// How to backfill `indexed_timestamp` for records in existing repodata
+    /// that lack the field: `from-conda-package-timestamp` (default) seeds it
+    /// from the package's build timestamp (clamped to the indexing time),
+    /// `now` seeds it with the indexing time, `off` leaves records untouched.
+    /// Overrides the value from the config file.
+    #[arg(long, global = true)]
+    backfill_indexed_timestamps: Option<BackfillIndexedTimestamps>,
 
     /// Disable precondition checks (`ETags`, timestamps) during file operations.
     /// Use this flag if your S3 backend doesn't fully support conditional requests,
@@ -142,8 +151,13 @@ async fn main() -> anyhow::Result<()> {
                 .to_string_lossy()
                 .into_owned();
             let resolved = resolve_index_channel_config(&config, &target);
-            let (write_zst, write_shards, repodata_revisions, package_revision_assignment) =
-                effective_index_options(&resolved);
+            let (
+                write_zst,
+                write_shards,
+                repodata_revisions,
+                package_revision_assignment,
+                backfill_indexed_timestamps,
+            ) = effective_index_options(&resolved);
             let channel_metadata = ChannelMetadata::from_index_config(&resolved);
 
             index_fs_with_channel_metadata(
@@ -155,6 +169,9 @@ async fn main() -> anyhow::Result<()> {
                     write_shards,
                     repodata_revisions,
                     package_revision_assignment,
+                    backfill_indexed_timestamps: cli
+                        .backfill_indexed_timestamps
+                        .unwrap_or(backfill_indexed_timestamps),
                     force: cli.force,
                     max_parallel,
                     multi_progress: Some(multi_progress),
@@ -170,8 +187,13 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let target = channel.to_string();
             let resolved = resolve_index_channel_config(&config, &target);
-            let (write_zst, write_shards, repodata_revisions, package_revision_assignment) =
-                effective_index_options(&resolved);
+            let (
+                write_zst,
+                write_shards,
+                repodata_revisions,
+                package_revision_assignment,
+                backfill_indexed_timestamps,
+            ) = effective_index_options(&resolved);
             let channel_metadata = ChannelMetadata::from_index_config(&resolved);
 
             let bucket = channel.host().context("Invalid S3 url")?.to_string();
@@ -204,6 +226,9 @@ async fn main() -> anyhow::Result<()> {
                     write_shards,
                     repodata_revisions,
                     package_revision_assignment,
+                    backfill_indexed_timestamps: cli
+                        .backfill_indexed_timestamps
+                        .unwrap_or(backfill_indexed_timestamps),
                     force: cli.force,
                     max_parallel,
                     multi_progress: Some(multi_progress),
@@ -232,15 +257,18 @@ fn effective_index_options(
     bool,
     Vec<rattler_index::RepodataRevisionInfo>,
     PackageRevisionAssignment,
+    BackfillIndexedTimestamps,
 ) {
     let write_zst = cfg.write_zst.unwrap_or(true);
     let write_shards = cfg.write_shards.unwrap_or(true);
     let repodata_revisions = cfg.repodata_revisions.clone().unwrap_or_default();
     let package_revision_assignment = cfg.package_revision_assignment.unwrap_or_default();
+    let backfill_indexed_timestamps = cfg.backfill_indexed_timestamps.unwrap_or_default();
     (
         write_zst,
         write_shards,
         repodata_revisions,
         package_revision_assignment,
+        backfill_indexed_timestamps,
     )
 }

--- a/crates/rattler_index/tests/integration/basic_indexing.rs
+++ b/crates/rattler_index/tests/integration/basic_indexing.rs
@@ -8,8 +8,8 @@ use rattler_conda_types::{
     ChannelRelations, Platform, ShardedRepodata, compression_level::CompressionLevel,
 };
 use rattler_index::{
-    ChannelMetadata, IndexFsConfig, PackageRevisionAssignment, RepodataRevision,
-    RepodataRevisionInfo, index_fs, index_fs_with_channel_metadata,
+    BackfillIndexedTimestamps, ChannelMetadata, IndexFsConfig, PackageRevisionAssignment,
+    RepodataRevision, RepodataRevisionInfo, index_fs, index_fs_with_channel_metadata,
 };
 use rattler_package_streaming::write::write_tar_bz2_package;
 use serde_json::Value;
@@ -26,6 +26,7 @@ fn test_data_dir() -> PathBuf {
 /// - Package records match expected values
 #[tokio::test]
 async fn test_index() {
+    let test_start_millis = current_unix_millis();
     let temp_dir = tempfile::tempdir().unwrap();
     let subdir_path = Path::new("win-64");
     let conda_file_path = tokio::task::spawn_blocking(|| {
@@ -78,6 +79,7 @@ async fn test_index() {
         write_shards: true,
         repodata_revisions: Vec::new(),
         package_revision_assignment: PackageRevisionAssignment::default(),
+        backfill_indexed_timestamps: BackfillIndexedTimestamps::default(),
         force: true,
         max_parallel: 32,
         multi_progress: None,
@@ -111,14 +113,31 @@ async fn test_index() {
             .get("conda-22.9.0-py38haa244fe_2.tar.bz2")
             .is_some()
     );
-    assert_eq!(
-        repodata_json
-            .get("packages.conda")
+    let mut actual_entry = repodata_json
+        .get("packages.conda")
+        .unwrap()
+        .get("conda-22.11.1-py38haa244fe_1.conda")
+        .unwrap()
+        .clone();
+    // `indexed_timestamp` is assigned by the indexer and not part of the
+    // build-tool fixture; verify it separately and strip it before comparing.
+    let indexed_timestamp = actual_entry
+        .as_object_mut()
+        .unwrap()
+        .remove("indexed_timestamp")
+        .unwrap();
+    assert!(indexed_timestamp.as_i64().unwrap() >= test_start_millis);
+    assert_eq!(actual_entry, expected_repodata_entry);
+}
+
+fn current_unix_millis() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .get("conda-22.11.1-py38haa244fe_1.conda")
-            .unwrap(),
-        &expected_repodata_entry
-    );
+            .as_millis(),
+    )
+    .unwrap()
 }
 
 /// Validates that indexing an empty directory creates a noarch subdir with repodata files.
@@ -143,6 +162,7 @@ async fn test_index_empty_directory_creates_noarch_repodata() {
         write_shards: true,
         repodata_revisions: Vec::new(),
         package_revision_assignment: PackageRevisionAssignment::default(),
+        backfill_indexed_timestamps: BackfillIndexedTimestamps::default(),
         force: true,
         max_parallel: 100,
         multi_progress: None,
@@ -181,6 +201,7 @@ async fn test_reindex_removes_deleted_conda_package() {
         write_shards: false,
         repodata_revisions: Vec::new(),
         package_revision_assignment: PackageRevisionAssignment::default(),
+        backfill_indexed_timestamps: BackfillIndexedTimestamps::default(),
         force: false,
         max_parallel: 1,
         multi_progress: None,
@@ -209,6 +230,7 @@ async fn test_reindex_removes_deleted_conda_package() {
         write_shards: false,
         repodata_revisions: Vec::new(),
         package_revision_assignment: PackageRevisionAssignment::default(),
+        backfill_indexed_timestamps: BackfillIndexedTimestamps::default(),
         force: false,
         max_parallel: 1,
         multi_progress: None,
@@ -250,6 +272,7 @@ async fn test_index_latest_repodata_revision() {
             newest: None,
         }],
         package_revision_assignment: PackageRevisionAssignment::Latest,
+        backfill_indexed_timestamps: BackfillIndexedTimestamps::default(),
         force: true,
         max_parallel: 1,
         multi_progress: None,
@@ -347,6 +370,7 @@ async fn test_index_repodata_revision_from_index_json() {
             newest: None,
         }],
         package_revision_assignment: PackageRevisionAssignment::FromIndexJson,
+        backfill_indexed_timestamps: BackfillIndexedTimestamps::default(),
         force: true,
         max_parallel: 1,
         multi_progress: None,
@@ -404,6 +428,7 @@ async fn test_index_writes_channel_metadata() {
                 newest: None,
             }],
             package_revision_assignment: PackageRevisionAssignment::Latest,
+            backfill_indexed_timestamps: BackfillIndexedTimestamps::default(),
             force: true,
             max_parallel: 1,
             multi_progress: None,
@@ -458,4 +483,294 @@ async fn test_index_writes_channel_metadata() {
         shard_index.info.repodata_revisions[&RepodataRevision::V3].n_packages,
         Some(0)
     );
+}
+
+fn empty_package_index_config(channel: &Path, force: bool) -> IndexFsConfig {
+    IndexFsConfig {
+        channel: channel.into(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: false,
+        write_shards: false,
+        repodata_revisions: Vec::new(),
+        package_revision_assignment: PackageRevisionAssignment::default(),
+        backfill_indexed_timestamps: BackfillIndexedTimestamps::default(),
+        force,
+        max_parallel: 1,
+        multi_progress: None,
+    }
+}
+
+fn read_indexed_timestamp(repodata_path: &Path, package_name: &str) -> Option<i64> {
+    let repodata_json: Value = serde_json::from_reader(File::open(repodata_path).unwrap()).unwrap();
+    repodata_json
+        .get("packages.conda")
+        .and_then(|packages| packages.get(package_name))
+        .or_else(|| {
+            repodata_json
+                .get("packages")
+                .and_then(|packages| packages.get(package_name))
+        })
+        .unwrap()
+        .get("indexed_timestamp")
+        .map(|value| value.as_i64().unwrap())
+}
+
+/// Validates that `indexed_timestamp` is assigned to newly indexed packages
+/// and preserved across re-indexing runs, including runs with `force`.
+#[tokio::test]
+async fn test_indexed_timestamp_assignment_and_preservation() {
+    let test_start_millis = current_unix_millis();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let subdir_path = temp_dir.path().join("noarch");
+    let package_name = "empty-0.1.0-h4616a5c_0.conda";
+
+    fs::create_dir(&subdir_path).unwrap();
+    fs::copy(
+        test_data_dir().join("packages").join(package_name),
+        subdir_path.join(package_name),
+    )
+    .unwrap();
+
+    index_fs(empty_package_index_config(temp_dir.path(), false))
+        .await
+        .unwrap();
+
+    let repodata_path = subdir_path.join("repodata.json");
+    let assigned = read_indexed_timestamp(&repodata_path, package_name).unwrap();
+    assert!(assigned >= test_start_millis);
+    assert!(assigned <= current_unix_millis());
+
+    // Re-indexing must not recompute the value.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    index_fs(empty_package_index_config(temp_dir.path(), false))
+        .await
+        .unwrap();
+    assert_eq!(
+        read_indexed_timestamp(&repodata_path, package_name).unwrap(),
+        assigned
+    );
+
+    // Even a force re-index (which rebuilds records from the package
+    // archives) must carry the value over.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    index_fs(empty_package_index_config(temp_dir.path(), true))
+        .await
+        .unwrap();
+    assert_eq!(
+        read_indexed_timestamp(&repodata_path, package_name).unwrap(),
+        assigned
+    );
+}
+
+/// Writes a channel containing two packages and a hand-written repodata.json
+/// in which one record lacks `indexed_timestamp` (with the given build
+/// `timestamp`) and the other has a pre-assigned value.
+fn write_backfill_channel(temp_dir: &Path) -> PathBuf {
+    let subdir_path = temp_dir.join("noarch");
+    let package_name = "empty-0.1.0-h4616a5c_0.conda";
+
+    fs::create_dir(&subdir_path).unwrap();
+    fs::copy(
+        test_data_dir().join("packages").join(package_name),
+        subdir_path.join(package_name),
+    )
+    .unwrap();
+
+    // A second package so that one record can carry a pre-assigned value.
+    let package_build_dir = temp_dir.join("package-build");
+    let package_info_dir = package_build_dir.join("info");
+    fs::create_dir(&package_build_dir).unwrap();
+    fs::create_dir(&package_info_dir).unwrap();
+    fs::write(
+        package_info_dir.join("index.json"),
+        r#"{
+            "build": "h123_0",
+            "build_number": 0,
+            "name": "preset-demo",
+            "noarch": "generic",
+            "subdir": "noarch",
+            "timestamp": 1710000000000,
+            "version": "1.0.0"
+        }"#,
+    )
+    .unwrap();
+    let writer = File::create(subdir_path.join("preset-demo-1.0.0-h123_0.tar.bz2")).unwrap();
+    write_tar_bz2_package(
+        writer,
+        &package_build_dir,
+        &[package_info_dir.join("index.json")],
+        CompressionLevel::Default,
+        None,
+        None,
+    )
+    .unwrap();
+
+    fs::write(
+        subdir_path.join("repodata.json"),
+        r#"{
+            "info": {"subdir": "noarch"},
+            "packages": {
+                "preset-demo-1.0.0-h123_0.tar.bz2": {
+                    "build": "h123_0",
+                    "build_number": 0,
+                    "indexed_timestamp": 1650000000000,
+                    "name": "preset-demo",
+                    "noarch": "generic",
+                    "subdir": "noarch",
+                    "timestamp": 1710000000000,
+                    "version": "1.0.0"
+                }
+            },
+            "packages.conda": {
+                "empty-0.1.0-h4616a5c_0.conda": {
+                    "build": "h4616a5c_0",
+                    "build_number": 0,
+                    "name": "empty",
+                    "noarch": "generic",
+                    "subdir": "noarch",
+                    "timestamp": 1710000000000,
+                    "version": "0.1.0"
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+
+    subdir_path.join("repodata.json")
+}
+
+/// Validates the backfill modes for records in existing repodata that lack
+/// `indexed_timestamp`. Records with a pre-assigned value are never touched.
+#[tokio::test]
+async fn test_indexed_timestamp_backfill_modes() {
+    for (mode, expected) in [
+        (
+            BackfillIndexedTimestamps::FromCondaPackageTimestamp,
+            Some(Some(1_710_000_000_000)),
+        ),
+        (BackfillIndexedTimestamps::Now, Some(None)),
+        (BackfillIndexedTimestamps::Off, None),
+    ] {
+        let test_start_millis = current_unix_millis();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repodata_path = write_backfill_channel(temp_dir.path());
+
+        let mut config = empty_package_index_config(temp_dir.path(), false);
+        config.backfill_indexed_timestamps = mode;
+        index_fs(config).await.unwrap();
+
+        let backfilled = read_indexed_timestamp(&repodata_path, "empty-0.1.0-h4616a5c_0.conda");
+        match expected {
+            // Seeded from the record's build timestamp.
+            Some(Some(timestamp)) => assert_eq!(backfilled, Some(timestamp), "mode {mode}"),
+            // Seeded with the indexing time.
+            Some(None) => {
+                let backfilled = backfilled.unwrap();
+                assert!(backfilled >= test_start_millis, "mode {mode}");
+                assert!(backfilled <= current_unix_millis(), "mode {mode}");
+            }
+            // Left untouched.
+            None => assert_eq!(backfilled, None, "mode {mode}"),
+        }
+
+        // The pre-assigned value is preserved in all modes.
+        assert_eq!(
+            read_indexed_timestamp(&repodata_path, "preset-demo-1.0.0-h123_0.tar.bz2"),
+            Some(1_650_000_000_000),
+            "mode {mode}"
+        );
+    }
+}
+
+/// Validates that a package with a build timestamp in the future is rejected
+/// and the subdir's repodata is not written.
+#[tokio::test]
+async fn test_index_rejects_future_build_timestamp() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let subdir_path = temp_dir.path().join("noarch");
+    let package_name = "future-demo-1.0.0-h123_0.tar.bz2";
+    let package_build_dir = temp_dir.path().join("package-build");
+    let package_info_dir = package_build_dir.join("info");
+
+    fs::create_dir(&subdir_path).unwrap();
+    fs::create_dir(&package_build_dir).unwrap();
+    fs::create_dir(&package_info_dir).unwrap();
+    // Year 2100.
+    fs::write(
+        package_info_dir.join("index.json"),
+        r#"{
+            "build": "h123_0",
+            "build_number": 0,
+            "name": "future-demo",
+            "noarch": "generic",
+            "subdir": "noarch",
+            "timestamp": 4102444800000,
+            "version": "1.0.0"
+        }"#,
+    )
+    .unwrap();
+    let writer = File::create(subdir_path.join(package_name)).unwrap();
+    write_tar_bz2_package(
+        writer,
+        &package_build_dir,
+        &[package_info_dir.join("index.json")],
+        CompressionLevel::Default,
+        None,
+        None,
+    )
+    .unwrap();
+
+    let err = index_fs(empty_package_index_config(temp_dir.path(), false))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains(package_name), "error: {err}");
+    assert!(
+        err.to_string().contains("refusing to index"),
+        "error: {err}"
+    );
+    assert!(!subdir_path.join("repodata.json").exists());
+}
+
+/// Validates that `indexed_timestamp` also ends up in the sharded repodata.
+#[tokio::test]
+async fn test_indexed_timestamp_in_shards() {
+    let test_start_millis = current_unix_millis();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let subdir_path = temp_dir.path().join("noarch");
+    let package_name = "empty-0.1.0-h4616a5c_0.conda";
+
+    fs::create_dir(&subdir_path).unwrap();
+    fs::copy(
+        test_data_dir().join("packages").join(package_name),
+        subdir_path.join(package_name),
+    )
+    .unwrap();
+
+    let mut config = empty_package_index_config(temp_dir.path(), false);
+    config.write_shards = true;
+    index_fs(config).await.unwrap();
+
+    let shard_index_bytes = fs::read(subdir_path.join("repodata_shards.msgpack.zst")).unwrap();
+    let shard_index_bytes = zstd::decode_all(shard_index_bytes.as_slice()).unwrap();
+    let shard_index: ShardedRepodata = rmp_serde::from_slice(&shard_index_bytes).unwrap();
+    let digest = shard_index.shards["empty"];
+    let shard_bytes = fs::read(
+        subdir_path
+            .join("shards")
+            .join(format!("{}.msgpack.zst", hex::encode(digest))),
+    )
+    .unwrap();
+    let shard_bytes = zstd::decode_all(shard_bytes.as_slice()).unwrap();
+    let shard: rattler_conda_types::Shard = rmp_serde::from_slice(&shard_bytes).unwrap();
+    let record = shard
+        .conda_packages
+        .values()
+        .next()
+        .expect("shard contains the package");
+    let indexed_timestamp = record
+        .indexed_timestamp
+        .expect("indexed_timestamp is present in the shard")
+        .timestamp_millis();
+    assert!(indexed_timestamp >= test_start_millis);
 }

--- a/crates/rattler_index/tests/integration/concurrent_indexing.rs
+++ b/crates/rattler_index/tests/integration/concurrent_indexing.rs
@@ -12,7 +12,9 @@ use std::path::Path;
 
 use opendal::Operator;
 use rattler_conda_types::Platform;
-use rattler_index::{PackageRevisionAssignment, PreconditionChecks, index};
+use rattler_index::{
+    BackfillIndexedTimestamps, PackageRevisionAssignment, PreconditionChecks, index,
+};
 use tracing::Instrument;
 
 use super::etag_memory_backend::ETagMemoryBuilder;
@@ -109,6 +111,7 @@ async fn test_concurrent_index_with_race_condition_and_retry() {
                 false,
                 Vec::new(),
                 PackageRevisionAssignment::default(),
+                BackfillIndexedTimestamps::default(),
                 false,
                 1,
                 None,
@@ -130,6 +133,7 @@ async fn test_concurrent_index_with_race_condition_and_retry() {
                 false,
                 Vec::new(),
                 PackageRevisionAssignment::default(),
+                BackfillIndexedTimestamps::default(),
                 false,
                 1,
                 None,

--- a/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
@@ -145,6 +145,7 @@ impl<'a> From<CondaPackageDataModel<'a>> for LegacyCondaPackageData {
                 extra_depends: std::collections::BTreeMap::new(),
                 features: value.features.into_owned(),
                 flags: value.flags.into_owned(),
+                indexed_timestamp: None,
                 legacy_bz2_md5: value.legacy_bz2_md5,
                 legacy_bz2_size: value.legacy_bz2_size.into_owned(),
                 license: value.license.into_owned(),

--- a/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
@@ -177,6 +177,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for LegacyCondaPackageData {
             extra_depends: value.extra_depends.into_owned(),
             features: value.features.into_owned(),
             flags: value.flags.into_owned(),
+            indexed_timestamp: None,
             legacy_bz2_md5: value.legacy_bz2_md5,
             legacy_bz2_size: value.legacy_bz2_size.into_owned(),
             license: value.license.into_owned(),

--- a/crates/rattler_lock/src/parse/models/v7/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/conda_package_data.rs
@@ -168,6 +168,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaBinaryData {
             extra_depends: value.extra_depends.into_owned(),
             features: value.features.into_owned(),
             flags: value.flags.into_owned(),
+            indexed_timestamp: None,
             legacy_bz2_md5: value.legacy_bz2_md5,
             legacy_bz2_size: value.legacy_bz2_size.into_owned(),
             license: value.license.into_owned(),

--- a/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
@@ -151,6 +151,7 @@ impl<'a> SourcePackageDataModel<'a> {
                 extra_depends: self.extra_depends.into_owned(),
                 features: self.features.into_owned(),
                 flags: self.flags.into_owned(),
+                indexed_timestamp: None,
                 legacy_bz2_md5: None,
                 legacy_bz2_size: None,
                 license: self.license.into_owned(),

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -231,6 +231,7 @@ pub fn parse_v3_or_lower(
                                     extra_depends: std::collections::BTreeMap::new(),
                                     features: value.features,
                                     flags: Vec::new(),
+                                    indexed_timestamp: None,
                                     legacy_bz2_md5: None,
                                     legacy_bz2_size: None,
                                     license: value.license,

--- a/crates/rattler_lock/src/source_identifier.rs
+++ b/crates/rattler_lock/src/source_identifier.rs
@@ -269,6 +269,7 @@ fn compute_source_hash(data: &CondaSourceData) -> u64 {
                 arch: _,
                 platform: _,
                 features: _,
+                indexed_timestamp: _,
                 legacy_bz2_md5: _,
                 legacy_bz2_size: _,
                 license: _,

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -1491,6 +1491,7 @@ mod test {
             license: None,
             license_family: None,
             timestamp: None,
+            indexed_timestamp: None,
             legacy_bz2_size: None,
             legacy_bz2_md5: None,
             purls: None,

--- a/crates/rattler_repodata_gateway/src/gateway/subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir.rs
@@ -207,6 +207,7 @@ mod tests {
             depends: deps.iter().map(|s| (*s).to_string()).collect(),
             features: None,
             flags: Vec::new(),
+            indexed_timestamp: None,
             legacy_bz2_md5: None,
             legacy_bz2_size: None,
             license: None,

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -311,13 +311,18 @@ impl ExcludeNewer {
     }
 
     /// Returns whether a package should be excluded.
+    ///
+    /// The cutoff is compared against `indexed_timestamp` (the time at which
+    /// the package was added to the channel index) when available, falling
+    /// back to the builder-provided build `timestamp` otherwise.
     pub fn is_excluded(
         &self,
         package: &PackageName,
         channel: Option<&str>,
+        indexed_timestamp: Option<&TimestampMs>,
         timestamp: Option<&TimestampMs>,
     ) -> bool {
-        match timestamp {
+        match indexed_timestamp.or(timestamp) {
             Some(timestamp) => *timestamp > self.cutoff_for_package(package, channel),
             None => !self.include_unknown_timestamp(),
         }

--- a/crates/rattler_solve/src/libsolv_c/input.rs
+++ b/crates/rattler_solve/src/libsolv_c/input.rs
@@ -129,11 +129,23 @@ pub fn add_repodata_records<'a>(
 
     // Track all extras we encounter so we can create synthetic solvables for them
     let mut extras: HashSet<(String, String)> = HashSet::new();
+
+    // Number of records that lack an `indexed_timestamp`, making
+    // exclude-newer fall back to the builder-provided build timestamp.
+    let mut records_without_indexed_timestamp: usize = 0;
     for (repo_data_index, repo_data) in repo_data.into_iter().enumerate() {
+        if exclude_newer.is_some()
+            && repo_data.package_record.indexed_timestamp.is_none()
+            && repo_data.package_record.timestamp.is_some()
+        {
+            records_without_indexed_timestamp += 1;
+        }
+
         if let Some(config) = exclude_newer
             && config.is_excluded(
                 &repo_data.package_record.name,
                 repo_data.channel.as_deref(),
+                repo_data.package_record.indexed_timestamp.as_ref(),
                 repo_data.package_record.timestamp.as_ref(),
             )
         {
@@ -296,6 +308,14 @@ pub fn add_repodata_records<'a>(
         }
 
         solvable_ids.push(solvable_id);
+    }
+
+    if records_without_indexed_timestamp > 0 {
+        tracing::warn!(
+            "exclude-newer: {records_without_indexed_timestamp} package record(s) have no `indexed_timestamp`; \
+             falling back to the builder-provided `timestamp` for them. Consider re-indexing the channel \
+             with an indexing tool that supports `indexed_timestamp`."
+        );
     }
 
     // Custom ids for storing extra info on synthetic solvables

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -37,18 +37,21 @@ fn exclude_newer_reason(
     config: &ExcludeNewer,
     package: &PackageName,
     channel: Option<&str>,
+    indexed_timestamp: Option<&rattler_conda_types::utils::TimestampMs>,
     timestamp: Option<&rattler_conda_types::utils::TimestampMs>,
 ) -> Option<String> {
     let cutoff = config.cutoff_for_package(package, channel);
-    match timestamp {
-        Some(timestamp) if *timestamp > cutoff => {
+    match indexed_timestamp.or(timestamp) {
+        Some(effective_timestamp) if *effective_timestamp > cutoff => {
             // Display in user's local timezone for better readability
             let display_time = cutoff
                 .to_zoned(jiff::tz::TimeZone::system())
                 .strftime("%Y-%m-%d %H:%M:%S");
-            Some(format!(
-                "the package is uploaded after the cutoff date of {display_time}"
-            ))
+            Some(if indexed_timestamp.is_some() {
+                format!("the package was indexed after the cutoff date of {display_time}")
+            } else {
+                format!("the package is uploaded after the cutoff date of {display_time}")
+            })
         }
         None if !config.include_unknown_timestamp() => Some("the package has no timestamp".into()),
         _ => None,
@@ -351,6 +354,10 @@ impl<'a> CondaDependencyProvider<'a> {
         // Hashmap that maps the package name to the channel it was first found in.
         let mut package_name_found_in_channel = HashMap::<String, &Option<String>>::new();
 
+        // Number of records that lack an `indexed_timestamp`, making
+        // exclude-newer fall back to the builder-provided build timestamp.
+        let mut records_without_indexed_timestamp: usize = 0;
+
         // Add additional records
         for repo_data in repodata {
             // Iterate over all records and dedup records that refer to the same package
@@ -374,9 +381,17 @@ impl<'a> CondaDependencyProvider<'a> {
                     config.is_excluded(
                         &record.package_record.name,
                         record.channel.as_deref(),
+                        record.package_record.indexed_timestamp.as_ref(),
                         record.package_record.timestamp.as_ref(),
                     )
                 });
+
+                if exclude_newer.is_some()
+                    && record.package_record.indexed_timestamp.is_none()
+                    && record.package_record.timestamp.is_some()
+                {
+                    records_without_indexed_timestamp += 1;
+                }
 
                 let identifier = &record.identifier.identifier;
                 let archive_type = record.identifier.archive_type;
@@ -437,6 +452,7 @@ impl<'a> CondaDependencyProvider<'a> {
                     && config.is_excluded(
                         &record.package_record.name,
                         record.channel.as_deref(),
+                        record.package_record.indexed_timestamp.as_ref(),
                         record.package_record.timestamp.as_ref(),
                     )
                 {
@@ -445,6 +461,7 @@ impl<'a> CondaDependencyProvider<'a> {
                             config,
                             &record.package_record.name,
                             record.channel.as_deref(),
+                            record.package_record.indexed_timestamp.as_ref(),
                             record.package_record.timestamp.as_ref(),
                         )
                         .expect("excluded records must have an exclusion reason"),
@@ -528,6 +545,14 @@ impl<'a> CondaDependencyProvider<'a> {
                     );
                 }
             }
+        }
+
+        if records_without_indexed_timestamp > 0 {
+            tracing::warn!(
+                "exclude-newer: {records_without_indexed_timestamp} package record(s) have no `indexed_timestamp`; \
+                 falling back to the builder-provided `timestamp` for them. Consider re-indexing the channel \
+                 with an indexing tool that supports `indexed_timestamp`."
+            );
         }
 
         // Add favored packages to the records

--- a/crates/rattler_solve/tests/backends/helpers/package_builder.rs
+++ b/crates/rattler_solve/tests/backends/helpers/package_builder.rs
@@ -52,6 +52,7 @@ impl PackageBuilder {
                     license: None,
                     license_family: None,
                     timestamp: None,
+                    indexed_timestamp: None,
                     legacy_bz2_size: None,
                     legacy_bz2_md5: None,
                     purls: None,
@@ -137,6 +138,12 @@ impl PackageBuilder {
     pub fn timestamp(mut self, timestamp: &str) -> Self {
         let ts: Timestamp = timestamp.parse().expect("invalid timestamp format");
         self.record.package_record.timestamp = Some(ts.into());
+        self
+    }
+
+    pub fn indexed_timestamp(mut self, timestamp: &str) -> Self {
+        let ts: Timestamp = timestamp.parse().expect("invalid timestamp format");
+        self.record.package_record.indexed_timestamp = Some(ts.into());
         self
     }
 

--- a/crates/rattler_solve/tests/backends/main.rs
+++ b/crates/rattler_solve/tests/backends/main.rs
@@ -133,6 +133,7 @@ impl PackageBuilder {
                     license: None,
                     license_family: None,
                     timestamp: None,
+                    indexed_timestamp: None,
                     legacy_bz2_size: None,
                     legacy_bz2_md5: None,
                     purls: None,
@@ -498,6 +499,21 @@ macro_rules! solver_backend_tests {
         #[test]
         fn test_min_age_per_channel() {
             crate::min_age_tests::solve_min_age_per_channel::<$T>();
+        }
+
+        #[test]
+        fn test_min_age_prefers_indexed_timestamp() {
+            crate::min_age_tests::solve_min_age_prefers_indexed_timestamp::<$T>();
+        }
+
+        #[test]
+        fn test_min_age_indexed_timestamp_overrides_new_build_timestamp() {
+            crate::min_age_tests::solve_min_age_indexed_timestamp_overrides_new_build_timestamp::<$T>();
+        }
+
+        #[test]
+        fn test_min_age_falls_back_to_build_timestamp() {
+            crate::min_age_tests::solve_min_age_falls_back_to_build_timestamp::<$T>();
         }
 
         #[test]

--- a/crates/rattler_solve/tests/backends/min_age_tests.rs
+++ b/crates/rattler_solve/tests/backends/min_age_tests.rs
@@ -217,6 +217,85 @@ pub fn solve_min_age_include_unknown_timestamp<T: SolverImpl + Default>() {
         .run::<T>();
 }
 
+/// Test that `indexed_timestamp` takes precedence over the build `timestamp`
+/// when filtering: a record with an old build timestamp but a recent
+/// `indexed_timestamp` is excluded.
+pub fn solve_min_age_prefers_indexed_timestamp<T: SolverImpl + Default>() {
+    let repo = vec![
+        PackageBuilder::new("pkg-a")
+            .version("1.0")
+            .timestamp("2020-01-15T12:00:00Z")
+            .indexed_timestamp("2020-01-16T12:00:00Z")
+            .build(),
+        // Old build timestamp, but only recently added to the channel index.
+        PackageBuilder::new("pkg-a")
+            .version("2.0")
+            .timestamp("2020-01-15T12:00:00Z")
+            .indexed_timestamp("2026-03-23T12:00:00Z")
+            .build(),
+    ];
+
+    // 1000 days minimum age - cutoff is 2023-06-28
+    let min_age = std::time::Duration::from_secs(1000 * 24 * 60 * 60);
+
+    SolverCase::new("min_age prefers indexed_timestamp")
+        .repository(repo)
+        .specs(["pkg-a"])
+        .exclude_newer(exclude_newer_duration_config(min_age))
+        .expect_present([("pkg-a", "1.0")])
+        .expect_absent([("pkg-a", "2.0")])
+        .run::<T>();
+}
+
+/// Test that a record with a new build `timestamp` but an old
+/// `indexed_timestamp` is kept: the indexed time wins over the build time.
+pub fn solve_min_age_indexed_timestamp_overrides_new_build_timestamp<T: SolverImpl + Default>() {
+    let repo = vec![
+        PackageBuilder::new("pkg-a")
+            .version("1.0")
+            // Future-dated build timestamp, but indexed long ago.
+            .timestamp("2026-03-23T12:00:00Z")
+            .indexed_timestamp("2020-01-16T12:00:00Z")
+            .build(),
+    ];
+
+    // 1000 days minimum age - cutoff is 2023-06-28
+    let min_age = std::time::Duration::from_secs(1000 * 24 * 60 * 60);
+
+    SolverCase::new("min_age indexed_timestamp overrides new build timestamp")
+        .repository(repo)
+        .specs(["pkg-a"])
+        .exclude_newer(exclude_newer_duration_config(min_age))
+        .expect_present([("pkg-a", "1.0")])
+        .run::<T>();
+}
+
+/// Test that records without an `indexed_timestamp` fall back to the build
+/// `timestamp`.
+pub fn solve_min_age_falls_back_to_build_timestamp<T: SolverImpl + Default>() {
+    let repo = vec![
+        PackageBuilder::new("pkg-a")
+            .version("1.0")
+            .timestamp("2020-01-15T12:00:00Z")
+            .build(),
+        PackageBuilder::new("pkg-a")
+            .version("2.0")
+            .timestamp("2024-06-15T12:00:00Z")
+            .build(),
+    ];
+
+    // 1000 days minimum age - cutoff is 2023-06-28
+    let min_age = std::time::Duration::from_secs(1000 * 24 * 60 * 60);
+
+    SolverCase::new("min_age falls back to build timestamp")
+        .repository(repo)
+        .specs(["pkg-a"])
+        .exclude_newer(exclude_newer_duration_config(min_age))
+        .expect_present([("pkg-a", "1.0")])
+        .expect_absent([("pkg-a", "2.0")])
+        .run::<T>();
+}
+
 /// Test that channel-specific minimum ages override the global minimum age.
 pub fn solve_min_age_per_channel<T: SolverImpl + Default>() {
     let repo = vec![

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -118,6 +118,7 @@ pub async fn simple_solve(
                 license: None,
                 license_family: None,
                 timestamp: None,
+                indexed_timestamp: None,
                 python_site_packages_path: None,
                 legacy_bz2_md5: None,
                 legacy_bz2_size: None,

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -4214,6 +4214,7 @@ dependencies = [
  "rattler_conda_types",
  "serde",
  "serde_json",
+ "strum",
  "thiserror 2.0.18",
  "toml",
  "tracing",

--- a/py-rattler/rattler/index/index.py
+++ b/py-rattler/rattler/index/index.py
@@ -95,6 +95,7 @@ async def index_fs(
     write_shards: bool = True,
     repodata_revisions: Optional[RepodataRevisions] = None,
     package_revision_assignment: Literal["from-index-json", "latest"] = "from-index-json",
+    backfill_indexed_timestamps: Literal["from-conda-package-timestamp", "now", "off"] = "from-conda-package-timestamp",
     force: bool = False,
     max_parallel: int | None = None,
 ) -> None:
@@ -115,6 +116,10 @@ async def index_fs(
         repodata_revisions: Repodata revisions to advertise, with optional `n_packages`, `oldest`, and `newest` metadata.
                             Either a sequence of revisions or a `vN`-keyed dictionary, e.g. `{"v3": {"n_packages": 1}}`.
         package_revision_assignment: Whether to assign packages to the revision required by their `index.json`, or to the latest advertised revision.
+        backfill_indexed_timestamps: How to backfill `indexed_timestamp` for records in existing repodata that lack the field:
+                                     `"from-conda-package-timestamp"` (default) seeds it from the package's build timestamp (clamped to the indexing time),
+                                     `"now"` seeds it with the indexing time, `"off"` leaves records untouched.
+                                     Newly indexed packages always get the current indexing time.
         force: Whether to forcefully re-index all subdirs.
         max_parallel: The maximum number of packages to process in-memory simultaneously.
     """
@@ -126,6 +131,7 @@ async def index_fs(
         write_shards,
         _repodata_revisions_to_dicts(repodata_revisions),
         package_revision_assignment,
+        backfill_indexed_timestamps,
         force,
         max_parallel,
     )
@@ -140,6 +146,7 @@ async def index_s3(
     write_shards: bool = True,
     repodata_revisions: Optional[RepodataRevisions] = None,
     package_revision_assignment: Literal["from-index-json", "latest"] = "from-index-json",
+    backfill_indexed_timestamps: Literal["from-conda-package-timestamp", "now", "off"] = "from-conda-package-timestamp",
     force: bool = False,
     max_parallel: int | None = None,
     precondition_checks: bool = True,
@@ -163,6 +170,10 @@ async def index_s3(
         repodata_revisions: Repodata revisions to advertise, with optional `n_packages`, `oldest`, and `newest` metadata.
                             Either a sequence of revisions or a `vN`-keyed dictionary, e.g. `{"v3": {"n_packages": 1}}`.
         package_revision_assignment: Whether to assign packages to the revision required by their `index.json`, or to the latest advertised revision.
+        backfill_indexed_timestamps: How to backfill `indexed_timestamp` for records in existing repodata that lack the field:
+                                     `"from-conda-package-timestamp"` (default) seeds it from the package's build timestamp (clamped to the indexing time),
+                                     `"now"` seeds it with the indexing time, `"off"` leaves records untouched.
+                                     Newly indexed packages always get the current indexing time.
         force: Whether to forcefully re-index all subdirs.
         max_parallel: The maximum number of packages to process in-memory simultaneously.
         precondition_checks: Whether to perform precondition checks before indexing on S3 buckets which helps to prevent data corruption when indexing with multiple processes at the same time.  Defaults to True.
@@ -176,6 +187,7 @@ async def index_s3(
         write_shards,
         _repodata_revisions_to_dicts(repodata_revisions),
         package_revision_assignment,
+        backfill_indexed_timestamps,
         force,
         max_parallel,
         precondition_checks,

--- a/py-rattler/rattler/repo_data/package_record.py
+++ b/py-rattler/rattler/repo_data/package_record.py
@@ -812,6 +812,45 @@ class PackageRecord:
             self._record.timestamp = None
 
     @property
+    def indexed_timestamp(self) -> Optional[datetime.datetime]:
+        """
+        The date this entry was first added to the channel index by an
+        indexing tool. Unlike `timestamp` (which is set by the build tool),
+        this field is assigned by the indexing tool and preserved across
+        re-indexing runs. See https://github.com/conda/ceps/pull/154.
+
+        Examples
+        --------
+        ```python
+        >>> from rattler import PrefixRecord
+        >>> import datetime
+        >>> record = PrefixRecord.from_path(
+        ...     "../test-data/conda-meta/libsqlite-3.40.0-hcfcfb64_0.json"
+        ... )
+        >>> record.indexed_timestamp is None
+        True
+        >>> record.indexed_timestamp = datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc)
+        >>> record.indexed_timestamp
+        datetime.datetime(2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        >>> record.indexed_timestamp = None
+        >>> record.indexed_timestamp is None
+        True
+        >>>
+        ```
+        """
+        if self._record.indexed_timestamp:
+            return datetime.datetime.fromtimestamp(self._record.indexed_timestamp / 1000.0, tz=datetime.timezone.utc)
+
+        return self._record.indexed_timestamp
+
+    @indexed_timestamp.setter
+    def indexed_timestamp(self, value: Optional[datetime.datetime]) -> None:
+        if value is not None:
+            self._record.indexed_timestamp = int(value.timestamp() * 1000)
+        else:
+            self._record.indexed_timestamp = None
+
+    @property
     def track_features(self) -> List[str]:
         """
         Track features are nowadays only used to downweight

--- a/py-rattler/rattler/repo_data/package_record.py
+++ b/py-rattler/rattler/repo_data/package_record.py
@@ -817,7 +817,7 @@ class PackageRecord:
         The date this entry was first added to the channel index by an
         indexing tool. Unlike `timestamp` (which is set by the build tool),
         this field is assigned by the indexing tool and preserved across
-        re-indexing runs. See https://github.com/conda/ceps/pull/154.
+        re-indexing runs. See the draft CEP: https://github.com/conda/ceps/pull/154.
 
         Examples
         --------

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -69,6 +69,8 @@ async def solve(
         timeout:    The maximum time the solver is allowed to run.
         exclude_newer: Exclude any record that is newer than the given datetime,
             or newer than the cutoff produced by subtracting a timedelta from now.
+            The cutoff is compared against a record's `indexed_timestamp` when
+            available, falling back to the build `timestamp` otherwise.
         strategy: The strategy to use when multiple versions of a package are available.
 
             * `"highest"`: Select the highest compatible version of all packages.
@@ -175,6 +177,8 @@ async def solve_with_sparse_repodata(
         timeout:    The maximum time the solver is allowed to run.
         exclude_newer: Exclude any record that is newer than the given datetime,
             or newer than the cutoff produced by subtracting a timedelta from now.
+            The cutoff is compared against a record's `indexed_timestamp` when
+            available, falling back to the build `timestamp` otherwise.
         strategy: The strategy to use when multiple versions of a package are available.
 
             * `"highest"`: Select the highest compatible version of all packages.

--- a/py-rattler/src/index.rs
+++ b/py-rattler/src/index.rs
@@ -3,8 +3,8 @@ use pyo3_async_runtimes::tokio::future_into_py;
 use rattler_conda_types::Platform;
 use rattler_config::config::concurrency::default_max_concurrent_solves;
 use rattler_index::{
-    IndexFsConfig, IndexS3Config, PackageRevisionAssignment, RepodataRevisionInfo, index_fs,
-    index_s3,
+    BackfillIndexedTimestamps, IndexFsConfig, IndexS3Config, PackageRevisionAssignment,
+    RepodataRevisionInfo, index_fs, index_s3,
 };
 use url::Url;
 
@@ -25,9 +25,17 @@ fn parse_package_revision_assignment(value: &str) -> PyResult<PackageRevisionAss
     }
 }
 
+fn parse_backfill_indexed_timestamps(value: &str) -> PyResult<BackfillIndexedTimestamps> {
+    value.parse().map_err(|_| {
+        PyValueError::new_err(format!(
+            "invalid backfill_indexed_timestamps '{value}', expected 'from-conda-package-timestamp', 'now' or 'off'"
+        ))
+    })
+}
+
 #[pyfunction]
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
-#[pyo3(signature = (channel_directory, target_platform=None, repodata_patch=None, write_zst=true, write_shards=true, repodata_revisions=None, package_revision_assignment=None, force=false, max_parallel=None))]
+#[pyo3(signature = (channel_directory, target_platform=None, repodata_patch=None, write_zst=true, write_shards=true, repodata_revisions=None, package_revision_assignment=None, backfill_indexed_timestamps=None, force=false, max_parallel=None))]
 pub fn py_index_fs<'py>(
     py: Python<'py>,
     channel_directory: PathBuf,
@@ -37,6 +45,7 @@ pub fn py_index_fs<'py>(
     write_shards: bool,
     repodata_revisions: Option<Bound<'py, PyAny>>,
     package_revision_assignment: Option<String>,
+    backfill_indexed_timestamps: Option<String>,
     force: bool,
     max_parallel: Option<usize>,
 ) -> PyResult<Bound<'py, PyAny>> {
@@ -44,6 +53,11 @@ pub fn py_index_fs<'py>(
         package_revision_assignment
             .as_deref()
             .unwrap_or("from-index-json"),
+    )?;
+    let backfill_indexed_timestamps = parse_backfill_indexed_timestamps(
+        backfill_indexed_timestamps
+            .as_deref()
+            .unwrap_or("from-conda-package-timestamp"),
     )?;
     let repodata_revisions = match repodata_revisions {
         Some(value) => depythonize::<Vec<RepodataRevisionInfo>>(&value)?,
@@ -59,6 +73,7 @@ pub fn py_index_fs<'py>(
             write_shards,
             repodata_revisions,
             package_revision_assignment,
+            backfill_indexed_timestamps,
             force,
             max_parallel: max_parallel.unwrap_or_else(default_max_concurrent_solves),
             multi_progress: None,
@@ -70,7 +85,7 @@ pub fn py_index_fs<'py>(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
-#[pyo3(signature = (channel_url, credentials=None, target_platform=None, repodata_patch=None, write_zst=true, write_shards=true, repodata_revisions=None, package_revision_assignment=None, force=false, max_parallel=None, precondition_checks=true))]
+#[pyo3(signature = (channel_url, credentials=None, target_platform=None, repodata_patch=None, write_zst=true, write_shards=true, repodata_revisions=None, package_revision_assignment=None, backfill_indexed_timestamps=None, force=false, max_parallel=None, precondition_checks=true))]
 pub fn py_index_s3<'py>(
     py: Python<'py>,
     channel_url: String,
@@ -81,6 +96,7 @@ pub fn py_index_s3<'py>(
     write_shards: bool,
     repodata_revisions: Option<Bound<'py, PyAny>>,
     package_revision_assignment: Option<String>,
+    backfill_indexed_timestamps: Option<String>,
     force: bool,
     max_parallel: Option<usize>,
     precondition_checks: bool,
@@ -89,6 +105,11 @@ pub fn py_index_s3<'py>(
         package_revision_assignment
             .as_deref()
             .unwrap_or("from-index-json"),
+    )?;
+    let backfill_indexed_timestamps = parse_backfill_indexed_timestamps(
+        backfill_indexed_timestamps
+            .as_deref()
+            .unwrap_or("from-conda-package-timestamp"),
     )?;
     let repodata_revisions = match repodata_revisions {
         Some(value) => depythonize::<Vec<RepodataRevisionInfo>>(&value)?,
@@ -126,6 +147,7 @@ pub fn py_index_s3<'py>(
             write_shards,
             repodata_revisions,
             package_revision_assignment,
+            backfill_indexed_timestamps,
             force,
             max_parallel: max_parallel.unwrap_or_else(default_max_concurrent_solves),
             multi_progress: None,

--- a/py-rattler/src/record.rs
+++ b/py-rattler/src/record.rs
@@ -206,6 +206,7 @@ impl PyRecord {
                 extra_depends: BTreeMap::new(),
                 features: None,
                 flags: Vec::new(),
+                indexed_timestamp: None,
                 legacy_bz2_md5: None,
                 legacy_bz2_size: None,
                 license: None,
@@ -614,6 +615,30 @@ impl PyRecord {
             ));
         } else {
             self.as_package_record_mut().timestamp = None;
+        }
+
+        Ok(())
+    }
+
+    /// The date this entry was first added to the channel index by an
+    /// indexing tool.
+    #[getter]
+    pub fn indexed_timestamp(&self) -> Option<i64> {
+        self.as_package_record()
+            .indexed_timestamp
+            .map(|time| time.timestamp_millis())
+    }
+
+    #[setter]
+    pub fn set_indexed_timestamp(&mut self, indexed_timestamp: Option<i64>) -> PyResult<()> {
+        if let Some(ts) = indexed_timestamp {
+            self.as_package_record_mut().indexed_timestamp =
+                Some(TimestampMs::from_timestamp_millis(
+                    jiff::Timestamp::from_millisecond(ts)
+                        .map_err(|_| PyValueError::new_err("Invalid timestamp"))?,
+                ));
+        } else {
+            self.as_package_record_mut().indexed_timestamp = None;
         }
 
         Ok(())

--- a/py-rattler/tests/unit/test_index.py
+++ b/py-rattler/tests/unit/test_index.py
@@ -44,6 +44,34 @@ async def test_index(package_directory):
 
 
 @pytest.mark.asyncio
+async def test_index_assigns_indexed_timestamp(package_directory):
+    test_start_ms = int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp() * 1000)
+    await index_fs(package_directory, Platform("noarch"))
+
+    with open(package_directory / "noarch/repodata.json") as f:
+        repodata = json.load(f)
+    record = repodata["packages"]["pytweening-1.0.4-pyhd8ed1ab_0.tar.bz2"]
+    assert record["indexed_timestamp"] >= test_start_ms
+
+
+@pytest.mark.asyncio
+async def test_index_backfill_indexed_timestamps_off(package_directory):
+    await index_fs(package_directory, Platform("noarch"), backfill_indexed_timestamps="off")
+
+    with open(package_directory / "noarch/repodata.json") as f:
+        repodata = json.load(f)
+    # Newly indexed packages always get a value, regardless of the backfill mode.
+    record = repodata["packages"]["pytweening-1.0.4-pyhd8ed1ab_0.tar.bz2"]
+    assert "indexed_timestamp" in record
+
+
+@pytest.mark.asyncio
+async def test_index_backfill_indexed_timestamps_invalid(package_directory):
+    with pytest.raises(ValueError, match="backfill_indexed_timestamps"):
+        await index_fs(package_directory, Platform("noarch"), backfill_indexed_timestamps="invalid")
+
+
+@pytest.mark.asyncio
 async def test_index_specific_subdir_non_noarch(package_directory):
     await index_fs(package_directory, Platform("win-64"))
 

--- a/py-rattler/tests/unit/test_package_record.py
+++ b/py-rattler/tests/unit/test_package_record.py
@@ -194,3 +194,26 @@ def test_package_record_topological_sort_robust() -> None:
         sorted_records = PackageRecord.sort_topologically(records)
         sorted_names = [r.name.normalized for r in sorted_records]
         assert sorted_names == expected_order
+
+
+def test_indexed_timestamp_roundtrip() -> None:
+    record = PackageRecord(
+        name="test-pkg",
+        version="1.0.0",
+        build="py_0",
+        build_number=0,
+        subdir="noarch",
+    )
+
+    assert record.indexed_timestamp is None
+
+    ts = datetime.datetime(2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+    record.indexed_timestamp = ts
+    assert record.indexed_timestamp == ts
+
+    json_data = json.loads(record.to_json())
+    assert json_data["indexed_timestamp"] == int(ts.timestamp() * 1000)
+
+    record.indexed_timestamp = None
+    assert record.indexed_timestamp is None
+    assert "indexed_timestamp" not in json.loads(record.to_json())


### PR DESCRIPTION
### Description

This PR implements support for the `indexed_timestamp` field in package records, as specified in [CEP 154](https://github.com/conda/ceps/pull/154). The `indexed_timestamp` field tracks when a package was first added to a channel index by an indexing tool, distinct from the build `timestamp` set by build tools.

**Key changes:**

1. **Core field addition**: Added `indexed_timestamp: Option<TimestampMs>` to `PackageRecord` in `rattler_conda_types`, with proper serialization/deserialization support.

2. **Indexing logic**: 
   - New packages are always assigned the current indexing time
   - Previously indexed packages preserve their `indexed_timestamp` across re-indexing runs, even with `force` mode
   - Packages with future build timestamps are rejected to prevent invalid state
   - Backfill modes for records lacking the field:
     - `FromCondaPackageTimestamp` (default): Seeds from package build timestamp, clamped to indexing time
     - `Now`: Seeds with current indexing time
     - `Off`: Leaves records untouched

3. **Solver integration**: The `exclude_newer` constraint now prefers `indexed_timestamp` over build `timestamp` when filtering packages, with appropriate messaging to users.

4. **Configuration**: Added `BackfillIndexedTimestamps` enum to `rattler_config` with CLI and config file support.

5. **Python bindings**: Exposed `indexed_timestamp` property in `PackageRecord` and `PrefixRecord` Python classes.

6. **Comprehensive testing**: Added tests covering timestamp assignment, preservation across re-indexing, backfill modes, future timestamp rejection, and solver behavior with indexed timestamps.

### How Has This Been Tested?

- Added integration tests in `basic_indexing.rs`:
  - `test_indexed_timestamp_assignment_and_preservation`: Verifies assignment on new packages and preservation across re-indexing
  - `test_indexed_timestamp_backfill_modes`: Tests all three backfill modes
  - `test_index_rejects_future_build_timestamp`: Validates rejection of future-dated packages
  
- Added solver tests in `min_age_tests.rs`:
  - `solve_min_age_prefers_indexed_timestamp`: Confirms indexed time takes precedence
  - `solve_min_age_indexed_timestamp_overrides_new_build_timestamp`: Tests override behavior
  - `solve_min_age_falls_back_to_build_timestamp`: Validates fallback for records without indexed_timestamp

- Added Python tests in `test_index.py` and `test_package_record.py` covering roundtrip serialization and timestamp assignment

- Existing tests updated to include the new `backfill_indexed_timestamps` configuration field

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README.md updated)
- [x] I have added sufficient tests to cover my changes

https://claude.ai/code/session_01KvrZfUCxfjQzPBJKzPG5Ez