### PR TITLE
fix(rattler_networking): report a missing OCI manifest as a 404 instead of erroring

### DIFF
--- a/crates/rattler_networking/src/oci_middleware.rs
+++ b/crates/rattler_networking/src/oci_middleware.rs
@@ -37,6 +37,9 @@ enum OciMiddlewareError {
     #[error("Layer not found")]
     LayerNotFound,
 
+    #[error("Manifest request failed with status {0}")]
+    ManifestRequestFailed(StatusCode),
+
     #[error("Invalid OCI URL '{0}': {1}")]
     InvalidUrl(Url, &'static str),
 
@@ -548,7 +551,10 @@ impl OCIUrl {
                 }
             }
 
-            let manifest: Manifest = manifest.error_for_status()?.json().await?;
+            if !manifest.status().is_success() {
+                return Err(OciMiddlewareError::ManifestRequestFailed(manifest.status()));
+            }
+            let manifest: Manifest = manifest.json().await?;
 
             let layer = if let Some(layer) = manifest
                 .layers
@@ -634,11 +640,15 @@ impl Middleware for OciMiddleware {
                 next.run(retry_req, extensions).await
             }
             Err(e) => match e {
+                // Return clean 404s rather than erroring as callers safely handle them.
                 OciMiddlewareError::LayerNotFound => {
                     return Ok(create_404_response(
                         req.url(),
                         "No layer available for media type",
                     ));
+                }
+                OciMiddlewareError::ManifestRequestFailed(StatusCode::NOT_FOUND) => {
+                    return Ok(create_404_response(req.url(), "Manifest not found"));
                 }
                 _ => {
                     return Err(reqwest_middleware::Error::Middleware(e.into()));
@@ -831,6 +841,27 @@ mod tests {
             hex::encode(hash),
             "8485a64911c7011c0270b8266ab2bffa1da41c59ac4f0a48000c31d4f4a966dd"
         );
+    }
+
+    /// Test that a missing package comes back as a plain 404.
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
+    #[tokio::test]
+    async fn test_oci_middleware_missing_package_is_404() {
+        let client = reqwest::Client::new();
+        let middleware = OciMiddleware::new(client.clone());
+
+        let client_with_middleware = reqwest_middleware::ClientBuilder::new(client)
+            .with(middleware)
+            .build();
+
+        // Repo exists, version doesn't.
+        let response = client_with_middleware
+            .get("oci://ghcr.io/channel-mirrors/conda-forge/osx-arm64/xtensor-999.999.999-h0000000_0.conda")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 404);
     }
 
     // test pulling an image from OCI registry


### PR DESCRIPTION
### Description

Third point of #2624, second PR in the series (after #2628).

#2281 added a status check before deserializing an OCI manifest response, but a failed manifest request still aborts the whole request chain with a middleware error. A 404 manifest now becomes a clean 404 response for the artifact, which callers can handle (mirror fallback, repodata variant probing). Other failure statuses become an error carrying the status.

### How Has This Been Tested?

New test `test_oci_middleware_missing_package_is_404` requests a nonexistent version of an existing package from ghcr.io, forcing the manifest path, and asserts a 404 response rather than an error.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
