### PR TITLE
feat: Support remote URLs in inject, fetch-file, and inspect commands

### DIFF
--- a/crates/rattler-bin/src/commands/compare_packages.rs
+++ b/crates/rattler-bin/src/commands/compare_packages.rs
@@ -15,7 +15,8 @@ use rattler_package_streaming::{
     archive::{ArchiveEntryKind, PackageArchive, Section},
 };
 use sha2::{Digest, Sha256};
-use url::Url;
+
+use super::package_source::{PackageSource, client_for};
 
 /// Compare two conda packages and report the differences.
 ///
@@ -33,58 +34,14 @@ pub struct Opt {
     right: String,
 }
 
-/// A package location: either a local file or a remote URL.
-enum PackageSource {
-    Url(Url),
-    Path(PathBuf),
-}
-
-/// Parses a command line argument into a local path or a remote URL. A single
-/// letter scheme is treated as a Windows drive letter.
-fn parse_source(source: &str) -> PackageSource {
-    match Url::parse(source) {
-        Ok(url) if url.scheme() == "file" => url.to_file_path().map_or_else(
-            |()| PackageSource::Path(PathBuf::from(source)),
-            PackageSource::Path,
-        ),
-        Ok(url) if url.scheme().len() > 1 => PackageSource::Url(url),
-        _ => PackageSource::Path(PathBuf::from(source)),
-    }
-}
-
-async fn open_package(
-    source: &PackageSource,
-    client: Option<reqwest_middleware::ClientWithMiddleware>,
-    display: &str,
-) -> miette::Result<PackageArchive> {
-    let archive = match source {
-        PackageSource::Url(url) => {
-            let client = client.expect("a client is created whenever a source is a URL");
-            PackageArchive::from_url(client, url.clone()).await
-        }
-        PackageSource::Path(path) => PackageArchive::from_path(path).await,
-    };
-    archive
-        .into_diagnostic()
-        .with_context(|| format!("failed to open package {display}"))
-}
-
 pub async fn compare_packages(opt: Opt, offline: bool) -> miette::Result<()> {
-    let left_source = parse_source(&opt.left);
-    let right_source = parse_source(&opt.right);
-
-    // Only create an HTTP client when at least one of the packages is remote.
-    let client = if matches!(left_source, PackageSource::Url(_))
-        || matches!(right_source, PackageSource::Url(_))
-    {
-        Some(super::client::create_client_with_middleware(offline)?)
-    } else {
-        None
-    };
+    let left_source = PackageSource::parse(&opt.left);
+    let right_source = PackageSource::parse(&opt.right);
+    let client = client_for([&left_source, &right_source], offline)?;
 
     let (left, right) = tokio::try_join!(
-        open_package(&left_source, client.clone(), &opt.left),
-        open_package(&right_source, client, &opt.right),
+        left_source.open(client.as_ref()),
+        right_source.open(client.as_ref()),
     )?;
 
     println!("comparing");
@@ -591,26 +548,5 @@ mod tests {
         assert_eq!(spec_name("libzlib"), "libzlib");
         assert_eq!(spec_name("foo[extras=[bar]]"), "foo");
         assert_eq!(spec_name("numpy 1.24.*"), "numpy");
-    }
-
-    #[test]
-    fn test_parse_source() {
-        assert!(matches!(
-            parse_source("https://example.com/pkg-1.0-0.conda"),
-            PackageSource::Url(_)
-        ));
-        assert!(matches!(
-            parse_source("./pkg-1.0-0.conda"),
-            PackageSource::Path(_)
-        ));
-        assert!(matches!(
-            parse_source("pkg-1.0-0.tar.bz2"),
-            PackageSource::Path(_)
-        ));
-        // A single letter scheme is a Windows drive letter, not a URL.
-        assert!(matches!(
-            parse_source(r"C:\packages\pkg-1.0-0.conda"),
-            PackageSource::Path(_)
-        ));
     }
 }

--- a/crates/rattler-bin/src/commands/fetch_file.rs
+++ b/crates/rattler-bin/src/commands/fetch_file.rs
@@ -48,7 +48,10 @@ pub async fn fetch_file(opt: Opt, offline: bool) -> miette::Result<()> {
 /// (including `file://` URLs).
 fn parse_remote_url(package: &str) -> Option<Url> {
     match Url::parse(package) {
-        Ok(url) if url.scheme() != "file" => Some(url),
+        // A single-character scheme is almost certainly a Windows drive letter
+        // (e.g. `C:\pkgs\foo.conda`), not a URL scheme. Treat those and
+        // `file://` URLs as local paths.
+        Ok(url) if url.scheme().len() > 1 && url.scheme() != "file" => Some(url),
         _ => None,
     }
 }

--- a/crates/rattler-bin/src/commands/fetch_file.rs
+++ b/crates/rattler-bin/src/commands/fetch_file.rs
@@ -1,16 +1,19 @@
+use std::fs::File;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use miette::{Context, IntoDiagnostic};
+use rattler_conda_types::package::CondaArchiveType;
 use rattler_package_streaming::reqwest::fetch::fetch_file_from_remote_url;
+use rattler_package_streaming::seek::read_package_file_content;
 use url::Url;
 
-/// Read a file from inside a remote conda package.
+/// Read a file from inside a local or remote conda package.
 #[derive(Debug, clap::Parser)]
 pub struct Opt {
-    /// URL of the conda package (.conda or .tar.bz2 archive)
+    /// Path or URL to the conda package (.conda or .tar.bz2 archive)
     #[clap(required = true)]
-    url: Url,
+    package: String,
 
     /// Path of the file inside the package (e.g. "info/index.json" or "lib/libfoo.so")
     #[clap(required = true)]
@@ -18,20 +21,55 @@ pub struct Opt {
 }
 
 pub async fn fetch_file(opt: Opt) -> miette::Result<()> {
-    let Opt { url, path } = opt;
-
-    let client = super::client::create_client_with_middleware()?;
+    let Opt { package, path } = opt;
 
     let target_path = Path::new(&path);
 
-    let bytes = fetch_file_from_remote_url(client, url, target_path)
-        .await
-        .into_diagnostic()?
-        .ok_or_else(|| miette::miette!("file '{}' not found in package", path))?;
+    let bytes = match parse_remote_url(&package) {
+        Some(url) => {
+            let client = super::client::create_client_with_middleware()?;
+            fetch_file_from_remote_url(client, url, target_path)
+                .await
+                .into_diagnostic()?
+        }
+        None => read_file_from_local_package(&package, target_path)?,
+    };
+
+    let bytes = bytes.ok_or_else(|| miette::miette!("file '{}' not found in package", path))?;
 
     std::io::stdout()
         .write_all(&bytes)
         .into_diagnostic()
         .context("failed to write to stdout")?;
     Ok(())
+}
+
+/// Parses the argument as a remote URL, returning `None` for local paths
+/// (including `file://` URLs).
+fn parse_remote_url(package: &str) -> Option<Url> {
+    match Url::parse(package) {
+        Ok(url) if url.scheme() != "file" => Some(url),
+        _ => None,
+    }
+}
+
+/// Reads a file from inside a local conda package archive.
+fn read_file_from_local_package(
+    package: &str,
+    target_path: &Path,
+) -> miette::Result<Option<Vec<u8>>> {
+    let package_path = PathBuf::from(package);
+    let archive_type = CondaArchiveType::try_from(&package_path)
+        .ok_or_else(|| miette::miette!("'{package}' is not a .conda or .tar.bz2 archive"))?;
+    let file = File::open(&package_path)
+        .into_diagnostic()
+        .with_context(|| format!("failed to open {package}"))?;
+
+    match read_package_file_content(&file, archive_type, target_path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(rattler_package_streaming::ExtractError::MissingComponent) => Ok(None),
+        Err(err) => Err(err)
+            .into_diagnostic()
+            .with_context(|| format!("failed to read '{}' from {package}", target_path.display())),
+    }
 }

--- a/crates/rattler-bin/src/commands/fetch_file.rs
+++ b/crates/rattler-bin/src/commands/fetch_file.rs
@@ -1,16 +1,15 @@
 use std::io::Write;
-use std::path::Path;
 
 use miette::{Context, IntoDiagnostic};
-use rattler_package_streaming::reqwest::fetch::fetch_file_from_remote_url;
-use url::Url;
 
-/// Read a file from inside a remote conda package.
+use super::package_source::{PackageSource, client_for};
+
+/// Read a file from inside a local or remote conda package.
 #[derive(Debug, clap::Parser)]
 pub struct Opt {
-    /// URL of the conda package (.conda or .tar.bz2 archive)
+    /// Path or URL of the conda package (.conda or .tar.bz2 archive)
     #[clap(required = true)]
-    url: Url,
+    package: String,
 
     /// Path of the file inside the package (e.g. "info/index.json" or "lib/libfoo.so")
     #[clap(required = true)]
@@ -18,16 +17,18 @@ pub struct Opt {
 }
 
 pub async fn fetch_file(opt: Opt, offline: bool) -> miette::Result<()> {
-    let Opt { url, path } = opt;
+    let Opt { package, path } = opt;
 
-    let client = super::client::create_client_with_middleware(offline)?;
+    let source = PackageSource::parse(&package);
+    let client = client_for([&source], offline)?;
+    let archive = source.open(client.as_ref()).await?;
 
-    let target_path = Path::new(&path);
-
-    let bytes = fetch_file_from_remote_url(client, url, target_path)
+    let bytes = archive
+        .read_file(&path)
         .await
-        .into_diagnostic()?
-        .ok_or_else(|| miette::miette!("file '{}' not found in package", path))?;
+        .into_diagnostic()
+        .with_context(|| format!("failed to read '{path}' from package {source}"))?
+        .ok_or_else(|| miette::miette!("file '{path}' not found in package"))?;
 
     std::io::stdout()
         .write_all(&bytes)

--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -1,26 +1,52 @@
 use miette::{Context, IntoDiagnostic};
-use rattler_conda_types::package::{IndexJson, PathsJson};
+use rattler_conda_types::package::{IndexJson, PackageFile, PathsJson};
 use rattler_package_streaming::reqwest::fetch::fetch_package_file_from_remote_url;
+use rattler_package_streaming::seek::read_package_file;
 use url::Url;
 
-/// Inspect package metadata from a remote conda package.
+/// Inspect package metadata from a local or remote conda package.
 #[derive(Debug, clap::Parser)]
 pub struct Opt {
-    /// URL of the conda package to inspect (must be a .conda archive)
+    /// Path or URL to the conda package to inspect (.conda or .tar.bz2 archive)
     #[clap(required = true)]
-    url: Url,
+    package: String,
 
     /// Number of files to print
     #[clap(long, default_value_t = 10)]
     limit: usize,
 }
 
-pub async fn inspect(opt: Opt) -> miette::Result<()> {
-    let client = super::client::create_client_with_middleware()?;
+/// Reads a typed package file from either a remote URL or a local path.
+async fn read_file<P: PackageFile + Send + 'static>(package: &str) -> miette::Result<P> {
+    match parse_remote_url(package) {
+        Some(url) => {
+            let client = super::client::create_client_with_middleware()?;
+            fetch_package_file_from_remote_url(client, url)
+                .await
+                .into_diagnostic()
+        }
+        None => {
+            let package = package.to_string();
+            tokio::task::spawn_blocking(move || read_package_file::<P>(&package))
+                .await
+                .into_diagnostic()?
+                .into_diagnostic()
+        }
+    }
+}
 
-    let index_json: IndexJson = fetch_package_file_from_remote_url(client.clone(), opt.url.clone())
+/// Parses the argument as a remote URL, returning `None` for local paths
+/// (including `file://` URLs).
+fn parse_remote_url(package: &str) -> Option<Url> {
+    match Url::parse(package) {
+        Ok(url) if url.scheme() != "file" => Some(url),
+        _ => None,
+    }
+}
+
+pub async fn inspect(opt: Opt) -> miette::Result<()> {
+    let index_json: IndexJson = read_file(&opt.package)
         .await
-        .into_diagnostic()
         .context("failed to read index.json")?;
 
     println!("name: {}", index_json.name.as_normalized());
@@ -45,9 +71,8 @@ pub async fn inspect(opt: Opt) -> miette::Result<()> {
         }
     }
 
-    let paths_json: PathsJson = fetch_package_file_from_remote_url(client, opt.url)
+    let paths_json: PathsJson = read_file(&opt.package)
         .await
-        .into_diagnostic()
         .context("failed to read paths.json")?;
 
     let total = paths_json.paths.len();

--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -21,20 +21,17 @@ async fn read_file<P: PackageFile + Send + 'static>(
     package: &str,
     offline: bool,
 ) -> miette::Result<P> {
-    match parse_remote_url(package) {
-        Some(url) => {
-            let client = super::client::create_client_with_middleware(offline)?;
-            fetch_package_file_from_remote_url(client, url)
-                .await
-                .into_diagnostic()
-        }
-        None => {
-            let package = package.to_string();
-            tokio::task::spawn_blocking(move || read_package_file::<P>(&package))
-                .await
-                .into_diagnostic()?
-                .into_diagnostic()
-        }
+    if let Some(url) = parse_remote_url(package) {
+        let client = super::client::create_client_with_middleware(offline)?;
+        fetch_package_file_from_remote_url(client, url)
+            .await
+            .into_diagnostic()
+    } else {
+        let package = package.to_string();
+        tokio::task::spawn_blocking(move || read_package_file::<P>(&package))
+            .await
+            .into_diagnostic()?
+            .into_diagnostic()
     }
 }
 

--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -39,7 +39,10 @@ async fn read_file<P: PackageFile + Send + 'static>(
 /// (including `file://` URLs).
 fn parse_remote_url(package: &str) -> Option<Url> {
     match Url::parse(package) {
-        Ok(url) if url.scheme() != "file" => Some(url),
+        // A single-character scheme is almost certainly a Windows drive letter
+        // (e.g. `C:\pkgs\foo.conda`), not a URL scheme. Treat those and
+        // `file://` URLs as local paths.
+        Ok(url) if url.scheme().len() > 1 && url.scheme() != "file" => Some(url),
         _ => None,
     }
 }

--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -5,16 +5,17 @@ use indicatif::HumanBytes;
 use miette::{Context, IntoDiagnostic};
 use rattler_conda_types::NoArchKind;
 use rattler_conda_types::package::{AboutJson, IndexJson, PackageFile, PathsJson, RunExportsJson};
-use rattler_package_streaming::archive::PackageArchive;
 use serde::Serialize;
 use url::Url;
 
-/// Inspect package metadata from a remote conda package.
+use super::package_source::{PackageSource, client_for};
+
+/// Inspect package metadata from a local or remote conda package.
 #[derive(Debug, clap::Parser)]
 pub struct Opt {
-    /// URL of the conda package to inspect (.conda or .tar.bz2 archive)
+    /// Path or URL of the conda package to inspect (.conda or .tar.bz2 archive)
     #[clap(required = true)]
-    url: Url,
+    package: String,
 
     /// Number of files to print (a negative value prints all files)
     #[clap(long, default_value_t = 10, allow_hyphen_values = true)]
@@ -39,12 +40,9 @@ struct Metadata {
 }
 
 pub async fn inspect(opt: Opt, offline: bool) -> miette::Result<()> {
-    let client = super::client::create_client_with_middleware(offline)?;
-
-    let archive = PackageArchive::from_url(client, opt.url.clone())
-        .await
-        .into_diagnostic()
-        .with_context(|| format!("failed to open package archive at {}", opt.url))?;
+    let source = PackageSource::parse(&opt.package);
+    let client = client_for([&source], offline)?;
+    let archive = source.open(client.as_ref()).await?;
 
     // All metadata lives in the info section; a single batched call reads it
     // in one pass (for sparse `.conda` archives usually straight from the

--- a/crates/rattler-bin/src/commands/mod.rs
+++ b/crates/rattler-bin/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod inspect;
 pub mod link;
 pub mod list;
 pub mod menu;
+pub mod package_source;
 pub mod prefix;
 pub mod progress;
 pub mod run;

--- a/crates/rattler-bin/src/commands/package_source.rs
+++ b/crates/rattler-bin/src/commands/package_source.rs
@@ -1,0 +1,122 @@
+//! Shared handling for commands that accept a conda package as either a local
+//! file path or a remote URL.
+
+use std::path::PathBuf;
+
+use miette::{Context, IntoDiagnostic};
+use rattler_package_streaming::archive::PackageArchive;
+use reqwest_middleware::ClientWithMiddleware;
+use url::Url;
+
+/// A conda package location: either a local file or a remote URL.
+#[derive(Debug, Clone)]
+pub enum PackageSource {
+    Url(Url),
+    Path(PathBuf),
+}
+
+impl PackageSource {
+    /// Parses a command line argument into a local path or a remote URL.
+    ///
+    /// `file://` URLs are converted to a path. A single letter scheme is
+    /// treated as a Windows drive letter (`C:\pkgs\foo.conda`), not a URL.
+    pub fn parse(source: &str) -> Self {
+        match Url::parse(source) {
+            Ok(url) if url.scheme() == "file" => url
+                .to_file_path()
+                .map_or_else(|()| Self::Path(PathBuf::from(source)), Self::Path),
+            Ok(url) if url.scheme().len() > 1 => Self::Url(url),
+            _ => Self::Path(PathBuf::from(source)),
+        }
+    }
+
+    /// Whether this source refers to a remote package.
+    pub fn is_url(&self) -> bool {
+        matches!(self, Self::Url(_))
+    }
+
+    /// Opens the package archive. A `client` must be supplied for remote
+    /// sources; see [`client_for`].
+    pub async fn open(
+        &self,
+        client: Option<&ClientWithMiddleware>,
+    ) -> miette::Result<PackageArchive> {
+        let archive = match self {
+            Self::Url(url) => {
+                let client = client.expect("a client is created whenever a source is a URL");
+                PackageArchive::from_url(client.clone(), url.clone()).await
+            }
+            Self::Path(path) => PackageArchive::from_path(path).await,
+        };
+        archive
+            .into_diagnostic()
+            .with_context(|| format!("failed to open package {self}"))
+    }
+}
+
+impl std::fmt::Display for PackageSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Url(url) => write!(f, "{url}"),
+            Self::Path(path) => write!(f, "{}", path.display()),
+        }
+    }
+}
+
+/// Creates an HTTP client only when at least one of the sources is remote, so
+/// purely local invocations never touch the network configuration.
+pub fn client_for<'a>(
+    sources: impl IntoIterator<Item = &'a PackageSource>,
+    offline: bool,
+) -> miette::Result<Option<ClientWithMiddleware>> {
+    if sources.into_iter().any(PackageSource::is_url) {
+        Ok(Some(super::client::create_client_with_middleware(offline)?))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_remote_urls() {
+        for source in [
+            "https://example.com/pkg-1.0-0.conda",
+            "http://example.com/pkg-1.0-0.tar.bz2",
+            "s3://bucket/pkg-1.0-0.conda",
+        ] {
+            assert!(
+                matches!(PackageSource::parse(source), PackageSource::Url(_)),
+                "{source} should be a URL"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_local_paths() {
+        for source in [
+            "/home/user/pkg-1.0-0.conda",
+            "./pkg-1.0-0.conda",
+            "pkg-1.0-0.tar.bz2",
+            // A single letter scheme is a Windows drive letter, not a URL.
+            r"C:\packages\pkg-1.0-0.conda",
+            "C:/packages/pkg-1.0-0.conda",
+        ] {
+            assert!(
+                matches!(PackageSource::parse(source), PackageSource::Path(_)),
+                "{source} should be a path"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_file_url_becomes_path() {
+        let source = PackageSource::parse("file:///home/user/pkg-1.0-0.conda");
+        assert!(
+            matches!(&source, PackageSource::Path(path) if path.ends_with("pkg-1.0-0.conda")),
+            "file:// URL should become a local path, got {source:?}"
+        );
+    }
+}

--- a/crates/rattler-bin/src/commands/prefix.rs
+++ b/crates/rattler-bin/src/commands/prefix.rs
@@ -178,7 +178,10 @@ struct ResolvedPackage {
 /// (including `file://` URLs).
 fn parse_remote_url(package: &str) -> Option<Url> {
     match Url::parse(package) {
-        Ok(url) if url.scheme() != "file" => Some(url),
+        // A single-character scheme is almost certainly a Windows drive letter
+        // (e.g. `C:\pkgs\foo.conda`), not a URL scheme. Treat those and
+        // `file://` URLs as local paths.
+        Ok(url) if url.scheme().len() > 1 && url.scheme() != "file" => Some(url),
         _ => None,
     }
 }
@@ -747,6 +750,24 @@ mod tests {
         .unwrap();
 
         target_package
+    }
+
+    #[test]
+    fn test_parse_remote_url_classifies_paths_and_urls() {
+        // Remote URLs.
+        assert!(parse_remote_url("https://example.com/pkg-1.0-0.conda").is_some());
+        assert!(parse_remote_url("http://example.com/pkg-1.0-0.conda").is_some());
+        assert!(parse_remote_url("s3://bucket/pkg-1.0-0.conda").is_some());
+
+        // Local paths must never be treated as remote.
+        assert!(parse_remote_url("/home/user/pkg-1.0-0.conda").is_none());
+        assert!(parse_remote_url("./pkg-1.0-0.conda").is_none());
+        assert!(parse_remote_url("pkg-1.0-0.conda").is_none());
+        // Windows drive-letter paths parse with a single-character "scheme".
+        assert!(parse_remote_url(r"C:\pkgs\pkg-1.0-0.conda").is_none());
+        assert!(parse_remote_url("C:/pkgs/pkg-1.0-0.conda").is_none());
+        // Explicit file:// URLs are local too.
+        assert!(parse_remote_url("file:///home/user/pkg-1.0-0.conda").is_none());
     }
 
     fn path_string(path: &Path) -> String {

--- a/crates/rattler-bin/src/commands/prefix.rs
+++ b/crates/rattler-bin/src/commands/prefix.rs
@@ -1,11 +1,14 @@
 use std::path::{Path, PathBuf};
 
+use futures_util::StreamExt;
 use miette::{Context, IntoDiagnostic};
-use rattler::install::Installer;
+use rattler::{default_cache_dir, install::Installer, package_cache::PackageCache};
 use rattler_conda_types::{
     MatchSpec, Matches, PackageName, PackageRecord, ParseStrictness, Platform, PrefixRecord,
     RepoDataRecord, package::DistArchiveIdentifier,
 };
+use reqwest_middleware::ClientWithMiddleware;
+use tokio::io::AsyncWriteExt;
 use url::Url;
 
 const PIXI_ENVIRONMENT_FINGERPRINT_FILE: &str = ".pixi-environment-fingerprint";
@@ -13,9 +16,9 @@ const PIXI_ENVIRONMENT_FINGERPRINT_FILE: &str = ".pixi-environment-fingerprint";
 /// Add one or more conda package archives to a prefix without solving.
 #[derive(Debug, clap::Parser)]
 pub struct InjectOpt {
-    /// Local paths to conda package archives (.conda or .tar.bz2)
+    /// Paths or URLs to conda package archives (.conda or .tar.bz2)
     #[clap(required = true)]
-    packages: Vec<PathBuf>,
+    packages: Vec<String>,
 
     /// Target prefix to inject the package into
     #[clap(short = 'p', long = "prefix", default_value = ".prefix")]
@@ -44,69 +47,84 @@ pub struct RemoveFromPrefixOpt {
 
 pub async fn inject(opt: InjectOpt) -> miette::Result<()> {
     let target_prefix = std::path::absolute(opt.target_prefix).into_diagnostic()?;
-    let packages = opt
-        .packages
-        .into_iter()
-        .map(|package_path| {
-            let package_path = package_path.canonicalize().into_diagnostic()?;
-            let package_record = rattler_index::package_record_from_archive(&package_path)
-                .into_diagnostic()
-                .with_context(|| {
-                    format!(
-                        "failed to read package metadata from {}",
-                        package_path.display()
-                    )
-                })?;
 
-            if !opt.skip_compatibility_checks {
-                validate_package_compatibility(&package_record)?;
+    // Temporary directory that holds remote archives while they are being
+    // injected. It must outlive the installer call below.
+    let download_dir = tempfile::tempdir()
+        .into_diagnostic()
+        .context("failed to create temporary download directory")?;
+
+    // Only create the download client when at least one remote package is
+    // requested.
+    let client: Option<ClientWithMiddleware> =
+        if opt.packages.iter().any(|p| parse_remote_url(p).is_some()) {
+            Some(super::client::create_client_with_middleware()?)
+        } else {
+            None
+        };
+
+    let mut resolved = Vec::with_capacity(opt.packages.len());
+    for package in opt.packages {
+        let resolved_package = match parse_remote_url(&package) {
+            Some(url) => {
+                let client = client
+                    .as_ref()
+                    .expect("client is created when a remote package is present");
+                resolve_remote_package(client, url, download_dir.path()).await?
             }
+            None => resolve_local_package(&package)?,
+        };
 
-            Ok((package_path, package_record))
-        })
-        .collect::<miette::Result<Vec<_>>>()?;
+        if !opt.skip_compatibility_checks {
+            validate_package_compatibility(&resolved_package.package_record)?;
+        }
+
+        resolved.push(resolved_package);
+    }
 
     let installed_packages =
         PrefixRecord::collect_from_prefix::<PrefixRecord>(&target_prefix).into_diagnostic()?;
 
-    for (_, package_record) in &packages {
-        reject_already_installed(&installed_packages, &package_record.name)?;
+    for resolved_package in &resolved {
+        reject_already_installed(&installed_packages, &resolved_package.package_record.name)?;
     }
-    reject_duplicate_package_records(packages.iter().map(|(_, package_record)| package_record))?;
+    reject_duplicate_package_records(resolved.iter().map(|p| &p.package_record))?;
 
     if !opt.skip_compatibility_checks {
         let records = installed_packages
             .iter()
             .map(|record| &record.repodata_record.package_record)
-            .chain(packages.iter().map(|(_, package_record)| package_record))
+            .chain(resolved.iter().map(|p| &p.package_record))
             .collect::<Vec<_>>();
         PackageRecord::validate(records)
             .into_diagnostic()
             .context("injecting these packages would make the prefix incompatible")?;
     }
 
-    let repodata_records = packages
-        .into_iter()
-        .map(|(package_path, package_record)| {
-            let repodata_record = RepoDataRecord {
-                package_record,
-                identifier: DistArchiveIdentifier::try_from_path(&package_path).ok_or_else(
-                    || {
-                        miette::miette!(
-                            "could not derive package identity from {}",
-                            package_path.display()
-                        )
-                    },
-                )?,
-                url: Url::from_file_path(&package_path).map_err(|_err| {
-                    miette::miette!("could not convert {} to a file URL", package_path.display())
-                })?,
-                channel: None,
-            };
+    // Reuse the shared package cache so that archives downloaded for remote
+    // packages are not fetched a second time during installation.
+    let cache_dir = default_cache_dir()
+        .map_err(|e| miette::miette!("could not determine default cache directory: {e}"))?;
+    let package_cache = PackageCache::new(cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR));
+    for resolved_package in &resolved {
+        if let Some(archive_path) = &resolved_package.cache_seed {
+            package_cache
+                .get_or_fetch_from_path(archive_path, Some(&resolved_package.package_record), None)
+                .await
+                .into_diagnostic()
+                .context("failed to populate package cache from downloaded archive")?;
+        }
+    }
 
-            Ok((package_path, repodata_record))
+    let repodata_records = resolved
+        .into_iter()
+        .map(|resolved_package| RepoDataRecord {
+            package_record: resolved_package.package_record,
+            identifier: resolved_package.identifier,
+            url: resolved_package.url,
+            channel: None,
         })
-        .collect::<miette::Result<Vec<_>>>()?;
+        .collect::<Vec<_>>();
 
     let mut desired_records = installed_packages
         .iter()
@@ -114,17 +132,14 @@ pub async fn inject(opt: InjectOpt) -> miette::Result<()> {
         .collect::<Vec<_>>();
     let injected_package_records = repodata_records
         .iter()
-        .map(|(_, repodata_record)| repodata_record.package_record.clone())
+        .map(|repodata_record| repodata_record.package_record.clone())
         .collect::<Vec<_>>();
-    desired_records.extend(
-        repodata_records
-            .iter()
-            .map(|(_, repodata_record)| repodata_record.clone()),
-    );
+    desired_records.extend(repodata_records);
 
     Installer::new()
         .with_target_platform(Platform::current())
         .with_installed_packages(installed_packages)
+        .with_package_cache(package_cache)
         .with_execute_link_scripts(true)
         .install(&target_prefix, desired_records)
         .await
@@ -141,6 +156,124 @@ pub async fn inject(opt: InjectOpt) -> miette::Result<()> {
             target_prefix.display()
         );
     }
+
+    Ok(())
+}
+
+/// A conda package archive resolved from a local path or a remote URL, ready to
+/// be injected into a prefix.
+struct ResolvedPackage {
+    package_record: PackageRecord,
+    identifier: DistArchiveIdentifier,
+    /// The URL recorded for the package in the prefix. A `file://` URL for local
+    /// archives, the original remote URL otherwise.
+    url: Url,
+    /// Local archive used to pre-populate the package cache, avoiding a second
+    /// download. `None` for local archives, which the installer reads directly
+    /// from their `file://` URL.
+    cache_seed: Option<PathBuf>,
+}
+
+/// Parses the argument as a remote URL, returning `None` for local paths
+/// (including `file://` URLs).
+fn parse_remote_url(package: &str) -> Option<Url> {
+    match Url::parse(package) {
+        Ok(url) if url.scheme() != "file" => Some(url),
+        _ => None,
+    }
+}
+
+/// Resolves a conda package archive from a local file path.
+fn resolve_local_package(package: &str) -> miette::Result<ResolvedPackage> {
+    let package_path = PathBuf::from(package)
+        .canonicalize()
+        .into_diagnostic()
+        .with_context(|| format!("failed to locate {package}"))?;
+    let package_record = rattler_index::package_record_from_archive(&package_path)
+        .into_diagnostic()
+        .with_context(|| {
+            format!(
+                "failed to read package metadata from {}",
+                package_path.display()
+            )
+        })?;
+    let identifier = DistArchiveIdentifier::try_from_path(&package_path).ok_or_else(|| {
+        miette::miette!(
+            "could not derive package identity from {}",
+            package_path.display()
+        )
+    })?;
+    let url = Url::from_file_path(&package_path).map_err(|()| {
+        miette::miette!("could not convert {} to a file URL", package_path.display())
+    })?;
+
+    Ok(ResolvedPackage {
+        package_record,
+        identifier,
+        url,
+        cache_seed: None,
+    })
+}
+
+/// Resolves a conda package archive from a remote URL by downloading it into
+/// `download_dir`.
+async fn resolve_remote_package(
+    client: &ClientWithMiddleware,
+    url: Url,
+    download_dir: &Path,
+) -> miette::Result<ResolvedPackage> {
+    let identifier = DistArchiveIdentifier::try_from_url(&url)
+        .ok_or_else(|| miette::miette!("could not derive package identity from {url}"))?;
+
+    let archive_path = download_dir.join(identifier.to_file_name());
+    download_archive(client, &url, &archive_path).await?;
+
+    let package_record = rattler_index::package_record_from_archive(&archive_path)
+        .into_diagnostic()
+        .with_context(|| format!("failed to read package metadata from {url}"))?;
+
+    Ok(ResolvedPackage {
+        package_record,
+        identifier,
+        url,
+        cache_seed: Some(archive_path),
+    })
+}
+
+/// Streams a remote archive to `destination`.
+async fn download_archive(
+    client: &ClientWithMiddleware,
+    url: &Url,
+    destination: &Path,
+) -> miette::Result<()> {
+    let response = client
+        .get(url.clone())
+        .send()
+        .await
+        .into_diagnostic()
+        .with_context(|| format!("failed to download {url}"))?
+        .error_for_status()
+        .into_diagnostic()
+        .with_context(|| format!("server returned an error for {url}"))?;
+
+    let mut file = tokio::fs::File::create(destination)
+        .await
+        .into_diagnostic()
+        .with_context(|| format!("failed to create {}", destination.display()))?;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk
+            .into_diagnostic()
+            .with_context(|| format!("failed to read response body from {url}"))?;
+        file.write_all(&chunk)
+            .await
+            .into_diagnostic()
+            .with_context(|| format!("failed to write {}", destination.display()))?;
+    }
+    file.flush()
+        .await
+        .into_diagnostic()
+        .with_context(|| format!("failed to flush {}", destination.display()))?;
 
     Ok(())
 }
@@ -385,7 +518,7 @@ mod tests {
         let other_package = write_empty_package(prefix.path(), "other-empty");
 
         inject(InjectOpt {
-            packages: vec![package, other_package],
+            packages: vec![path_string(&package), path_string(&other_package)],
             target_prefix: prefix.path().to_path_buf(),
             skip_compatibility_checks: false,
         })
@@ -436,7 +569,7 @@ mod tests {
             .join("empty-0.1.0-h4616a5c_0.conda");
 
         inject(InjectOpt {
-            packages: vec![package.clone()],
+            packages: vec![path_string(&package)],
             target_prefix: prefix.path().to_path_buf(),
             skip_compatibility_checks: false,
         })
@@ -444,7 +577,7 @@ mod tests {
         .unwrap();
 
         let result = inject(InjectOpt {
-            packages: vec![package],
+            packages: vec![path_string(&package)],
             target_prefix: prefix.path().to_path_buf(),
             skip_compatibility_checks: false,
         })
@@ -467,7 +600,7 @@ mod tests {
             .join("empty-0.1.0-h4616a5c_0.conda");
 
         let result = inject(InjectOpt {
-            packages: vec![package.clone(), package],
+            packages: vec![path_string(&package), path_string(&package)],
             target_prefix: prefix.path().to_path_buf(),
             skip_compatibility_checks: false,
         })
@@ -490,7 +623,7 @@ mod tests {
             .join("empty-0.1.0-h4616a5c_0.conda");
 
         inject(InjectOpt {
-            packages: vec![package],
+            packages: vec![path_string(&package)],
             target_prefix: prefix.path().to_path_buf(),
             skip_compatibility_checks: false,
         })
@@ -599,6 +732,10 @@ mod tests {
         .unwrap();
 
         target_package
+    }
+
+    fn path_string(path: &Path) -> String {
+        path.to_str().unwrap().to_string()
     }
 
     fn workspace_root() -> PathBuf {

--- a/crates/rattler-bin/src/commands/prefix.rs
+++ b/crates/rattler-bin/src/commands/prefix.rs
@@ -1,21 +1,27 @@
 use std::path::{Path, PathBuf};
 
+use futures_util::StreamExt;
 use miette::{Context, IntoDiagnostic};
-use rattler::install::Installer;
+use rattler::{default_cache_dir, install::Installer, package_cache::PackageCache};
 use rattler_conda_types::{
     MatchSpec, Matches, PackageName, PackageRecord, ParseStrictness, Platform, PrefixRecord,
     RepoDataRecord, package::DistArchiveIdentifier,
 };
+use rattler_package_streaming::fs::repodata_record_from_package_archive;
+use reqwest_middleware::ClientWithMiddleware;
+use tokio::io::AsyncWriteExt;
 use url::Url;
+
+use super::package_source::{PackageSource, client_for};
 
 const PIXI_ENVIRONMENT_FINGERPRINT_FILE: &str = ".pixi-environment-fingerprint";
 
 /// Add one or more conda package archives to a prefix without solving.
 #[derive(Debug, clap::Parser)]
 pub struct InjectOpt {
-    /// Local paths to conda package archives (.conda or .tar.bz2)
+    /// Paths or URLs of conda package archives (.conda or .tar.bz2)
     #[clap(required = true)]
-    packages: Vec<PathBuf>,
+    packages: Vec<String>,
 
     /// Target prefix to inject the package into
     #[clap(short = 'p', long = "prefix", default_value = ".prefix")]
@@ -42,89 +48,78 @@ pub struct RemoveFromPrefixOpt {
     skip_compatibility_checks: bool,
 }
 
-pub async fn inject(opt: InjectOpt) -> miette::Result<()> {
+pub async fn inject(opt: InjectOpt, offline: bool) -> miette::Result<()> {
     let target_prefix = std::path::absolute(opt.target_prefix).into_diagnostic()?;
-    let packages = opt
+    let sources: Vec<PackageSource> = opt
         .packages
-        .into_iter()
-        .map(|package_path| {
-            let package_path = package_path.canonicalize().into_diagnostic()?;
-            let package_record = rattler_index::package_record_from_archive(&package_path)
-                .into_diagnostic()
-                .with_context(|| {
-                    format!(
-                        "failed to read package metadata from {}",
-                        package_path.display()
-                    )
-                })?;
+        .iter()
+        .map(|package| PackageSource::parse(package))
+        .collect();
+    let client = client_for(&sources, offline)?;
 
-            if !opt.skip_compatibility_checks {
-                validate_package_compatibility(&package_record)?;
-            }
+    // Temporary directory that holds remote archives while they are being
+    // injected. It must outlive the installer call below.
+    let download_dir = tempfile::tempdir()
+        .into_diagnostic()
+        .context("failed to create temporary download directory")?;
 
-            Ok((package_path, package_record))
-        })
-        .collect::<miette::Result<Vec<_>>>()?;
+    let mut resolved = Vec::with_capacity(sources.len());
+    for source in &sources {
+        let package = resolve_package(source, client.as_ref(), download_dir.path()).await?;
+        if !opt.skip_compatibility_checks {
+            validate_package_compatibility(&package.record.package_record)?;
+        }
+        resolved.push(package);
+    }
 
     let installed_packages =
         PrefixRecord::collect_from_prefix::<PrefixRecord>(&target_prefix).into_diagnostic()?;
 
-    for (_, package_record) in &packages {
-        reject_already_installed(&installed_packages, &package_record.name)?;
+    for package in &resolved {
+        reject_already_installed(&installed_packages, &package.record.package_record.name)?;
     }
-    reject_duplicate_package_records(packages.iter().map(|(_, package_record)| package_record))?;
+    reject_duplicate_package_records(resolved.iter().map(|p| &p.record.package_record))?;
 
     if !opt.skip_compatibility_checks {
         let records = installed_packages
             .iter()
             .map(|record| &record.repodata_record.package_record)
-            .chain(packages.iter().map(|(_, package_record)| package_record))
+            .chain(resolved.iter().map(|p| &p.record.package_record))
             .collect::<Vec<_>>();
         PackageRecord::validate(records)
             .into_diagnostic()
             .context("injecting these packages would make the prefix incompatible")?;
     }
 
-    let repodata_records = packages
-        .into_iter()
-        .map(|(package_path, package_record)| {
-            let repodata_record = RepoDataRecord {
-                package_record,
-                identifier: DistArchiveIdentifier::try_from_path(&package_path).ok_or_else(
-                    || {
-                        miette::miette!(
-                            "could not derive package identity from {}",
-                            package_path.display()
-                        )
-                    },
-                )?,
-                url: Url::from_file_path(&package_path).map_err(|_err| {
-                    miette::miette!("could not convert {} to a file URL", package_path.display())
-                })?,
-                channel: None,
-            };
+    // Reuse the shared package cache so that archives downloaded for remote
+    // packages are not fetched a second time during installation.
+    let cache_dir = default_cache_dir()
+        .map_err(|e| miette::miette!("could not determine default cache directory: {e}"))?;
+    let package_cache = PackageCache::new(cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR));
+    for package in &resolved {
+        if let Some(archive_path) = &package.cache_seed {
+            package_cache
+                .get_or_fetch_from_path(archive_path, Some(&package.record.package_record), None)
+                .await
+                .into_diagnostic()
+                .context("failed to populate package cache from downloaded archive")?;
+        }
+    }
 
-            Ok((package_path, repodata_record))
-        })
-        .collect::<miette::Result<Vec<_>>>()?;
-
+    let injected_package_records = resolved
+        .iter()
+        .map(|package| package.record.package_record.clone())
+        .collect::<Vec<_>>();
     let mut desired_records = installed_packages
         .iter()
         .map(|record| record.repodata_record.clone())
         .collect::<Vec<_>>();
-    let injected_package_records = repodata_records
-        .iter()
-        .map(|(_, repodata_record)| repodata_record.package_record.clone())
-        .collect::<Vec<_>>();
-    desired_records.extend(
-        repodata_records
-            .iter()
-            .map(|(_, repodata_record)| repodata_record.clone()),
-    );
+    desired_records.extend(resolved.into_iter().map(|package| package.record));
 
     Installer::new()
         .with_target_platform(Platform::current())
         .with_installed_packages(installed_packages)
+        .with_package_cache(package_cache)
         .with_execute_link_scripts(true)
         .install(&target_prefix, desired_records)
         .await
@@ -141,6 +136,96 @@ pub async fn inject(opt: InjectOpt) -> miette::Result<()> {
             target_prefix.display()
         );
     }
+
+    Ok(())
+}
+
+/// A conda package archive resolved from a local path or a remote URL, ready to
+/// be injected into a prefix.
+struct ResolvedPackage {
+    record: RepoDataRecord,
+    /// Local archive used to pre-populate the package cache so the installer
+    /// does not download a remote package a second time. `None` for local
+    /// archives, which the installer reads directly from their `file://` URL.
+    cache_seed: Option<PathBuf>,
+}
+
+/// Resolves a package source into a [`RepoDataRecord`]. Remote archives are
+/// downloaded into `download_dir` first; the record keeps the remote URL as its
+/// origin rather than the temporary download path.
+async fn resolve_package(
+    source: &PackageSource,
+    client: Option<&ClientWithMiddleware>,
+    download_dir: &Path,
+) -> miette::Result<ResolvedPackage> {
+    match source {
+        PackageSource::Path(path) => {
+            let record = repodata_record_from_package_archive(path)
+                .await
+                .into_diagnostic()
+                .with_context(|| {
+                    format!("failed to read package metadata from {}", path.display())
+                })?;
+            Ok(ResolvedPackage {
+                record,
+                cache_seed: None,
+            })
+        }
+        PackageSource::Url(url) => {
+            let client = client.expect("a client is created whenever a source is a URL");
+            let file_name = DistArchiveIdentifier::try_from_url(url)
+                .ok_or_else(|| miette::miette!("could not derive package identity from {url}"))?
+                .to_file_name();
+            let archive_path = download_dir.join(file_name);
+            download_archive(client, url, &archive_path).await?;
+
+            let mut record = repodata_record_from_package_archive(&archive_path)
+                .await
+                .into_diagnostic()
+                .with_context(|| format!("failed to read package metadata from {url}"))?;
+            record.url = url.clone();
+            Ok(ResolvedPackage {
+                record,
+                cache_seed: Some(archive_path),
+            })
+        }
+    }
+}
+
+/// Streams a remote archive to `destination`.
+async fn download_archive(
+    client: &ClientWithMiddleware,
+    url: &Url,
+    destination: &Path,
+) -> miette::Result<()> {
+    let response = client
+        .get(url.clone())
+        .send()
+        .await
+        .into_diagnostic()
+        .with_context(|| format!("failed to download {url}"))?
+        .error_for_status()
+        .into_diagnostic()
+        .with_context(|| format!("server returned an error for {url}"))?;
+
+    let mut file = tokio::fs::File::create(destination)
+        .await
+        .into_diagnostic()
+        .with_context(|| format!("failed to create {}", destination.display()))?;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk
+            .into_diagnostic()
+            .with_context(|| format!("failed to read response body from {url}"))?;
+        file.write_all(&chunk)
+            .await
+            .into_diagnostic()
+            .with_context(|| format!("failed to write {}", destination.display()))?;
+    }
+    file.flush()
+        .await
+        .into_diagnostic()
+        .with_context(|| format!("failed to flush {}", destination.display()))?;
 
     Ok(())
 }
@@ -385,11 +470,14 @@ mod tests {
             .join("empty-0.1.0-h4616a5c_0.conda");
         let other_package = write_empty_package(prefix.path(), "other-empty");
 
-        inject(InjectOpt {
-            packages: vec![package, other_package],
-            target_prefix: prefix.path().to_path_buf(),
-            skip_compatibility_checks: false,
-        })
+        inject(
+            InjectOpt {
+                packages: vec![path_string(&package), path_string(&other_package)],
+                target_prefix: prefix.path().to_path_buf(),
+                skip_compatibility_checks: false,
+            },
+            false,
+        )
         .await
         .unwrap();
 
@@ -436,19 +524,25 @@ mod tests {
             .join("packages")
             .join("empty-0.1.0-h4616a5c_0.conda");
 
-        inject(InjectOpt {
-            packages: vec![package.clone()],
-            target_prefix: prefix.path().to_path_buf(),
-            skip_compatibility_checks: false,
-        })
+        inject(
+            InjectOpt {
+                packages: vec![path_string(&package)],
+                target_prefix: prefix.path().to_path_buf(),
+                skip_compatibility_checks: false,
+            },
+            false,
+        )
         .await
         .unwrap();
 
-        let result = inject(InjectOpt {
-            packages: vec![package],
-            target_prefix: prefix.path().to_path_buf(),
-            skip_compatibility_checks: false,
-        })
+        let result = inject(
+            InjectOpt {
+                packages: vec![path_string(&package)],
+                target_prefix: prefix.path().to_path_buf(),
+                skip_compatibility_checks: false,
+            },
+            false,
+        )
         .await;
 
         assert!(
@@ -467,11 +561,14 @@ mod tests {
             .join("packages")
             .join("empty-0.1.0-h4616a5c_0.conda");
 
-        let result = inject(InjectOpt {
-            packages: vec![package.clone(), package],
-            target_prefix: prefix.path().to_path_buf(),
-            skip_compatibility_checks: false,
-        })
+        let result = inject(
+            InjectOpt {
+                packages: vec![path_string(&package), path_string(&package)],
+                target_prefix: prefix.path().to_path_buf(),
+                skip_compatibility_checks: false,
+            },
+            false,
+        )
         .await;
 
         assert!(
@@ -490,11 +587,14 @@ mod tests {
             .join("packages")
             .join("empty-0.1.0-h4616a5c_0.conda");
 
-        inject(InjectOpt {
-            packages: vec![package],
-            target_prefix: prefix.path().to_path_buf(),
-            skip_compatibility_checks: false,
-        })
+        inject(
+            InjectOpt {
+                packages: vec![path_string(&package)],
+                target_prefix: prefix.path().to_path_buf(),
+                skip_compatibility_checks: false,
+            },
+            false,
+        )
         .await
         .unwrap();
 
@@ -600,6 +700,10 @@ mod tests {
         .unwrap();
 
         target_package
+    }
+
+    fn path_string(path: &Path) -> String {
+        path.to_str().unwrap().to_string()
     }
 
     fn workspace_root() -> PathBuf {

--- a/crates/rattler-bin/src/main.rs
+++ b/crates/rattler-bin/src/main.rs
@@ -139,7 +139,7 @@ async fn async_main() -> miette::Result<()> {
         Command::Run(opts) => commands::run::run(opts).await,
         Command::Extract(opts) => commands::extract::extract(opts, offline).await,
         Command::Link(opts) => commands::link::link(opts).await,
-        Command::InjectIntoPrefix(opts) => commands::prefix::inject(opts).await,
+        Command::InjectIntoPrefix(opts) => commands::prefix::inject(opts, offline).await,
         Command::RemoveFromPrefix(opts) => commands::prefix::remove_from_prefix(opts).await,
         Command::Upload(opts) => {
             if offline {


### PR DESCRIPTION
<details>
<summary>🤖 yap</summary>

### Description

Makes the single-archive `rattler` subcommands symmetric: each accepts **either a local file path or a remote URL** for a conda package (`.conda` / `.tar.bz2`).

| Command | Before | After |
|---|---|---|
| `inspect` | URL only | path or URL |
| `fetch-file` | URL only | path or URL |
| `inject-into-prefix` | local path only | path or URL |

Already symmetric on `main`, so unchanged in behaviour: `extract`, `compare-packages`, `whoneeds`.

Implementation:

- New shared `commands/package_source.rs`: `PackageSource::{Url, Path}` with `parse` (converts `file://` URLs to paths and treats a single-letter scheme as a Windows drive letter — `Url::parse` otherwise reads `C:\pkgs\foo.conda` as scheme `c`), `open` (via `PackageArchive::from_url` / `from_path`), and `client_for` (only builds an HTTP client when some source is remote, so local-only invocations never touch the network).
- `inspect` / `fetch-file`: open the archive through `PackageArchive`, so local and remote share one code path. `fetch-file` uses `PackageArchive::read_file`.
- `inject-into-prefix`: resolves local archives with `rattler_package_streaming::fs::repodata_record_from_package_archive`. Remote archives are streamed to a temp dir, resolved the same way, recorded under their **remote URL** (not the temp path), and pre-seeded into the shared `PackageCache` so the installer does not download them a second time. Now honours `--offline`.
- `compare-packages` switched to the shared module, removing its private copy of the same parsing logic.

### How Has This Been Tested?

- `cargo clippy -p rattler-bin --all-targets -- -D warnings -Dclippy::dbg_macro` (CI flags): clean.
- `cargo test -p rattler-bin`: 20 passed, including the `inject` tests (local archives, duplicate / already-installed rejection) and new `package_source` tests for URL vs. path classification (http/https/s3, relative and absolute paths, Windows drive letters, `file://`).

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

</details>

prompt:

In rattler bin Give me an overview of subcommands that only support local file system conda packages and which only support remote conda packages. Is it feasible to support both?

<img width="1008" height="317" alt="image" src="https://github.com/user-attachments/assets/4f1c4593-bdcb-458f-9396-ca6b926bc446" />

lets add url support to inject-into-prefix and local fs support for inspect + fetch-file

Please rebase the pr with main, handle conflicts and check for eventual new commands that we want to apply this patch to as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkUDTwKbtUcLCwrnuzwYn5