### PR TITLE
fix: accept quoted extras lists and enforce CEP 44 group names

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -2401,7 +2401,8 @@ mod tests {
         assert!(parse_extras("gpu, MKL").is_err());
 
         // Non-ASCII "alphanumerics" are rejected even though `char::is_alphanumeric` accepts them.
-        assert!(parse_extras("caf\u{e9}").is_err());
+        assert!(parse_extras("\u{e9}").is_err());
+        assert!(parse_extras("\u{3b1}").is_err());
 
         // Length: 1..=64 characters.
         assert!(parse_extras("").is_err());

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -62,6 +62,12 @@ pub enum ParseMatchSpecError {
     #[error("invalid bracket key: {0}")]
     InvalidBracketKey(String),
 
+    /// An extras group name does not conform to the CEP 44 grammar.
+    #[error(
+        "invalid extras group name '{0}': names must match the pattern [a-z0-9_.+-] and be between 1 and 64 characters long"
+    )]
+    InvalidExtraName(String),
+
     /// Missing package name in match spec
     #[error("missing package name")]
     MissingPackageName,
@@ -411,18 +417,52 @@ fn strip_brackets(input: &str) -> Result<(Cow<'_, str>, BracketVec<'_>), ParseMa
     Ok((Cow::Borrowed(&input[..open]), bracket_contents))
 }
 
+/// Returns whether `name` conforms to the CEP 44 optional dependency group
+/// name grammar: the regex `[a-z0-9_.+-]{1,64}`. This is enforced when parsing
+/// `extras` so we never accept (and later serialize) group names that would be
+/// invalid metadata per the spec.
+fn is_valid_extra_group_name(name: &str) -> bool {
+    let mut len = 0usize;
+    for c in name.chars() {
+        if !(c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '_' | '-' | '.' | '+')) {
+            return false;
+        }
+        len += 1;
+    }
+    (1..=64).contains(&len)
+}
+
 /// Parses a list of optional dependencies from a string `feat1, feat2, feat3]`
 /// -> `vec![feat1, feat2, feat3]`.
+///
+/// Group names are validated against the CEP 44 grammar (`[a-z0-9_.+-]{1,64}`);
+/// names that do not conform produce a [`ParseMatchSpecError::InvalidExtraName`]
+/// error.
 pub fn parse_extras(input: &str) -> Result<Vec<String>, ParseMatchSpecError> {
     use nom::{
         combinator::{all_consuming, map},
         multi::separated_list1,
     };
 
+    // Permissive tokenizer character set: anything that could plausibly be part
+    // of a group name. The strict CEP 44 grammar is enforced separately below so
+    // that a non-conforming name yields a descriptive error rather than an
+    // opaque "invalid bracket".
+    fn is_name_token_char(c: char) -> bool {
+        c.is_alphanumeric() || matches!(c, '_' | '-' | '.' | '+')
+    }
+
     fn parse_feature_name(i: &str) -> IResult<&str, &str> {
+        // A feature name is either a bare identifier or an (optionally) quoted
+        // string, so that Python-style lists like `["science", 'plot']` parse
+        // the same as `[science, plot]`.
         delimited(
             multispace0,
-            take_while1(|c: char| c.is_alphanumeric() || c == '_' || c == '-'),
+            alt((
+                parse_quoted_string_with_escapes('"'),
+                parse_quoted_string_with_escapes('\''),
+                take_while1(is_name_token_char),
+            )),
             multispace0,
         )
         .parse(i)
@@ -432,10 +472,20 @@ pub fn parse_extras(input: &str) -> Result<Vec<String>, ParseMatchSpecError> {
         separated_list1(char(','), map(parse_feature_name, |s: &str| s.to_string())).parse(i)
     }
 
-    match all_consuming(parse_features).parse(input).finish() {
-        Ok((_remaining, features)) => Ok(features),
-        Err(_e) => Err(ParseMatchSpecError::InvalidBracket),
+    let features = match all_consuming(parse_features).parse(input).finish() {
+        Ok((_remaining, features)) => features,
+        Err(_e) => return Err(ParseMatchSpecError::InvalidBracket),
+    };
+
+    // Enforce the CEP 44 group name grammar so we never produce metadata that is
+    // not up to spec (lowercase only, `[a-z0-9_.+-]`, at most 64 characters).
+    for name in &features {
+        if !is_valid_extra_group_name(name) {
+            return Err(ParseMatchSpecError::InvalidExtraName(name.clone()));
+        }
     }
+
+    Ok(features)
 }
 
 /// Parses variant flags from either a single string or a comma-separated list.
@@ -2289,6 +2339,85 @@ mod tests {
             vec!["bar".to_string(), "baz".to_string()]
         );
         assert!(parse_extras("[bar,baz]").is_err());
+    }
+
+    #[test]
+    fn test_quoted_extras() {
+        let opts = ParseMatchSpecOptions::strict().with_extras(true);
+
+        // Double-quoted list items (Python-style list syntax).
+        let spec = MatchSpec::from_str("foobar[extras=[\"science\", \"plot\"]]", opts).unwrap();
+        assert_eq!(
+            spec.extras,
+            Some(vec!["science".to_string(), "plot".to_string()])
+        );
+
+        // Single-quoted and a mix of quoted/unquoted items should also work.
+        let spec = MatchSpec::from_str("foobar[extras=['science', plot]]", opts).unwrap();
+        assert_eq!(
+            spec.extras,
+            Some(vec!["science".to_string(), "plot".to_string()])
+        );
+
+        // Direct parse_extras checks.
+        assert_eq!(
+            parse_extras("\"science\", \"plot\"").unwrap(),
+            vec!["science".to_string(), "plot".to_string()]
+        );
+        assert_eq!(
+            parse_extras("'bar' , baz").unwrap(),
+            vec!["bar".to_string(), "baz".to_string()]
+        );
+
+        // CEP 44 group names allow `.` and `+` (regex `[a-z0-9_.+-]{1,64}`);
+        // these must parse both bare and quoted.
+        assert_eq!(
+            parse_extras("foo.bar, c++").unwrap(),
+            vec!["foo.bar".to_string(), "c++".to_string()]
+        );
+        assert_eq!(
+            parse_extras("\"foo.bar\"").unwrap(),
+            vec!["foo.bar".to_string()]
+        );
+
+        // Empty quoted feature names are still rejected.
+        assert!(parse_extras("\"\"").is_err());
+        // Quotes cannot smuggle in characters outside the group-name grammar.
+        assert!(parse_extras("\"foo bar\"").is_err());
+        assert!(parse_extras("\"foo/bar\"").is_err());
+    }
+
+    #[test]
+    fn test_extras_cep44_grammar() {
+        // CEP 44 group names MUST match `[a-z0-9_.+-]{1,64}`. Enforce it so we
+        // never accept (and later serialize) metadata that is not up to spec.
+
+        // Uppercase is rejected (bare and quoted).
+        assert!(matches!(
+            parse_extras("GPU"),
+            Err(ParseMatchSpecError::InvalidExtraName(name)) if name == "GPU"
+        ));
+        assert!(parse_extras("\"GPU\"").is_err());
+        assert!(parse_extras("gpu, MKL").is_err());
+
+        // Non-ASCII "alphanumerics" are rejected even though `char::is_alphanumeric` accepts them.
+        assert!(parse_extras("caf\u{e9}").is_err());
+
+        // Length: 1..=64 characters.
+        assert!(parse_extras("").is_err());
+        let max = "a".repeat(64);
+        assert_eq!(parse_extras(&max).unwrap(), vec![max.clone()]);
+        let too_long = "a".repeat(65);
+        assert!(matches!(
+            parse_extras(&too_long),
+            Err(ParseMatchSpecError::InvalidExtraName(_))
+        ));
+
+        // All allowed symbols parse.
+        assert_eq!(
+            parse_extras("a_b-c.d+e").unwrap(),
+            vec!["a_b-c.d+e".to_string()]
+        );
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/package_name.rs
+++ b/crates/rattler_conda_types/src/package_name.rs
@@ -550,7 +550,9 @@ mod test {
     // Extras present.
     #[case("numpy[extras=[gpu]]", "numpy", &["gpu"])]
     #[case("numpy[extras=[gpu, mkl]]", "numpy", &["gpu", "mkl"])]
-    #[case("Numpy[extras=[GPU]]", "numpy", &["GPU"])]
+    // Uppercase group names violate the CEP 44 grammar ([a-z0-9_.+-]); the
+    // parser rejects them, so extras fall back to empty (name still extracted).
+    #[case("Numpy[extras=[GPU]]", "numpy", &[])]
     // Extras combined with other bracket keys.
     #[case(
         r#"aiohttp[extras=[speedups], build="py*"]"#,


### PR DESCRIPTION
### Description

MatchSpec `extras` lists only accepted bare identifiers, so a Python-style quoted list failed while the unquoted form worked:

```
foobar[extras=[science, plot]]        # ✅ worked
foobar[extras=["science", "plot"]]    # ❌ "invalid value for 'item': invalid bracket"
```

The value parser captured the raw list content (`"science", "plot"`) and passed it to `parse_extras`, whose feature-name matcher (`[A-Za-z0-9_-]+`) then choked on the leading quote.

This PR:
- **Accepts optionally single/double-quoted list items**, so `["science", 'plot']` parses the same as `[science, plot]`. This is consistent with CEP 44, which describes the value as "a string or a list of string" and shows the scalar form quoted (`example[extras="group-name"]`).
- **Enforces the CEP 44 group-name grammar `[a-z0-9_.+-]{1,64}`** for every group name (bare and quoted), so we never accept — and later serialize — names that would be invalid metadata per spec. Non-conforming names now return a descriptive `ParseMatchSpecError::InvalidExtraName` instead of an opaque `invalid bracket`.

Behavior changes vs. before (all toward CEP conformance):

| Case | Before | After |
|------|--------|-------|
| Quoted list items `["a","b"]` | ❌ error | ✅ accepted |
| `.` / `+` (`foo.bar`, `c++`) — CEP-allowed | ❌ rejected (bare) | ✅ accepted |
| Uppercase / non-ASCII (`GPU`, `café`) — off-spec | ✅ accepted | ❌ rejected |
| Length > 64 — off-spec | ✅ accepted | ❌ rejected |

Note: `Numpy[extras=[GPU]]` previously yielded the extra `GPU`; it now yields no extra. This is correct per CEP (real group keys are lowercase, so `GPU` could never match a stored group), but it is a stricter, non-normalizing behavior change worth calling out.

### How Has This Been Tested?

- New `test_extras_cep44_grammar`: uppercase, non-ASCII, empty, the 64/65-char boundary, and every allowed symbol.
- New `test_quoted_extras`: double/single/mixed-quote lists, `.`/`+`, and rejection of quote-smuggled illegal chars (space, `/`, empty).
- Updated the `Numpy[extras=[GPU]]` case in `package_name.rs`.
- Full crate suite passes (`cargo nextest run -p rattler_conda_types`, 460 tests); `cargo clippy -p rattler_conda_types` clean; `cargo check --workspace` clean (new error variant breaks no exhaustive matches).

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 4.8)

```plaintext
I just tried `foobar[extras=["bla", "baz"]]` but with the quotes in the list I get invalid bracket. Can you check if that is an issue in the parser, or by design? ... write a test case for this and then fix it or document it ... double check vs. the CEP ... We should also enforce these things per CEP (lowercase, 64 cap ...) otherwise we might produce metadata not up to spec!
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
