### PR TITLE
fix(repodata_gateway)!: log user-order conflicts at debug level

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/channel_expander.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_expander.rs
@@ -40,8 +40,7 @@ pub enum ChannelRelationsMode {
 
 /// A non-fatal CEP-42 problem, collected on the query output in
 /// [`Warn`](ChannelRelationsMode::Warn) mode. In
-/// [`Strict`](ChannelRelationsMode::Strict) mode every variant except
-/// [`UserOrderConflict`](Self::UserOrderConflict) becomes a
+/// [`Strict`](ChannelRelationsMode::Strict) mode every variant becomes a
 /// [`GatewayError::ChannelRelationsError`](super::GatewayError::ChannelRelationsError).
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ChannelRelationsWarning {
@@ -121,19 +120,6 @@ pub enum ChannelRelationsWarning {
         platform: Platform,
         /// Display-formatted [`GatewayError`](super::GatewayError).
         error: String,
-    },
-
-    /// The relation contradicts the explicit channel order and was
-    /// ignored. Never fatal: the user's order wins.
-    #[error(
-        "CEP-42 relation `{from}` -> `{to}` contradicts the explicit \
-         channel order and was ignored"
-    )]
-    UserOrderConflict {
-        /// Channel the dropped edge ranked higher.
-        from: ChannelUrl,
-        /// Channel the dropped edge ranked lower.
-        to: ChannelUrl,
     },
 
     /// Relation edges dropped to break a cycle in the declared
@@ -452,8 +438,8 @@ impl ChannelExpander {
     }
 
     /// Report deferred depth refusals, resolve the priority order from
-    /// canonically sorted inputs (identical run to run), and surface
-    /// ignored and broken edges.
+    /// canonically sorted inputs (identical run to run), log edges the
+    /// user order overrides, and surface broken edges.
     pub fn finalize(&mut self) -> Result<Resolution<ChannelUrl>, super::GatewayError> {
         self.report_depth_refusals()?;
 
@@ -473,11 +459,14 @@ impl ChannelExpander {
         let resolution = resolve_channel_priority(&self.user_channels, &nodes, &edges);
 
         for edge in &resolution.ignored_edges {
-            // Never fatal: CEP-42 says the explicit user order wins.
-            self.push_warning(ChannelRelationsWarning::UserOrderConflict {
-                from: edge.from.clone(),
-                to: edge.to.clone(),
-            });
+            // Not a warning: CEP-42 says the explicit user order wins, so
+            // there is nothing for the user to act on.
+            tracing::debug!(
+                "CEP-42 relation `{}` -> `{}` contradicts the explicit channel \
+                 order and was ignored",
+                edge.from,
+                edge.to,
+            );
         }
         if !resolution.broken_cycle_edges.is_empty() {
             let broken_edges = resolution

--- a/crates/rattler_repodata_gateway/src/gateway/channel_relations.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_relations.rs
@@ -41,8 +41,8 @@ pub struct PriorityEdge<K> {
 }
 
 /// Outcome of a channel priority resolution. Always succeeds; the
-/// caller surfaces `ignored_edges` / `broken_cycle_edges` as warnings
-/// or errors per its mode.
+/// caller logs `ignored_edges` and surfaces `broken_cycle_edges` as a
+/// warning or an error per its mode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Resolution<K> {
     /// Final priority order, highest first.
@@ -50,8 +50,7 @@ pub struct Resolution<K> {
     /// Edges respected by `order`.
     pub edges: Vec<PriorityEdge<K>>,
     /// Relation edges dropped because they contradicted the user's
-    /// explicit ordering. Surfaced by the expander as
-    /// `UserOrderConflict` warnings.
+    /// explicit ordering. Logged at debug level by the expander.
     pub ignored_edges: Vec<PriorityEdge<K>>,
     /// Relation edges dropped to break a cycle.
     pub broken_cycle_edges: Vec<PriorityEdge<K>>,

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -3925,10 +3925,10 @@ mod test {
         );
     }
 
-    /// A relation the explicit user order overrides surfaces as a
-    /// `UserOrderConflict` warning instead of being silently dropped.
+    /// A relation the explicit user order overrides is dropped without
+    /// a warning: the user cannot act on it, so it is only logged.
     #[tokio::test]
-    async fn test_cep42_user_order_conflict_surfaces_as_warning() {
+    async fn test_cep42_user_order_conflict_produces_no_warning() {
         let dir = tempfile::tempdir().unwrap();
         let bc_root = dir.path().join("bioconda");
         let cf_root = dir.path().join("conda-forge");
@@ -3941,8 +3941,7 @@ mod test {
 
         let gateway = Gateway::new();
         // The user puts bioconda FIRST, contradicting bioconda's own
-        // `base: conda-forge` declaration. The user wins; the dropped
-        // relation is reported.
+        // `base: conda-forge` declaration. The user wins.
         let output = gateway
             .query(
                 vec![bioconda, conda_forge],
@@ -3966,14 +3965,52 @@ mod test {
             .collect();
         assert_eq!(versions, ["2.0.0", "1.0.0"], "user order wins");
         assert!(
-            output.warnings.iter().any(|w| matches!(
-                w,
-                crate::GatewayWarning::ChannelRelations(
-                    crate::ChannelRelationsWarning::UserOrderConflict { .. }
-                )
-            )),
-            "expected UserOrderConflict warning; got {:?}",
+            output.warnings.is_empty(),
+            "overriding a relation via the explicit channel order must not warn; got {:?}",
             output.warnings,
         );
+    }
+
+    /// CEP-42 makes the explicit user order authoritative, so a
+    /// relation it overrides is not a violation even in `Strict` mode.
+    #[tokio::test]
+    async fn test_cep42_strict_mode_tolerates_user_order_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let bc_root = dir.path().join("bioconda");
+        let cf_root = dir.path().join("conda-forge");
+        write_test_subdir(&bc_root, "shared", "2.0.0", Some("../conda-forge"), None);
+        write_test_subdir(&cf_root, "shared", "1.0.0", None, None);
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let bioconda = Channel::from_url(server.url().join("bioconda/").unwrap());
+        let conda_forge = Channel::from_url(server.url().join("conda-forge/").unwrap());
+
+        let gateway = Gateway::new();
+        let output = gateway
+            .query(
+                vec![bioconda, conda_forge],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("shared", Strict).unwrap()],
+            )
+            .recursive(false)
+            .channel_relations(crate::ChannelRelationsMode::Strict)
+            .execute()
+            .await
+            .expect(
+                "the explicit channel order overriding a relation must not fail a Strict query",
+            );
+
+        let versions: Vec<String> = output
+            .repodata
+            .iter()
+            .map(|b| {
+                b.iter()
+                    .map(|r| r.package_record.version.as_str().to_string())
+                    .next()
+                    .unwrap_or_default()
+            })
+            .collect();
+        assert_eq!(versions, ["2.0.0", "1.0.0"], "user order wins");
+        assert!(output.warnings.is_empty(), "got {:?}", output.warnings);
     }
 }


### PR DESCRIPTION
CEP-42 relations that the explicit channel order overrides are no longer collected as warnings; `finalize` logs each ignored edge with `tracing::debug!` instead.

A user cannot act on this warning. Take a pixi manifest where conda-forge is the default channel and a feature adds a robostack channel on top: robostack declares conda-forge as its base, so the relation points the other way round from the order the manifest asks for. The user order wins, as CEP-42 says it must, and the dropped edge was reported once per resolve. Removing the channel is not an option and reordering it defeats the point of putting it on top, so the only way to silence the warning was to stop using the feature.

Removes the `ChannelRelationsWarning::UserOrderConflict` variant, so the case no longer reaches `Reporter::on_gateway_warning`, `RepoDataQueryOutput::warnings`, `rattler.GatewayWarning` in py-rattler, or `console.warn` in js-rattler.

### How Has This Been Tested?

By running it and with some tests.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.