### PR TITLE
chore(ci): maintain lockfiles and automerge non-major updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,23 +1,21 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended"],
+  extends: ["config:best-practices"],
   enabledManagers: ["github-actions", "pixi", "cargo", "npm"],
   commitMessagePrefix: "chore(ci):",
-  separateMajorMinor: false,
   ignorePaths: ["**/test-data/**"],
   labels: ["dependencies"],
   schedule: ["before 4am on Tuesday"],
   prHourlyLimit: 2,
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["before 4am on Tuesday"],
+  },
   cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
     rangeStrategy: "update-lockfile",
   },
   packageRules: [
-    {
-      description: "Pin GitHub Actions to immutable SHAs.",
-      matchDepTypes: ["action"],
-      pinDigests: true,
-    },
     {
       description: "Annotate GitHub Actions SHAs with a SemVer version.",
       extends: ["helpers:pinGitHubActionDigests"],
@@ -25,34 +23,15 @@
       versioning: "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
     },
     {
-      "groupName": "Pixi-Lock",
-      "matchManagers": ["pixi"],
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "automerge": true,
+      description: "Automerge non-major dependency updates after CI passes.",
+      matchUpdateTypes: ["digest", "pinDigest", "patch", "minor", "lockFileMaintenance"],
+      automerge: true,
     },
     {
       description: "We want to update Rust manually and keep it in sync with rust-toolchain",
       matchPackageNames: "rust",
       matchManagers: ["pixi"],
       enabled: false,
-    },
-    {
-      groupName: "Rust dev-dependencies",
-      matchManagers: ["cargo"],
-      matchDepTypes: ["devDependencies"],
-      description: "Weekly update of Rust development dependencies",
-    },
-    {
-      description: "Automerge Cargo patch bumps (only touches Cargo.lock via update-lockfile).",
-      matchManagers: ["cargo"],
-      matchUpdateTypes: ["patch"],
-      automerge: true,
-    },
-    {
-      "groupName": "Npm-Lock",
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "automerge": true,
     },
   ],
   vulnerabilityAlerts: {


### PR DESCRIPTION
### Description

The npm and Pixi rules looked like they enabled lockfile maintenance, but they only configured updates after Renovate had created them. Since lockfile maintenance is disabled by default, transitive dependencies could remain stale until another update happened to rewrite the lockfile.

This enables weekly maintenance for the Cargo, Pixi, and npm lockfiles and automerges lockfile and non-major updates once CI passes. It also removes the broad Rust dev-dependency group and restores separate major updates. Renovate's curated monorepo and ecosystem groups remain, since those dependencies are expected to move together.

The config now extends `config:best-practices`. Besides lockfile maintenance, this enables Renovate's config migration, pins development dependencies, reports abandoned packages, and applies a three-day minimum release age to npm updates. Major updates and the initial dependency pinning changes still require review.

### How Has This Been Tested?

The resulting config was checked with `renovate-config-validator`, which reported that it is valid. The validator could not load its optional RE2 module in this environment and fell back to regular expressions; the existing regex configuration was not changed by this PR.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

### Checklist:

- [x] I have performed a self-review of my own code