### PR TITLE
feat: support OAuth2 authentication in rattler-upload for non-prefix backends

### DIFF
--- a/crates/rattler_upload/src/upload/mod.rs
+++ b/crates/rattler_upload/src/upload/mod.rs
@@ -91,8 +91,12 @@ pub async fn upload_package_to_quetz(
 ) -> miette::Result<()> {
     let token = match quetz_data.api_key {
         Some(api_key) => api_key,
-        None => match storage.get_by_url(Url::from(quetz_data.url.clone())) {
+        None => match storage
+            .get_by_url_refreshed(Url::from(quetz_data.url.clone()))
+            .await
+        {
             Ok((_, Some(Authentication::CondaToken(token)))) => token,
+            Ok((_, Some(Authentication::OAuth { access_token, .. }))) => access_token,
             Ok((_, Some(_))) => {
                 return Err(miette::miette!("A Conda token is required for authentication with quetz.
                         Authentication information found in the keychain / auth file, but it was not a Conda token"));
@@ -145,7 +149,10 @@ pub async fn upload_package_to_artifactory(
 ) -> miette::Result<()> {
     let token = match artifactory_data.token {
         Some(t) => t,
-        _ => match storage.get_by_url(Url::from(artifactory_data.url.clone())) {
+        _ => match storage
+            .get_by_url_refreshed(Url::from(artifactory_data.url.clone()))
+            .await
+        {
             Ok((_, Some(Authentication::BearerToken(token)))) => token,
             Ok((
                 _,
@@ -159,6 +166,7 @@ pub async fn upload_package_to_artifactory(
                 );
                 password
             }
+            Ok((_, Some(Authentication::OAuth { access_token, .. }))) => access_token,
             Ok((_, Some(_))) => {
                 return Err(miette::miette!("A bearer token is required for authentication with artifactory.
                             Authentication information found in the keychain / auth file, but it was not a bearer token"));
@@ -221,8 +229,12 @@ pub async fn upload_package_to_anaconda(
 ) -> Result<(), anaconda::AnacondaError> {
     let token = match anaconda_data.api_key {
         Some(token) => token,
-        None => match storage.get_by_url(Url::from(anaconda_data.url.clone())) {
+        None => match storage
+            .get_by_url_refreshed(Url::from(anaconda_data.url.clone()))
+            .await
+        {
             Ok((_, Some(Authentication::CondaToken(token)))) => token,
+            Ok((_, Some(Authentication::OAuth { access_token, .. }))) => access_token,
             Ok((_, Some(_))) => {
                 return Err(anaconda::AnacondaError::WrongAuthenticationType);
             }
@@ -279,11 +291,15 @@ pub async fn upload_package_to_cloudsmith(
 ) -> Result<(), cloudsmith::CloudsmithError> {
     let token = match cloudsmith_data.api_key {
         Some(token) => token,
-        None => match storage.get_by_url(Url::from(cloudsmith_data.url.clone())) {
+        None => match storage
+            .get_by_url_refreshed(Url::from(cloudsmith_data.url.clone()))
+            .await
+        {
             Ok((
                 _,
                 Some(Authentication::CondaToken(token) | Authentication::BearerToken(token)),
             )) => token,
+            Ok((_, Some(Authentication::OAuth { access_token, .. }))) => access_token,
             Ok((_, Some(_))) => {
                 return Err(cloudsmith::CloudsmithError::WrongAuthenticationType);
             }
@@ -473,9 +489,13 @@ async fn send_request(
 #[cfg(test)]
 mod test {
     use axum::{Router, http::StatusCode};
-    use rattler_networking::AuthenticationStorage;
+    use rattler_networking::{
+        Authentication, AuthenticationStorage,
+        authentication_storage::backends::memory::MemoryStorage,
+    };
+    use std::sync::Arc;
 
-    use crate::upload::opt::{ArtifactoryData, QuetzData};
+    use crate::upload::opt::{ArtifactoryData, CloudsmithData, QuetzData};
     use crate::upload::test_utils::{start_test_server, test_package_path};
 
     async fn ok_with_api_key(
@@ -656,9 +676,96 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_cloudsmith_upload_oauth_from_storage_success() {
+        use axum::routing::post;
+        use std::net::SocketAddr;
+
+        let addr = SocketAddr::new([127, 0, 0, 1].into(), 0);
+        let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base_url: url::Url = format!("http://{}:{}", addr.ip(), addr.port())
+            .parse()
+            .unwrap();
+
+        let upload_handler = {
+            let base_url = base_url.clone();
+            move |headers: axum::http::HeaderMap| {
+                let base_url = base_url.clone();
+                async move {
+                    let api_key = headers.get("X-Api-Key").unwrap().to_str().unwrap();
+                    assert_eq!(api_key, "oauth-access-token");
+                    let upload_url = base_url.join("s3-upload").unwrap();
+                    (
+                        axum::http::StatusCode::OK,
+                        [("content-type", "application/json")],
+                        serde_json::json!({
+                            "identifier": "test-file-id",
+                            "upload_url": upload_url.to_string(),
+                            "upload_fields": {"key": "value"}
+                        })
+                        .to_string(),
+                    )
+                }
+            }
+        };
+
+        let router = Router::new()
+            .route("/files/{owner}/{repo}/", post(upload_handler))
+            .route("/s3-upload", post(|| async { StatusCode::OK }))
+            .route(
+                "/packages/{owner}/{repo}/upload/conda/",
+                post(|| async {
+                    (
+                        StatusCode::OK,
+                        [("content-type", "application/json")],
+                        serde_json::json!({
+                            "slug_perm": "test-slug-perm",
+                            "slug": "test-slug"
+                        })
+                        .to_string(),
+                    )
+                }),
+            );
+
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+
+        let mut storage = AuthenticationStorage::empty();
+        storage.add_backend(Arc::new(MemoryStorage::new()));
+        storage
+            .store(
+                base_url.host_str().unwrap(),
+                &Authentication::OAuth {
+                    access_token: "oauth-access-token".to_string(),
+                    refresh_token: None,
+                    expires_at: Some(i64::MAX),
+                    token_endpoint: String::new(),
+                    revocation_endpoint: None,
+                    client_id: "client".to_string(),
+                },
+            )
+            .unwrap();
+
+        let cloudsmith_data = CloudsmithData::new(
+            "test-owner".to_string(),
+            "test-repo".to_string(),
+            None,
+            Some(base_url),
+        );
+        let result = super::upload_package_to_cloudsmith(
+            &storage,
+            &vec![test_package_path()],
+            cloudsmith_data,
+        )
+        .await;
+        assert!(result.is_ok(), "{:?}", result.unwrap_err());
+    }
+
+    #[tokio::test]
     async fn test_cloudsmith_upload_missing_api_key() {
         let storage = AuthenticationStorage::empty();
-        let cloudsmith_data = crate::upload::opt::CloudsmithData::new(
+        let cloudsmith_data = CloudsmithData::new(
             "test-owner".to_string(),
             "test-repo".to_string(),
             None,


### PR DESCRIPTION
### Description

The Quetz, Anaconda, Cloudsmith, and Artifactory upload backends did not accept OAuth2 credentials: they looked up authentication via the non-refreshing `storage.get_by_url(...)` and only matched their native token variant (`CondaToken`/`BearerToken`), returning a wrong-authentication-type error for an `Authentication::OAuth` entry.

The prefix.dev path already solves this in `prefix.rs::fetch_token_from_storage`, which calls the async `storage.get_by_url_refreshed(url).await` (transparently invoking `maybe_refresh_oauth` when the access token is near expiry) and accepts `Authentication::OAuth { access_token, .. }`.

This PR switches the four non-prefix backends to the same `get_by_url_refreshed(...).await` lookup and adds an `Authentication::OAuth { access_token, .. }` match arm that yields the (refreshed) access token, mirroring `prefix.rs`. Each backend continues to send the resulting token over its existing transport, so the same OAuth credential now works uniformly across all upload backends and is automatically refreshed before use.

Fixes #2324

### How Has This Been Tested?

- `cargo test -p rattler_upload` (23 tests pass).
- Added `test_cloudsmith_upload_oauth_from_storage_success`: stores an `Authentication::OAuth` credential (with a non-expired `access_token`, so no refresh network call fires) for the Cloudsmith host in a `MemoryStorage` backend, runs the upload against a mock server, and asserts the server receives the OAuth access token.
- The pre-existing `WrongAuthenticationType` / `MissingApiKey` error paths are unchanged and still covered by their existing tests (e.g. `test_cloudsmith_upload_missing_api_key`).
- `cargo fmt --check` and `cargo check -p rattler_upload` are clean.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
