### PR TITLE
ci: unblock pixi setup and source package builds

### DIFF
--- a/crates/rattler-bin/pixi.toml
+++ b/crates/rattler-bin/pixi.toml
@@ -3,7 +3,7 @@ name = "rattler"
 
 [package.build.backend]
 name = "pixi-build-rust"
-version = "0.4.*"
+version = "0.5.*"
 channels = [
     "https://prefix.dev/pixi-build-backends",
     "https://prefix.dev/conda-forge"

--- a/crates/rattler_index/pixi.toml
+++ b/crates/rattler_index/pixi.toml
@@ -3,7 +3,7 @@ name = "rattler_index"
 
 [package.build.backend]
 name = "pixi-build-rust"
-version = "0.4.*"
+version = "0.5.*"
 channels = [
     "https://prefix.dev/pixi-build-backends",
     "https://prefix.dev/conda-forge"

--- a/pixi.toml
+++ b/pixi.toml
@@ -18,6 +18,14 @@ requires-pixi = ">=0.67.0"
 # Use the same Rust version everywhere
 rust_compiler_version = ["1.95.0"]
 
+# The build backend has to match the build API version that pixi hands out, so
+# the workspace cutoff cannot hold it back. On Windows the MSVC runtime it links
+# against has to come along.
+[exclude-newer]
+pixi-build-rust = "0d"
+vc14_runtime = "0d"
+vcomp14 = "0d"
+
 [tasks]
 build = "cargo build"
 check = "cargo check"


### PR DESCRIPTION
### Description

Every PR is red right now. `lint`, `Check intra-doc links` and the E2E jobs die in `Set up pixi`, and `merge-gatekeeper` follows. `pixi.lock` itself is fine and needs no changes.

`rattler` and `rattler_index` are source packages, so pixi has to start their build backend. Two things stop it:

1. The backend is pinned to `pixi-build-rust 0.4.*`, whose newest build wants `pixi-build-api-version >=5,<6`. pixi 0.76.1 hands out API 6. Bumped the pin to `0.5.*`.
2. Every `pixi-build-rust` supporting API 6 was uploaded on or after 2026-07-29, which the rolling `exclude-newer = "7d"` cutoff excludes. Added a per-package exemption for the backend.

The backend version is tied to the build API that pixi hands out, so it cannot be held back by a cutoff meant to pin the packages we build against. The exemption is scoped to `pixi-build-rust`, the workspace cutoff still applies to everything else. `vc14_runtime` and `vcomp14` are in there too because on Windows the backend needs the MSVC runtime it links against. Linux does not need any dependency exemptions, the backend's deps (`openssl 4.0.1`, `liblzma 5.8.3`, `libgcc`, `libzlib`) all have versions well inside the cutoff.

E2E was green on 2026-08-03 and broke on 2026-08-04, when setup-pixi started installing a pixi that provides API 6.

### How Has This Been Tested?

`pixi install -e minio --locked` reproduced the CI failure exactly, and now gets past the backend and into compiling the crates. `pixi install -e lint --locked` succeeds and `pixi lock --check` reports the lock file as already up-to-date.

CI on the previous push already confirmed the `0.5.*` bump alone fixes `lint`, `Check intra-doc links` and `Check semver`.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [ ] I have performed a self-review of my own code
