### PR TITLE
feat(auth): request Basilisk query scope

### DIFF
--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- prefix.dev OAuth logins now request Basilisk query access while retaining channel access. Pixi users must upgrade to the eventual Pixi release containing this change, then run `pixi auth logout prefix.dev` and `pixi auth login prefix.dev` to update existing credentials.
+
 ## [0.48.1](https://github.com/conda/rattler/compare/rattler-v0.48.0...rattler-v0.48.1) - 2026-08-03
 
 ### Other

--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -268,7 +268,7 @@ fn normalize_login_host(host: &str) -> String {
         .unwrap_or_else(|| host.trim_end_matches('/').to_string())
 }
 
-/// prefix.dev's default channel scopes
+/// prefix.dev's default OAuth scopes.
 #[cfg(feature = "oauth")]
 const PREFIX_DEV_OAUTH_SCOPES: &[&str] = &[
     "openid",
@@ -276,6 +276,7 @@ const PREFIX_DEV_OAUTH_SCOPES: &[&str] = &[
     "offline_access",
     "channel:read",
     "channel:upload",
+    "basilisk:query",
 ];
 
 /// Built-in OAuth defaults for a known host.
@@ -1524,7 +1525,23 @@ mod tests {
         let prefix = default_oauth_config_for_host("prefix.dev").unwrap();
         assert_eq!(prefix.issuer_url, "https://prefix.dev");
         assert_eq!(prefix.client_id, "rattler");
-        assert!(prefix.scopes.iter().any(|s| s == "channel:upload"));
+        assert_eq!(
+            prefix
+                .scopes
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>(),
+            [
+                "openid",
+                "profile",
+                "offline_access",
+                "channel:read",
+                "channel:upload",
+                "basilisk:query",
+            ]
+            .into_iter()
+            .map(ToString::to_string)
+            .collect()
+        );
     }
 
     #[cfg(feature = "oauth")]

--- a/crates/rattler_networking/src/oauth_refresh.rs
+++ b/crates/rattler_networking/src/oauth_refresh.rs
@@ -423,6 +423,9 @@ mod tests {
             let success_count = success_count.clone();
             let invalid_grant_count = invalid_grant_count.clone();
             move |form| {
+                // Omitting scope preserves the originally granted channel and
+                // Basilisk access (RFC 6749 section 6).
+                assert!(!form.contains_key("scope"));
                 let presented = form.get("refresh_token").cloned().unwrap_or_default();
                 let mut valid = valid_refresh_token.lock().unwrap();
                 if presented == *valid {


### PR DESCRIPTION
### Description

`pixi audit` will use prefix.dev access tokens to query Basilisk. Rattler's built-in prefix.dev client currently asks for identity and channel scopes only, so those tokens cannot call the authenticated query API.

This adds `basilisk:query` to the shared prefix.dev OAuth defaults used by the authorization-code and device-code flows without dropping the existing channel scopes. Refresh requests continue to omit `scope`, which preserves the original grant. Users with an existing login will need to upgrade to a Pixi release containing this change, then log out and back in.

PFX-1798

### How Has This Been Tested?

- Formatting and workspace Clippy pass.
- Focused auth tests cover the complete prefix.dev default scope set.
- Refresh tests assert that refresh requests do not replace the original grant.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: OpenAI Codex via pi

```plaintext
Add basilisk:query to prefix.dev's shared OAuth defaults, preserve the existing channel grant during refresh, cover the auth flows, add re-login guidance, and validate the change.
```

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented the refresh behavior where it is easy to regress
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes
