### PR TITLE
feat: Introduce default versions for virtual packages

### DIFF
--- a/crates/rattler_virtual_packages/src/defaults.rs
+++ b/crates/rattler_virtual_packages/src/defaults.rs
@@ -1,0 +1,39 @@
+//! Default virtual package versions to use when the actual version cannot be
+//! detected from the host system, for example when detecting virtual packages
+//! for a platform other than the current one (see
+//! [`crate::VirtualPackages::detect_for_platform`]).
+//!
+//! The values match the defaults used by
+//! [pixi](https://github.com/prefix-dev/pixi) when no system requirements are
+//! specified.
+
+use rattler_conda_types::{Platform, Version};
+
+/// The default `glibc` version to use when the version cannot be detected.
+///
+/// This is the `glibc` version that ships with RHEL 8 and Debian 10.
+pub fn default_glibc_version() -> Version {
+    "2.28".parse().unwrap()
+}
+
+/// The default Linux kernel version to use when the version cannot be
+/// detected.
+///
+/// This is the kernel version that ships with RHEL 8.
+pub fn default_linux_version() -> Version {
+    "4.18".parse().unwrap()
+}
+
+/// The default Windows version to use when the version cannot be detected.
+pub fn default_windows_version() -> Version {
+    "10.0".parse().unwrap()
+}
+
+/// Returns the default macOS version to use when the version cannot be
+/// detected, or `None` if the given platform is not a macOS platform.
+pub fn default_mac_os_version(platform: Platform) -> Option<Version> {
+    match platform {
+        Platform::Osx64 | Platform::OsxArm64 => Some("13.0".parse().unwrap()),
+        _ => None,
+    }
+}

--- a/crates/rattler_virtual_packages/src/defaults.rs
+++ b/crates/rattler_virtual_packages/src/defaults.rs
@@ -2,10 +2,6 @@
 //! detected from the host system, for example when detecting virtual packages
 //! for a platform other than the current one (see
 //! [`crate::VirtualPackages::detect_for_platform`]).
-//!
-//! The values match the defaults used by
-//! [pixi](https://github.com/prefix-dev/pixi) when no system requirements are
-//! specified.
 
 use rattler_conda_types::{Platform, Version};
 

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -332,8 +332,15 @@ impl VirtualPackages {
             let win = if platform.is_windows() {
                 // Check override first, fall back to the default version
                 virtual_packages.win.or_else(|| {
+                    let version = defaults::default_windows_version();
+                    log_default_virtual_package(
+                        "__win",
+                        platform,
+                        &version,
+                        Windows::DEFAULT_ENV_NAME,
+                    );
                     Some(Windows {
-                        version: Some(defaults::default_windows_version()),
+                        version: Some(version),
                     })
                 })
             } else {
@@ -342,9 +349,14 @@ impl VirtualPackages {
 
             let linux = if platform.is_linux() {
                 virtual_packages.linux.or_else(|| {
-                    Some(Linux {
-                        version: defaults::default_linux_version(),
-                    })
+                    let version = defaults::default_linux_version();
+                    log_default_virtual_package(
+                        "__linux",
+                        platform,
+                        &version,
+                        Linux::DEFAULT_ENV_NAME,
+                    );
+                    Some(Linux { version })
                 })
             } else {
                 None
@@ -352,9 +364,17 @@ impl VirtualPackages {
 
             let osx = if platform.is_osx() {
                 // Check override first, fall back to the default version
-                virtual_packages
-                    .osx
-                    .or_else(|| defaults::default_mac_os_version(platform).map(Osx::from))
+                virtual_packages.osx.or_else(|| {
+                    defaults::default_mac_os_version(platform).map(|version| {
+                        log_default_virtual_package(
+                            "__osx",
+                            platform,
+                            &version,
+                            Osx::DEFAULT_ENV_NAME,
+                        );
+                        Osx { version }
+                    })
+                })
             } else {
                 None
             };
@@ -384,9 +404,16 @@ impl VirtualPackages {
             let libc = if platform.is_linux() {
                 // Check override first, fall back to the default glibc version
                 virtual_packages.libc.or_else(|| {
+                    let version = defaults::default_glibc_version();
+                    log_default_virtual_package(
+                        "__glibc",
+                        platform,
+                        &version,
+                        LibC::DEFAULT_ENV_NAME,
+                    );
                     Some(LibC {
                         family: "glibc".into(),
-                        version: defaults::default_glibc_version(),
+                        version,
                     })
                 })
             } else {
@@ -415,6 +442,19 @@ impl VirtualPackages {
             })
         }
     }
+}
+
+/// Logs that the version of a virtual package could not be detected for the
+/// target platform and that a default version is assumed instead.
+fn log_default_virtual_package(
+    name: &str,
+    platform: Platform,
+    version: &Version,
+    env_var_name: &str,
+) {
+    tracing::info!(
+        "cannot detect the version of the virtual package '{name}' when targeting '{platform}', assuming version {version}; set the {env_var_name} environment variable to override"
+    );
 }
 
 impl From<VirtualPackage> for GenericVirtualPackage {

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -33,6 +33,7 @@
 //! example.
 
 pub mod cuda;
+pub mod defaults;
 pub mod libc;
 pub mod linux;
 pub mod osx;
@@ -307,14 +308,15 @@ impl VirtualPackages {
     /// # Cross-compilation defaults
     ///
     /// When cross-compiling (targeting a platform different from the current one), the following
-    /// defaults are used if no override is provided:
+    /// defaults are used if no override is provided (see the [`defaults`] module, the versions
+    /// match the defaults used by pixi):
     ///
-    /// - **Windows** (`__win`): No version specified
-    /// - **Linux** (`__linux`): Version 0
-    /// - **OSX** (`__osx`): Version 0
+    /// - **Windows** (`__win`): Version 10.0
+    /// - **Linux** (`__linux`): Version 4.18
+    /// - **OSX** (`__osx`): Version 13.0
     /// - **iOS** (`__ios`): Version 0 (minimum supported iOS version)
     /// - **Android** (`__android`): Version 0 (minimum supported API level)
-    /// - **`LibC`** (`__glibc`): `glibc` with version 0 (only for Linux platforms)
+    /// - **`LibC`** (`__glibc`): `glibc` with version 2.28 (only for Linux platforms)
     /// - **CUDA** (`__cuda`): Not included (None)
     /// - **Archspec**: Platform-specific minimal architecture (e.g., `x86_64` for `osx-64`)
     pub fn detect_for_platform(
@@ -328,10 +330,12 @@ impl VirtualPackages {
         } else {
             // When cross-compiling, respect overrides but fall back to defaults
             let win = if platform.is_windows() {
-                // Check override first, fall back to default (no version)
-                virtual_packages
-                    .win
-                    .or_else(|| Some(Windows { version: None }))
+                // Check override first, fall back to the default version
+                virtual_packages.win.or_else(|| {
+                    Some(Windows {
+                        version: Some(defaults::default_windows_version()),
+                    })
+                })
             } else {
                 None
             };
@@ -339,7 +343,7 @@ impl VirtualPackages {
             let linux = if platform.is_linux() {
                 virtual_packages.linux.or_else(|| {
                     Some(Linux {
-                        version: Version::major(0),
+                        version: defaults::default_linux_version(),
                     })
                 })
             } else {
@@ -347,12 +351,10 @@ impl VirtualPackages {
             };
 
             let osx = if platform.is_osx() {
-                // Check override first, fall back to version 0
-                virtual_packages.osx.or_else(|| {
-                    Some(Osx {
-                        version: Version::major(0),
-                    })
-                })
+                // Check override first, fall back to the default version
+                virtual_packages
+                    .osx
+                    .or_else(|| defaults::default_mac_os_version(platform).map(Osx::from))
             } else {
                 None
             };
@@ -380,11 +382,11 @@ impl VirtualPackages {
             };
 
             let libc = if platform.is_linux() {
-                // Check override first, fall back to glibc 0
+                // Check override first, fall back to the default glibc version
                 virtual_packages.libc.or_else(|| {
                     Some(LibC {
                         family: "glibc".into(),
-                        version: Version::major(0),
+                        version: defaults::default_glibc_version(),
                     })
                 })
             } else {
@@ -1426,6 +1428,46 @@ mod test {
         assert!(win_names.contains(&"__win".to_string()));
         assert!(!win_names.contains(&"__unix".to_string()));
         assert!(win_names.contains(&"__archspec".to_string()));
+    }
+
+    #[test]
+    fn test_cross_platform_default_versions() {
+        // When targeting a platform whose virtual packages cannot be detected
+        // on the host, the pixi default versions are used instead of 0. The
+        // host's own platform family is skipped because there the detected
+        // (host) versions take precedence over the defaults.
+        let overrides = VirtualPackageOverrides::default();
+        let current = Platform::current();
+
+        if !current.is_linux() {
+            let packages =
+                VirtualPackages::detect_for_platform(Platform::Linux64, &overrides).unwrap();
+            assert_eq!(
+                packages.linux.expect("__linux should be present").version,
+                defaults::default_linux_version()
+            );
+            let libc = packages.libc.expect("__glibc should be present");
+            assert_eq!(libc.family, "glibc");
+            assert_eq!(libc.version, defaults::default_glibc_version());
+        }
+
+        if !current.is_osx() {
+            let packages =
+                VirtualPackages::detect_for_platform(Platform::OsxArm64, &overrides).unwrap();
+            assert_eq!(
+                packages.osx.expect("__osx should be present").version,
+                defaults::default_mac_os_version(Platform::OsxArm64).unwrap()
+            );
+        }
+
+        if !current.is_windows() {
+            let packages =
+                VirtualPackages::detect_for_platform(Platform::Win64, &overrides).unwrap();
+            assert_eq!(
+                packages.win.expect("__win should be present").version,
+                Some(defaults::default_windows_version())
+            );
+        }
     }
 
     #[test]

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -308,15 +308,15 @@ impl VirtualPackages {
     /// # Cross-compilation defaults
     ///
     /// When cross-compiling (targeting a platform different from the current one), the following
-    /// defaults are used if no override is provided (see the [`defaults`] module, the versions
-    /// match the defaults used by pixi):
+    /// defaults are used if no override is provided (see the [`defaults`] module):
     ///
-    /// - **Windows** (`__win`): Version 10.0
-    /// - **Linux** (`__linux`): Version 4.18
-    /// - **OSX** (`__osx`): Version 13.0
+    /// - **Windows** (`__win`): [`defaults::default_windows_version`]
+    /// - **Linux** (`__linux`): [`defaults::default_linux_version`]
+    /// - **OSX** (`__osx`): [`defaults::default_mac_os_version`]
     /// - **iOS** (`__ios`): Version 0 (minimum supported iOS version)
     /// - **Android** (`__android`): Version 0 (minimum supported API level)
-    /// - **`LibC`** (`__glibc`): `glibc` with version 2.28 (only for Linux platforms)
+    /// - **`LibC`** (`__glibc`): `glibc` with [`defaults::default_glibc_version`] (only for Linux
+    ///   platforms)
     /// - **CUDA** (`__cuda`): Not included (None)
     /// - **Archspec**: Platform-specific minimal architecture (e.g., `x86_64` for `osx-64`)
     pub fn detect_for_platform(


### PR DESCRIPTION
i noticed that `rattler solve --platform <different-platform-than-host>` results in `__linux=0=0` which leads to weird solving errors by default. wdyt about having default versions?

```
❯ rattler solve rattler --platform linux-64 python
Solving for platform: linux-64
Loaded 3247 records in 61.649958ms
Virtual packages:
  - __unix=0=0
  - __linux=0=0
  - __glibc=0=0
  - __archspec=1=x86_64

Error:   × Cannot solve the request because of: rattler * cannot be installed because there are no viable options:
  │ └─ rattler 0.1.0 | 0.1.1 | ... | 0.2.7 would require
  │    └─ __glibc >=2.17,<3.0.a0, for which no candidates were found.
  │
```

prompt

```
rattler solve uses wrong virtual packages by default when doing cross-platform solves.

❯ rattler solve pnpm --platform linux-64
Solving for platform: linux-64
Loaded 4061 records in 215.789625ms
Virtual packages:
  - __unix=0=0
  - __linux=0=0
  - __glibc=0=0
  - __archspec=1=x86_64


it should specify certain versions by default, for example for __linux and __glibc.
pixi does that already, can you fetch those default versions there and put them into rattler somewhere and use them here?
```

i think we could use those versions in `pixi` as well in their defaults, wdyt?

<details>
<summary>🤖 yap</summary>

### Description

This PR introduces a new `defaults` module that provides default virtual package versions matching those used by pixi when detecting packages for platforms other than the current host. Previously, cross-compilation would use hardcoded version 0 for most packages, which doesn't reflect real-world defaults.

**Changes:**
- Added `crates/rattler_virtual_packages/src/defaults.rs` with functions for default versions:
  - `default_glibc_version()` → 2.28 (RHEL 8 / Debian 10)
  - `default_linux_version()` → 4.18 (RHEL 8 kernel)
  - `default_windows_version()` → 10.0
  - `default_mac_os_version()` → 13.0 (for macOS platforms)
- Updated `VirtualPackages::detect_for_platform()` to use these defaults instead of hardcoded zeros
- Updated documentation to reference the new defaults module and clarify version behavior
- Added comprehensive test `test_cross_platform_default_versions()` to verify defaults are applied correctly when cross-compiling

The defaults now align with pixi's behavior, ensuring consistent virtual package resolution across tools in the conda ecosystem.

### How Has This Been Tested?

- Added unit test `test_cross_platform_default_versions()` that verifies:
  - Linux defaults (kernel 4.18, glibc 2.28) are used when targeting Linux from non-Linux platforms
  - macOS default (13.0) is used when targeting macOS from non-macOS platforms
  - Windows default (10.0) is used when targeting Windows from non-Windows platforms
  - Host platform detection takes precedence (test skips checks for current platform)
- Existing tests continue to pass

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes

https://claude.ai/code/session_01WyyLK4E1qspcGuhDgoqS7K

</details>