### PR TITLE
fix(rattler_solve): rate candidates by their most restrictive requirement

### DIFF
--- a/crates/rattler_solve/src/resolvo/conda_sorting.rs
+++ b/crates/rattler_solve/src/resolvo/conda_sorting.rs
@@ -276,25 +276,27 @@ impl<'a, 'repo> SolvableSorter<'a, 'repo> {
             .sorted_by_key(|name| self.pool().resolve_package_name(*name))
             .collect_vec();
 
-        // A closure that locates the highest version of a dependency for a solvable.
-        let mut find_highest_version_for_set = |version_set_ids: &Vec<VersionSetId>| {
+        // The best version of a dependency that this solvable can end up with.
+        //
+        // A solvable can require the same package more than once: a recipe lists a bare
+        // `nodejs` next to the `nodejs >=26.5.1,<27.0a0` pin from its run-export. Only
+        // versions matching all of the requirements can be selected, so take the lowest
+        // of their highest versions. Taking the highest would score every build by the
+        // bare requirement, which matches everything and separates nothing.
+        //
+        // This is an approximation. It does not intersect the requirements, only takes
+        // the lowest of their individual maxima. Enough to order candidates.
+        let mut find_best_selectable_version = |version_set_ids: &Vec<VersionSetId>| {
             version_set_ids
                 .iter()
                 .filter_map(|id| find_highest_version(*id, self.solver, version_cache))
                 .map(|v| TrackedFeatureVersion::new(v.0, v.1))
-                .fold(None, |init, version| {
-                    if let Some(init) = init {
-                        Some(
-                            if version.compare_with_strategy(&init, CompareStrategy::Default)
-                                == Ordering::Less
-                            {
-                                version
-                            } else {
-                                init
-                            },
-                        )
+                .reduce(|a, b| {
+                    // Better sorts first, so `Greater` means `a` is the more restrictive.
+                    if a.compare_with_strategy(&b, CompareStrategy::Default) == Ordering::Greater {
+                        a
                     } else {
-                        Some(version)
+                        b
                     }
                 })
         };
@@ -305,10 +307,10 @@ impl<'a, 'repo> SolvableSorter<'a, 'repo> {
             for &name in sorted_unique_names.iter() {
                 let a_version = id_and_deps
                     .get(&(*a, name))
-                    .and_then(&mut find_highest_version_for_set);
+                    .and_then(&mut find_best_selectable_version);
                 let b_version = id_and_deps
                     .get(&(*b, name))
-                    .and_then(&mut find_highest_version_for_set);
+                    .and_then(&mut find_best_selectable_version);
 
                 // Deal with the case where resolving the version set doesn't actually select a
                 // version

--- a/crates/rattler_solve/tests/backends/main.rs
+++ b/crates/rattler_solve/tests/backends/main.rs
@@ -22,6 +22,7 @@ mod extras_tests;
 mod helpers;
 mod min_age_tests;
 mod solver_case_tests;
+mod sorting_tests;
 mod strategy_tests;
 mod variant_flags_tests;
 
@@ -1350,6 +1351,22 @@ mod resolvo {
               └─ bar <2, which cannot be installed because there are no viable options:
                  └─ bar 1, which conflicts with the versions reported above.
         "###);
+    }
+
+    // Candidate ordering tests (resolvo-specific)
+
+    #[test]
+    fn test_prefers_build_with_highest_dependency() {
+        crate::sorting_tests::solve_prefers_build_with_highest_dependency::<
+            rattler_solve::resolvo::Solver,
+        >();
+    }
+
+    #[test]
+    fn test_prefers_build_with_highest_dependency_with_bare_requirement() {
+        crate::sorting_tests::solve_prefers_build_with_highest_dependency_with_bare_requirement::<
+            rattler_solve::resolvo::Solver,
+        >();
     }
 
     // Strategy tests (resolvo-specific)

--- a/crates/rattler_solve/tests/backends/sorting_tests.rs
+++ b/crates/rattler_solve/tests/backends/sorting_tests.rs
@@ -1,0 +1,68 @@
+//! Tests for how candidates of the same version and build number are ordered.
+
+use super::helpers::{PackageBuilder, SolverCase};
+use rattler_conda_types::RepoDataRecord;
+use rattler_solve::SolverImpl;
+
+/// Two builds of `pkg 1.0` with the same build number that pin different majors
+/// of `dep`. Mirrors conda-forge, where `pnpm 11.19.0` exists both pinned to
+/// `nodejs 24.*` and pinned to `nodejs 26.*`.
+///
+/// With `bare_requirement` both builds also carry an unpinned `dep` next to the
+/// pin, which is what a recipe listing `dep` in its run requirements produces.
+fn duplicate_dependency_repository(bare_requirement: bool) -> Vec<RepoDataRecord> {
+    let dep_24 = PackageBuilder::new("dep").version("24.19.0").build();
+    let dep_26 = PackageBuilder::new("dep").version("26.6.0").build();
+
+    let requirements = |pin: &str| {
+        if bare_requirement {
+            vec!["dep".to_string(), pin.to_string()]
+        } else {
+            vec![pin.to_string()]
+        }
+    };
+
+    // The build pinned to the older `dep` is built last, so it wins any tie that
+    // falls through to the timestamp.
+    let pkg_dep24 = PackageBuilder::new("pkg")
+        .version("1.0")
+        .build_number(0)
+        .build_string("h_dep24_0")
+        .depends(requirements("dep >=24.18.0,<25.0a0"))
+        .timestamp("2026-07-31T18:34:43Z")
+        .build();
+    let pkg_dep26 = PackageBuilder::new("pkg")
+        .version("1.0")
+        .build_number(0)
+        .build_string("h_dep26_0")
+        .depends(requirements("dep >=26.5.1,<27.0a0"))
+        .timestamp("2026-07-31T18:34:41Z")
+        .build();
+
+    vec![dep_24, dep_26, pkg_dep24, pkg_dep26]
+}
+
+/// One pin per build: the build allowing the newest `dep` wins, even though the
+/// other one has a newer timestamp.
+pub(super) fn solve_prefers_build_with_highest_dependency<T: SolverImpl + Default>() {
+    SolverCase::new("build pinning the newest dependency wins over a newer build timestamp")
+        .repository(duplicate_dependency_repository(false))
+        .specs(["pkg"])
+        .expect_present([("pkg", "1.0", "h_dep26_0")])
+        .expect_present([("dep", "26.6.0")])
+        .run::<T>();
+}
+
+/// Same, but with a bare `dep` next to each pin. The bare requirement matches
+/// every `dep`, so scoring a build by its least restrictive requirement leaves
+/// the timestamp to decide, and that only says which variant built last.
+pub(super) fn solve_prefers_build_with_highest_dependency_with_bare_requirement<
+    T: SolverImpl + Default,
+>() {
+    SolverCase::new("a bare requirement next to a pin does not mask the pin")
+        .repository(duplicate_dependency_repository(true))
+        .specs(["pkg"])
+        .expect_present([("pkg", "1.0", "h_dep26_0")])
+        .expect_present([("dep", "26.6.0")])
+        .run::<T>();
+}


### PR DESCRIPTION
### Description

The solver picked a different `nodejs` for the same `pnpm` version depending on the platform and on the `pnpm` release. After this change all four combinations from #2643 give `nodejs 26.6.0`.

`pnpm` ships two builds per version with the same version and the same build number, one pinned to `nodejs 24.*` and one to `nodejs 26.*`:

```
11.19.0 h245e063_0 | nodejs ; nodejs >=26.5.1,<27.0a0
11.19.0 hcdd682b_0 | nodejs ; nodejs >=24.18.0,<25.0a0
```

When candidates tie on version and build number, `SolvableSorter` prefers the one that allows the highest versions of the dependencies they share. But a solvable can depend on the same package more than once, and we scored such a dependency by the highest version across all of its requirements. That is the requirement that tells us the least.

`pnpm` lists a bare `nodejs` in its run requirements next to the `nodejs` run-export pin. The bare requirement matches every `nodejs`, so both builds scored `26.6.0` and the pin that separates them was ignored.

So the tie fell through to the build timestamp, which only says which variant the build matrix finished last:

| subdir | pnpm | ts of `nodejs 26` build | ts of `nodejs 24` build | newer | solved before |
| --- | --- | --- | --- | --- | --- |
| linux-64 | 11.19.0 | …836011 | …838045 | 24 | nodejs 24 |
| linux-64 | 11.20.0 | …542102 | …537008 | 26 | nodejs 26 |
| osx-arm64 | 11.19.0 | …941145 | …880076 | 26 | nodejs 26 |
| osx-arm64 | 11.20.0 | …614906 | …658235 | 24 | nodejs 24 |

Score a dependency by the lowest of the highest versions of its requirements instead. Only versions that satisfy all of them can be selected anyway.

It stays an approximation. It does not compute the highest version in the intersection of the requirements, only the lowest of their individual maxima. That is enough to order candidates and it saves intersecting the candidate sets.

Fixes #2643

### How Has This Been Tested?

Two tests in `crates/rattler_solve/tests/backends/sorting_tests.rs`. Both use two builds of `pkg 1.0` that share a build number and pin different majors of `dep`, where the build pinning the older `dep` has the newer timestamp.

`test_prefers_build_with_highest_dependency` has one pin per build. It passes before and after, so it pins down the behaviour we already had.

`test_prefers_build_with_highest_dependency_with_bare_requirement` adds a bare `dep` next to each pin. On `main` it fails with `pkg=1.0=h_dep24_0, dep=24.19.0`. It passes after the change.

`cargo test -p rattler_solve --all-features` is green, 153 tests. The `tests/sorting.rs` snapshots over the real `conda-forge` fixture did not change.

The reproducer from the issue, with the CLI built from this branch:

```console
$ rattler solve pnpm==11.19.0 --platform linux-64 --exclude-newer 2026-08-05 ... | grep -E "^(nodejs|pnpm) "
pnpm 11.19.0 h245e063_0 linux-64
nodejs 26.6.0 hc039f44_0 linux-64
```

All four platform/version combinations give `nodejs 26.6.0` now.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
