### PR TITLE
fix: report download completion before extraction

### DIFF
--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -141,9 +141,12 @@ pub struct ExtractResult {
 pub trait DownloadReporter: Send + Sync {
     /// Called when the download starts.
     fn on_download_start(&self);
-    /// Called when the download makes progress.
+    /// Called as downloaded archive bytes are consumed by the extractor.
+    ///
+    /// `total_bytes` is the compressed archive size when it is known.
     fn on_download_progress(&self, bytes_downloaded: u64, total_bytes: Option<u64>);
-    /// Called when the download finishes.
+    /// Called when the response body has been fully consumed or the download reader
+    /// is dropped. Extraction may still be in progress when this is called.
     fn on_download_complete(&self);
 }
 

--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -1,14 +1,19 @@
 //! Functionality to stream and extract packages directly from a
 //! [`reqwest::Url`] within a [`tokio`] async context.
 
-use std::{path::Path, sync::Arc};
+use std::{
+    path::Path,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use fs_err::tokio as tokio_fs;
 use futures_util::stream::TryStreamExt;
 use rattler_conda_types::package::CondaArchiveType;
 use rattler_digest::Sha256Hash;
 use reqwest::Response;
-use tokio::io::BufReader;
+use tokio::io::{AsyncRead, BufReader, ReadBuf};
 use tokio_util::{either::Either, io::StreamReader};
 use tracing;
 use url::Url;
@@ -30,6 +35,58 @@ fn error_for_status(response: reqwest::Response) -> reqwest_middleware::Result<R
         .map_err(reqwest_middleware::Error::Reqwest)
 }
 
+/// Reports completion when the response body reaches EOF (or is dropped), rather
+/// than when extraction of that body completes.
+struct ReportingReader<R> {
+    inner: R,
+    reporter: Option<Arc<dyn DownloadReporter>>,
+    bytes_read: u64,
+    total_bytes: Option<u64>,
+    completed: bool,
+}
+
+impl<R> ReportingReader<R> {
+    fn complete(&mut self) {
+        if !self.completed {
+            if let Some(reporter) = &self.reporter {
+                reporter.on_download_complete();
+            }
+            self.completed = true;
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for ReportingReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let filled_before = buf.filled().len();
+        match Pin::new(&mut self.inner).poll_read(cx, buf) {
+            Poll::Ready(Ok(())) => {
+                let bytes_read = buf.filled().len() - filled_before;
+                if bytes_read == 0 {
+                    self.complete();
+                } else {
+                    self.bytes_read += bytes_read as u64;
+                    if let Some(reporter) = &self.reporter {
+                        reporter.on_download_progress(self.bytes_read, self.total_bytes);
+                    }
+                }
+                Poll::Ready(Ok(()))
+            }
+            result => result,
+        }
+    }
+}
+
+impl<R> Drop for ReportingReader<R> {
+    fn drop(&mut self) {
+        self.complete();
+    }
+}
+
 async fn get_reader(
     url: Url,
     client: reqwest_middleware::ClientWithMiddleware,
@@ -40,13 +97,14 @@ async fn get_reader(
         reporter.on_download_start();
     }
 
-    if url.scheme() == "file" {
+    let (reader, total_bytes) = if url.scheme() == "file" {
         let file =
             tokio_fs::File::open(url.to_file_path().expect("Could not convert to file path"))
                 .await
                 .map_err(ExtractError::IoError)?;
+        let total_bytes = file.metadata().await.map_err(ExtractError::IoError)?.len();
 
-        Ok(Either::Left(BufReader::new(file)))
+        (Either::Left(BufReader::new(file)), Some(total_bytes))
     } else {
         // Send the request for the file
         let mut request = client.get(url.clone());
@@ -64,27 +122,28 @@ async fn get_reader(
             .map_err(ExtractError::ReqwestError)?;
 
         let total_bytes = response.content_length();
-        let mut bytes_received = Box::new(0);
-        let byte_stream = response.bytes_stream().inspect_ok(move |frame| {
-            *bytes_received += frame.len() as u64;
-            if let Some(reporter) = &reporter {
-                reporter.on_download_progress(*bytes_received, total_bytes);
-            }
-        });
+        let byte_stream = response.bytes_stream();
 
         // Get the response as a stream
-        Ok(Either::Right(StreamReader::new(byte_stream.map_err(
-            |err| {
-                if err.is_body() {
-                    std::io::Error::new(std::io::ErrorKind::Interrupted, err)
-                } else if err.is_decode() {
-                    std::io::Error::new(std::io::ErrorKind::InvalidData, err)
-                } else {
-                    std::io::Error::other(err)
-                }
-            },
-        ))))
-    }
+        let reader = Either::Right(StreamReader::new(byte_stream.map_err(|err| {
+            if err.is_body() {
+                std::io::Error::new(std::io::ErrorKind::Interrupted, err)
+            } else if err.is_decode() {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, err)
+            } else {
+                std::io::Error::other(err)
+            }
+        })));
+        (reader, total_bytes)
+    };
+
+    Ok(ReportingReader {
+        inner: reader,
+        reporter,
+        bytes_read: 0,
+        total_bytes,
+        completed: false,
+    })
 }
 
 /// Extracts the contents a `.tar.bz2` package archive from the specified remote
@@ -117,11 +176,7 @@ pub async fn extract_tar_bz2(
 ) -> Result<ExtractResult, ExtractError> {
     let reader = get_reader(url.clone(), client, expected_sha256, reporter.clone()).await?;
     // The `response` is used to stream in the package data
-    let result = crate::tokio::async_read::extract_tar_bz2(reader, destination).await?;
-    if let Some(reporter) = &reporter {
-        reporter.on_download_complete();
-    }
-    Ok(result)
+    crate::tokio::async_read::extract_tar_bz2(reader, destination).await
 }
 
 /// Extracts the contents a `.conda` package archive from the specified remote
@@ -161,12 +216,7 @@ pub async fn extract_conda(
     )
     .await?;
     match crate::tokio::async_read::extract_conda(reader, destination).await {
-        Ok(result) => {
-            if let Some(reporter) = &reporter {
-                reporter.on_download_complete();
-            }
-            Ok(result)
-        }
+        Ok(result) => Ok(result),
         // https://github.com/conda/rattler/issues/794
         Err(ExtractError::ZipError(ZipError::UnsupportedArchive(zip_error)))
             if (zip_error.contains(DATA_DESCRIPTOR_ERROR_MESSAGE)) =>
@@ -175,23 +225,8 @@ pub async fn extract_conda(
                 "Failed to stream decompress conda package from '{}' due to the presence of zip data descriptors. Falling back to non streaming decompression",
                 url
             );
-            if let Some(reporter) = &reporter {
-                reporter.on_download_complete();
-            }
-            let new_reader =
-                get_reader(url.clone(), client, expected_sha256, reporter.clone()).await?;
-
-            match crate::tokio::async_read::extract_conda_via_buffering(new_reader, destination)
-                .await
-            {
-                Ok(result) => {
-                    if let Some(reporter) = &reporter {
-                        reporter.on_download_complete();
-                    }
-                    Ok(result)
-                }
-                Err(e) => Err(e),
-            }
+            let new_reader = get_reader(url, client, expected_sha256, reporter).await?;
+            crate::tokio::async_read::extract_conda_via_buffering(new_reader, destination).await
         }
         Err(e) => Err(e),
     }
@@ -234,5 +269,56 @@ pub async fn extract(
         CondaArchiveType::Conda => {
             extract_conda(client, url, destination, expected_sha256, reporter).await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestReporter {
+        completed: AtomicUsize,
+        progress: std::sync::Mutex<Vec<(u64, Option<u64>)>>,
+    }
+
+    impl DownloadReporter for TestReporter {
+        fn on_download_start(&self) {}
+        fn on_download_progress(&self, bytes_downloaded: u64, total_bytes: Option<u64>) {
+            self.progress
+                .lock()
+                .unwrap()
+                .push((bytes_downloaded, total_bytes));
+        }
+        fn on_download_complete(&self) {
+            self.completed.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_bytes_consumed_and_completion_at_eof() {
+        let reporter = Arc::new(TestReporter::default());
+        let mut reader = ReportingReader {
+            inner: tokio::io::AsyncReadExt::take(tokio::io::repeat(0), 10),
+            reporter: Some(reporter.clone()),
+            bytes_read: 0,
+            total_bytes: Some(10),
+            completed: false,
+        };
+
+        let mut contents = Vec::new();
+        reader.read_to_end(&mut contents).await.unwrap();
+        assert_eq!(
+            reporter.progress.lock().unwrap().last(),
+            Some(&(10, Some(10)))
+        );
+        assert_eq!(reporter.completed.load(Ordering::Relaxed), 1);
+
+        drop(reader);
+        assert_eq!(reporter.completed.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
## Summary

- measure progress as compressed archive bytes are consumed by the extractor, including the compressed total when known
- emit `DownloadReporter::on_download_complete` when the streamed response body reaches EOF instead of after package extraction
- report completion exactly once when the reader is consumed or dropped
- clarify that extraction may still be running when the callback fires

Package downloads are streamed directly into the extractor. Previously, progress was counted when reqwest yielded a complete network frame and completion was delayed until extraction completed. This could make consumers display chunky or frozen download progress during long extractions.

The reporting reader now counts the exact bytes handed to the extractor. This provides determinate combined download/extraction progress against the compressed archive size. Response completion remains separate from cache/extraction completion, so consumers can show an extraction spinner for any work remaining after the archive reaches 100%.

## Tests

- `cargo test --manifest-path crates/rattler_package_streaming/Cargo.toml --lib --features reqwest`
- `cargo clippy --manifest-path crates/rattler_package_streaming/Cargo.toml --all-targets --features reqwest -- -D warnings`
- `cargo fmt --check --manifest-path crates/rattler_package_streaming/Cargo.toml`