### PR TITLE
feat: emit consistent v3 repodata

### DIFF
--- a/crates/rattler_conda_types/src/lib.rs
+++ b/crates/rattler_conda_types/src/lib.rs
@@ -67,10 +67,11 @@ pub use prefix_data::PrefixData;
 pub use prefix_record::PrefixRecord;
 pub use record_traits::HasArtifactIdentificationRefs;
 pub use repo_data::{
-    ChannelInfo, ChannelRelations, ConvertSubdirError, PackageRecord, RecordFromPath, RepoData,
-    RepodataRevision, RepodataRevisionInfo, RepodataRevisionMetadata, RepodataRevisionSelection,
-    RepodataRevisions, ReservedV3ExtensionError, SubdirRunExportsJson, UrlOrPath, V3Extensions,
-    V3Packages, ValidatePackageRecordsError, WhlPackageRecord, compute_package_url,
+    ChannelInfo, ChannelRelations, ConvertSubdirError, MAX_REPODATA_REVISION_MESSAGE_BYTES,
+    PackageRecord, RecordFromPath, RepoData, RepodataRevision, RepodataRevisionInfo,
+    RepodataRevisionMetadata, RepodataRevisionSelection, RepodataRevisions,
+    ReservedV3ExtensionError, SubdirRunExportsJson, UrlOrPath, V3Extensions, V3Packages,
+    ValidatePackageRecordsError, WhlPackageRecord, compute_package_url,
     patches::{PackageRecordPatch, PatchInstructions, RepoDataPatch},
     sharded::{Shard, ShardedRepodata, ShardedSubdirInfo},
 };

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -178,6 +178,7 @@ pub struct RepodataRevisionInfo {
 /// Package counts and timestamps are derived from emitted records, so callers
 /// can only select a revision and optionally override its message.
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct RepodataRevisionSelection {
     /// The revision to publish.
     #[serde(default)]
@@ -1513,25 +1514,40 @@ mod test {
     }
 
     #[test]
-    fn test_repodata_revision_info_rejects_obsolete_or_oversized_caller_input() {
+    fn test_repodata_revision_info_preserves_published_statistics() {
+        let raw = serde_json::json!({
+            "revision": 3,
+            "message": "v3 packages",
+            "n_packages": 1,
+            "oldest": 1,
+            "newest": 2
+        });
+        let info = serde_json::from_value::<crate::RepodataRevisionInfo>(raw.clone()).unwrap();
+        assert_eq!(info.n_packages, Some(1));
+        assert_eq!(serde_json::to_value(info).unwrap(), raw);
+    }
+
+    #[test]
+    fn test_repodata_revision_selection_rejects_statistics_or_oversized_message() {
         let obsolete = serde_json::json!({
             "revision": 3,
             "message": "v3 packages",
             "n_packages": 1
         });
-        assert!(serde_json::from_value::<crate::RepodataRevisionInfo>(obsolete).is_err());
+        assert!(serde_json::from_value::<crate::RepodataRevisionSelection>(obsolete).is_err());
 
         let at_limit = serde_json::json!({
             "revision": 3,
             "message": "a".repeat(crate::MAX_REPODATA_REVISION_MESSAGE_BYTES)
         });
-        assert!(serde_json::from_value::<crate::RepodataRevisionInfo>(at_limit).is_ok());
+        assert!(serde_json::from_value::<crate::RepodataRevisionSelection>(at_limit).is_ok());
 
         let oversized = serde_json::json!({
             "revision": 3,
             "message": "é".repeat(4097)
         });
-        let err = serde_json::from_value::<crate::RepodataRevisionInfo>(oversized).unwrap_err();
+        let err =
+            serde_json::from_value::<crate::RepodataRevisionSelection>(oversized).unwrap_err();
         assert!(err.to_string().contains("may not exceed 8192 bytes"));
     }
 

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -137,19 +137,27 @@ pub struct RepodataRevisionMetadata {
     pub newest: Option<TimestampMs>,
 }
 
+/// The maximum byte length of an indexer-supplied repodata revision message.
+pub const MAX_REPODATA_REVISION_MESSAGE_BYTES: usize = 8192;
+
 /// Published metadata for a repodata revision.
 ///
 /// In `info.repodata_revisions`, the revision is represented by the enclosing
 /// `vN` map key. This flattened form is useful when revision metadata is
 /// handled as an individual value.
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct RepodataRevisionInfo {
     /// The integer identifying the revision.
     #[serde(default)]
     pub revision: RepodataRevision,
 
     /// An optional message describing this revision.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_repodata_revision_message"
+    )]
     pub message: Option<String>,
 
     /// The number of packages available in this revision.
@@ -176,8 +184,30 @@ pub struct RepodataRevisionSelection {
     pub revision: RepodataRevision,
 
     /// An optional publisher message for this revision.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_repodata_revision_message"
+    )]
     pub message: Option<String>,
+}
+
+fn deserialize_repodata_revision_message<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let message = Option::<String>::deserialize(deserializer)?;
+    if message
+        .as_ref()
+        .is_some_and(|message| message.len() > MAX_REPODATA_REVISION_MESSAGE_BYTES)
+    {
+        return Err(D::Error::custom(format!(
+            "repodata revision messages may not exceed {MAX_REPODATA_REVISION_MESSAGE_BYTES} bytes"
+        )));
+    }
+    Ok(message)
 }
 
 /// A repodata revision.
@@ -1480,6 +1510,29 @@ mod test {
             Some(raw["message"].as_str().unwrap())
         );
         assert_eq!(serde_json::to_value(metadata).unwrap(), raw);
+    }
+
+    #[test]
+    fn test_repodata_revision_info_rejects_obsolete_or_oversized_caller_input() {
+        let obsolete = serde_json::json!({
+            "revision": 3,
+            "message": "v3 packages",
+            "n_packages": 1
+        });
+        assert!(serde_json::from_value::<crate::RepodataRevisionInfo>(obsolete).is_err());
+
+        let at_limit = serde_json::json!({
+            "revision": 3,
+            "message": "a".repeat(crate::MAX_REPODATA_REVISION_MESSAGE_BYTES)
+        });
+        assert!(serde_json::from_value::<crate::RepodataRevisionInfo>(at_limit).is_ok());
+
+        let oversized = serde_json::json!({
+            "revision": 3,
+            "message": "é".repeat(4097)
+        });
+        let err = serde_json::from_value::<crate::RepodataRevisionInfo>(oversized).unwrap_err();
+        assert!(err.to_string().contains("may not exceed 8192 bytes"));
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/repo_data/patches.rs
+++ b/crates/rattler_conda_types/src/repo_data/patches.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::option_option)]
 
-use std::{collections::BTreeSet, io, path::Path};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io,
+    path::Path,
+};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -68,6 +72,9 @@ pub struct PackageRecordPatch {
     /// not required to be installed, but if they are installed they must follow
     /// these constraints.
     pub constrains: Option<Vec<String>>,
+
+    /// Optional dependency groups keyed by extra name.
+    pub extra_depends: Option<BTreeMap<String, Vec<String>>>,
 
     /// Track features are nowadays only used to downweight packages (ie. give
     /// them less priority). To that effect, the number of track features is
@@ -240,6 +247,13 @@ impl PackageRecord {
             self.purls = package_urls.clone();
         }
     }
+
+    fn apply_v3_patch(&mut self, patch: &PackageRecordPatch) {
+        self.apply_patch(patch);
+        if let Some(extra_depends) = &patch.extra_depends {
+            self.extra_depends = extra_depends.clone();
+        }
+    }
 }
 
 /// Apply a patch to a repodata file
@@ -271,17 +285,17 @@ pub fn apply_patches_impl(
     // Apply patches to v3 packages
     for (identifier, patch) in instructions.v3.tar_bz2.iter() {
         if let Some(record) = v3.tar_bz2.get_mut(identifier) {
-            record.apply_patch(patch);
+            record.apply_v3_patch(patch);
         }
     }
     for (identifier, patch) in instructions.v3.conda.iter() {
         if let Some(record) = v3.conda.get_mut(identifier) {
-            record.apply_patch(patch);
+            record.apply_v3_patch(patch);
         }
     }
     for (identifier, patch) in instructions.v3.whl.iter() {
         if let Some(record) = v3.whl.get_mut(identifier) {
-            record.package_record.apply_patch(patch);
+            record.package_record.apply_v3_patch(patch);
         }
     }
     for (extension, patch) in instructions.v3.extensions.iter() {

--- a/crates/rattler_config/src/config/index.rs
+++ b/crates/rattler_config/src/config/index.rs
@@ -35,9 +35,10 @@
 use std::{collections::HashMap, str::FromStr};
 
 use rattler_conda_types::{
-    ChannelNotice, ChannelRelations, RepodataRevision, RepodataRevisionSelection,
+    ChannelNotice, ChannelRelations, MAX_REPODATA_REVISION_MESSAGE_BYTES, RepodataRevision,
+    RepodataRevisionSelection,
 };
-use serde::{Deserialize, Deserializer, Serialize, de::Error as DeError};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as DeError};
 
 use crate::config::{Config, MergeError, ValidationError};
 
@@ -90,7 +91,8 @@ pub struct IndexChannelConfig {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_optional_repodata_revisions"
+        deserialize_with = "deserialize_optional_repodata_revisions",
+        serialize_with = "serialize_optional_repodata_revisions"
     )]
     pub repodata_revisions: Option<Vec<RepodataRevisionSelection>>,
 
@@ -255,27 +257,84 @@ fn validate_channel_relations(
     Ok(())
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ConfiguredRepodataRevision {
+    Revision(String),
+    RevisionWithMessage(ConfiguredRepodataRevisionWithMessage),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct ConfiguredRepodataRevisionWithMessage {
+    revision: String,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+fn serialize_optional_repodata_revisions<S>(
+    revisions: &Option<Vec<RepodataRevisionSelection>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    #[derive(Serialize)]
+    #[serde(untagged)]
+    enum ConfiguredRevision<'a> {
+        Revision(String),
+        RevisionWithMessage { revision: String, message: &'a str },
+    }
+
+    revisions
+        .as_ref()
+        .map(|revisions| {
+            revisions
+                .iter()
+                .map(|info| match info.message.as_deref() {
+                    Some(message) => ConfiguredRevision::RevisionWithMessage {
+                        revision: info.revision.to_string(),
+                        message,
+                    },
+                    None => ConfiguredRevision::Revision(info.revision.to_string()),
+                })
+                .collect::<Vec<_>>()
+        })
+        .serialize(serializer)
+}
+
 fn deserialize_optional_repodata_revisions<'de, D>(
     deserializer: D,
 ) -> Result<Option<Vec<RepodataRevisionSelection>>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let revisions: Option<Vec<String>> = Option::deserialize(deserializer)?;
+    let revisions: Option<Vec<ConfiguredRepodataRevision>> = Option::deserialize(deserializer)?;
     revisions
-        .map(|revs| {
-            revs.into_iter()
-                .map(|s| {
-                    let revision = RepodataRevision::from_str(&s).map_err(D::Error::custom)?;
+        .map(|revisions| {
+            revisions
+                .into_iter()
+                .map(|configured| {
+                    let (revision, message) = match configured {
+                        ConfiguredRepodataRevision::Revision(revision) => (revision, None),
+                        ConfiguredRepodataRevision::RevisionWithMessage(configured) => {
+                            (configured.revision, configured.message)
+                        }
+                    };
+                    if message.as_ref().is_some_and(|message| {
+                        message.len() > MAX_REPODATA_REVISION_MESSAGE_BYTES
+                    }) {
+                        return Err(D::Error::custom(format!(
+                            "repodata revision messages may not exceed {MAX_REPODATA_REVISION_MESSAGE_BYTES} bytes"
+                        )));
+                    }
+                    let revision = RepodataRevision::from_str(&revision).map_err(D::Error::custom)?;
                     if revision != RepodataRevision::V3 {
                         return Err(D::Error::custom(
                             "only v3 can be configured; the legacy layout is implicit",
                         ));
                     }
-                    Ok(RepodataRevisionSelection {
-                        revision,
-                        message: None,
-                    })
+                    Ok(RepodataRevisionSelection { revision, message })
                 })
                 .collect::<Result<Vec<_>, _>>()
         })
@@ -435,6 +494,36 @@ base-url = "../packages/"
     }
 
     #[test]
+    fn parses_repodata_revision_message() {
+        let cfg = parse(
+            r#"
+repodata-revisions = [{ revision = "v3", message = "v3 packages" }]
+"#,
+        );
+        assert_eq!(
+            cfg.default.repodata_revisions,
+            Some(vec![RepodataRevisionSelection {
+                revision: RepodataRevision::V3,
+                message: Some("v3 packages".to_string()),
+            }])
+        );
+    }
+
+    #[test]
+    fn repodata_revision_messages_roundtrip_through_toml() {
+        let config = parse(
+            r#"
+repodata-revisions = [{ revision = "v3", message = "v3 packages" }]
+"#,
+        );
+
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(serialized.contains("revision = \"v3\""));
+        assert!(!serialized.contains("revision = 3"));
+        assert_eq!(toml::from_str::<IndexConfig>(&serialized).unwrap(), config);
+    }
+
+    #[test]
     fn rejects_legacy_repodata_revision_selection() {
         let err = toml::from_str::<IndexConfig>("repodata-revisions = [\"legacy\"]\n").unwrap_err();
         assert!(err.to_string().contains("the legacy layout is implicit"));
@@ -444,8 +533,40 @@ base-url = "../packages/"
     fn rejects_numeric_repodata_revisions() {
         let err = toml::from_str::<IndexConfig>("repodata-revisions = [3]\n").unwrap_err();
         assert!(
-            err.to_string().contains("invalid type"),
-            "unexpected error: {err}"
+            !err.to_string().is_empty(),
+            "numeric repodata revisions must be rejected"
+        );
+    }
+
+    #[test]
+    fn rejects_obsolete_repodata_revision_metadata() {
+        let err = toml::from_str::<IndexConfig>(
+            "repodata-revisions = [{ revision = \"v3\", n-packages = 1 }]\n",
+        )
+        .unwrap_err();
+        assert!(
+            !err.to_string().is_empty(),
+            "obsolete revision metadata must be rejected"
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_repodata_revision_messages_by_byte_length() {
+        let at_limit = format!(
+            "repodata-revisions = [{{ revision = \"v3\", message = \"{}\" }}]\n",
+            "a".repeat(MAX_REPODATA_REVISION_MESSAGE_BYTES)
+        );
+        assert!(toml::from_str::<IndexConfig>(&at_limit).is_ok());
+
+        let oversized = format!(
+            "repodata-revisions = [{{ revision = \"v3\", message = \"{}\" }}]\n",
+            "é".repeat(MAX_REPODATA_REVISION_MESSAGE_BYTES / 2 + 1)
+        );
+        let error = toml::from_str::<IndexConfig>(&oversized).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("repodata revision messages may not exceed 8192 bytes")
         );
     }
 

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -29,9 +29,10 @@ use opendal::layers::RetryLayer;
 use opendal::services::S3Config;
 use opendal::{Configurator, Operator, services::FsConfig};
 use rattler_conda_types::{
-    ChannelInfo, ChannelNotice, ChannelNotices, ChannelRelations, PackageRecord, PatchInstructions,
-    Platform, RepoData, Shard, ShardedRepodata, ShardedSubdirInfo, UrlOrPath, V3Extensions,
-    V3Packages, WhlPackageRecord,
+    ChannelInfo, ChannelNotice, ChannelNotices, ChannelRelations,
+    MAX_REPODATA_REVISION_MESSAGE_BYTES, MatchSpec, PackageRecord, PackageRecordPatch,
+    ParseMatchSpecOptions, PatchInstructions, Platform, RepoData, Shard, ShardedRepodata,
+    ShardedSubdirInfo, UrlOrPath, V3Extensions, V3Packages, WhlPackageRecord,
     package::{
         CondaArchiveType, DistArchiveIdentifier, DistArchiveType, IndexJson, PackageFile,
         RunExportsJson, WheelArchiveType,
@@ -938,6 +939,11 @@ async fn index_subdir_inner(
     }
 
     // TODO: don't serialize run_exports and purls but in their own files
+    let repodata_version = if channel_metadata.base_url.is_some() {
+        2
+    } else {
+        1
+    };
     let repodata_before_patches = RepoData {
         info: Some(ChannelInfo {
             subdir: Some(subdir.to_string()),
@@ -955,7 +961,7 @@ async fn index_subdir_inner(
         conda_packages,
         v3,
         removed: HashSet::default(),
-        version: Some(2),
+        version: Some(repodata_version),
     };
 
     write_repodata(
@@ -991,6 +997,15 @@ fn validate_configured_repodata_revisions(
             return Err(RepodataError::Other(anyhow::anyhow!(
                 "repodata revision {} cannot be configured; only v3 is selectable and the legacy layout is implicit",
                 revision.revision
+            )));
+        }
+        if revision
+            .message
+            .as_ref()
+            .is_some_and(|message| message.len() > MAX_REPODATA_REVISION_MESSAGE_BYTES)
+        {
+            return Err(RepodataError::Other(anyhow::anyhow!(
+                "repodata revision messages may not exceed {MAX_REPODATA_REVISION_MESSAGE_BYTES} bytes"
             )));
         }
     }
@@ -1186,7 +1201,7 @@ struct RevisionStats {
 impl RevisionStats {
     fn add(&mut self, record: &PackageRecord) {
         self.n_packages += 1;
-        if let Some(timestamp) = record.timestamp {
+        if let Some(timestamp) = record.timestamp_for_indexing() {
             self.oldest = Some(
                 self.oldest
                     .map_or(timestamp, |oldest| oldest.min(timestamp)),
@@ -1264,20 +1279,152 @@ fn repodata_revisions_for_packages(
     revisions.into_iter().collect()
 }
 
+fn canonicalize_v3_match_spec(field: &str, spec: &str) -> Result<String, RepodataError> {
+    let parsed = MatchSpec::from_str(
+        spec,
+        ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3),
+    )
+    .with_context(|| format!("failed to parse {field} MatchSpec '{spec}' for v3 repodata"))?;
+    Ok(parsed.to_canonical_string().with_context(|| {
+        format!("failed to canonicalize {field} MatchSpec '{spec}' for v3 repodata")
+    })?)
+}
+
+fn canonicalize_v3_match_specs(field: &str, specs: &mut [String]) -> Result<(), RepodataError> {
+    for spec in specs {
+        *spec = canonicalize_v3_match_spec(field, spec)?;
+    }
+    Ok(())
+}
+
+fn canonicalize_v3_package_record(record: &mut PackageRecord) -> Result<(), RepodataError> {
+    canonicalize_v3_match_specs("depends", &mut record.depends)?;
+    canonicalize_v3_match_specs("constrains", &mut record.constrains)?;
+    for (extra, specs) in &mut record.extra_depends {
+        canonicalize_v3_match_specs(&format!("extra_depends.{extra}"), specs)?;
+    }
+    Ok(())
+}
+
+fn validate_v3_package_patch(patch: &PackageRecordPatch) -> Result<(), RepodataError> {
+    if let Some(specs) = &patch.depends {
+        for spec in specs {
+            canonicalize_v3_match_spec("depends", spec)?;
+        }
+    }
+    if let Some(specs) = &patch.constrains {
+        for spec in specs {
+            canonicalize_v3_match_spec("constrains", spec)?;
+        }
+    }
+    if let Some(extra_depends) = &patch.extra_depends {
+        for (extra, specs) in extra_depends {
+            for spec in specs {
+                canonicalize_v3_match_spec(&format!("extra_depends.{extra}"), spec)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_indexer_patch(instructions: &PatchInstructions) -> Result<(), RepodataError> {
+    let legacy_extra_depends = instructions
+        .packages
+        .values()
+        .chain(instructions.conda_packages.values())
+        .any(|patch| {
+            patch
+                .extra_depends
+                .as_ref()
+                .is_some_and(|extra_depends| !extra_depends.is_empty())
+        });
+    if legacy_extra_depends {
+        return Err(RepodataError::Patch(
+            "legacy repodata patches cannot set extra_depends; use a v3 patch bucket".to_string(),
+        ));
+    }
+
+    for patch in instructions
+        .v3
+        .tar_bz2
+        .values()
+        .chain(instructions.v3.conda.values())
+        .chain(instructions.v3.whl.values())
+    {
+        validate_v3_package_patch(patch)?;
+    }
+    Ok(())
+}
+
+/// Canonicalizes only indexer-produced v3 package metadata after all source and
+/// patch inputs have been applied. General repodata serialization remains
+/// permissive so consumers can round-trip legacy or third-party v3 data.
+fn canonicalize_indexer_v3(repodata: &mut RepoData) -> Result<(), RepodataError> {
+    for record in repodata.v3.tar_bz2.values_mut() {
+        canonicalize_v3_package_record(record)?;
+    }
+    for record in repodata.v3.conda.values_mut() {
+        canonicalize_v3_package_record(record)?;
+    }
+    for record in repodata.v3.whl.values_mut() {
+        canonicalize_v3_package_record(&mut record.package_record)?;
+    }
+    Ok(())
+}
+
+/// Serialize repodata emitted by this indexer.
+///
+/// Producer output always advertises all supported package layouts, including
+/// an empty `v3` map. `RepoData` itself intentionally remains permissive when
+/// round-tripping older producer output that omitted this map.
+fn serialize_indexer_repodata(repodata: &RepoData) -> Result<Vec<u8>, RepodataError> {
+    if repodata.v3.is_empty() {
+        #[derive(Serialize)]
+        struct WithEmptyV3<'a> {
+            #[serde(flatten)]
+            repodata: &'a RepoData,
+            v3: &'a V3Packages,
+        }
+
+        Ok(serde_json::to_vec(&WithEmptyV3 {
+            repodata,
+            v3: &repodata.v3,
+        })?)
+    } else {
+        Ok(serde_json::to_vec(repodata)?)
+    }
+}
+
 /// Write a `repodata.json` for all packages in the given configurator's root.
 /// Uses conditional writes based on the provided metadata to prevent concurrent
 /// modification issues.
 pub async fn write_repodata(
-    repodata: RepoData,
+    mut repodata: RepoData,
     repodata_patch: Option<PatchInstructions>,
     subdir: Platform,
     op: Operator,
     metadata: &RepodataMetadataCollection,
 ) -> Result<(), RepodataError> {
+    if let Some(instructions) = repodata_patch.as_ref() {
+        validate_indexer_patch(instructions)?;
+    }
+    canonicalize_indexer_v3(&mut repodata)?;
+    let patched_repodata = if let Some(instructions) = repodata_patch {
+        tracing::info!("Patching repodata");
+        let mut patched_repodata = repodata.clone();
+        patched_repodata.apply_patches(&instructions);
+        canonicalize_indexer_v3(&mut patched_repodata)?;
+        Some(patched_repodata)
+    } else {
+        None
+    };
+
+    // Finish all fallible transformation and canonicalization before publishing
+    // either artifact, so invalid patch output cannot leave a partial update.
     if let Some(repodata_from_packages_metadata) = &metadata.repodata_from_packages {
         let unpatched_repodata_path = format!("{subdir}/{REPODATA_FROM_PACKAGES}");
         tracing::info!("Writing unpatched repodata to {unpatched_repodata_path}");
-        let unpatched_repodata_bytes = serde_json::to_vec(&repodata)?;
+        let unpatched_repodata_bytes = serialize_indexer_repodata(&repodata)?;
         crate::utils::write_with_metadata_check(
             &op,
             &unpatched_repodata_path,
@@ -1288,16 +1435,8 @@ pub async fn write_repodata(
         .await?;
     }
 
-    let repodata = if let Some(instructions) = repodata_patch {
-        tracing::info!("Patching repodata");
-        let mut patched_repodata = repodata.clone();
-        patched_repodata.apply_patches(&instructions);
-        patched_repodata
-    } else {
-        repodata
-    };
-
-    let repodata_bytes = serde_json::to_vec(&repodata)?;
+    let repodata = patched_repodata.unwrap_or(repodata);
+    let repodata_bytes = serialize_indexer_repodata(&repodata)?;
 
     // Write compressed version if requested
     if let Some(repodata_zst_metadata) = &metadata.repodata_zst {
@@ -1765,6 +1904,11 @@ pub async fn index_with_channel_metadata(
         let repodata_patch_bytes = op.read(&repodata_patch_path).await?.to_bytes();
         let reader = Cursor::new(repodata_patch_bytes);
         let repodata_patch = repodata_patch_from_conda_package_stream(reader)?;
+        for (subdir, instructions) in &repodata_patch.subdirs {
+            validate_indexer_patch(instructions).map_err(|error| {
+                anyhow::anyhow!("invalid repodata patch for subdir {subdir}: {error}")
+            })?;
+        }
         Some(repodata_patch)
     } else {
         None
@@ -1885,6 +2029,11 @@ pub async fn ensure_channel_initialized_with_channel_metadata(
         op.create_dir(&noarch_path).await?;
     }
 
+    let repodata_version = if channel_metadata.base_url.is_some() {
+        2
+    } else {
+        1
+    };
     let empty_repodata = RepoData {
         info: Some(ChannelInfo {
             subdir: Some(Platform::NoArch.to_string()),
@@ -1896,10 +2045,10 @@ pub async fn ensure_channel_initialized_with_channel_metadata(
         conda_packages: IndexMap::default(),
         v3: V3Packages::default(),
         removed: HashSet::default(),
-        version: Some(2),
+        version: Some(repodata_version),
     };
 
-    let repodata_bytes = serde_json::to_vec(&empty_repodata)?;
+    let repodata_bytes = serialize_indexer_repodata(&empty_repodata)?;
     match op
         .write_with(&noarch_repodata_path, repodata_bytes)
         .if_not_exists(true)
@@ -1976,7 +2125,7 @@ pub async fn ensure_channel_initialized_s3_with_channel_metadata(
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{collections::BTreeMap, str::FromStr};
 
     use indexmap::IndexMap;
     use rattler_conda_types::Version;
@@ -2085,10 +2234,7 @@ mod tests {
             },
         )]);
         let revisions = repodata_revisions_for_packages(
-            &[RepodataRevisionSelection {
-                revision: RepodataRevision::Legacy,
-                message: Some("legacy packages".to_string()),
-            }],
+            &[],
             &existing,
             &legacy_packages,
             &legacy_conda_packages,
@@ -2097,7 +2243,7 @@ mod tests {
 
         assert_eq!(revisions.len(), 1);
         let metadata = &revisions[&RepodataRevision::Legacy];
-        assert_eq!(metadata.message.as_deref(), Some("legacy packages"));
+        assert_eq!(metadata.message.as_deref(), Some("stale message"));
         assert_eq!(metadata.n_packages, Some(2));
         assert_eq!(metadata.oldest, Some(oldest));
         assert_eq!(metadata.newest, Some(newest));
@@ -2162,6 +2308,19 @@ mod tests {
     }
 
     #[test]
+    fn indexer_rejects_oversized_revision_messages() {
+        let err = validate_configured_repodata_revisions(&[RepodataRevisionSelection {
+            revision: RepodataRevision::V3,
+            message: Some("é".repeat(4097)),
+        }])
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("repodata revision messages may not exceed 8192 bytes")
+        );
+    }
+
+    #[test]
     fn indexer_rejects_unsupported_producer_maps() {
         for key in ["v4", "V3", "v03", "v18446744073709551616"] {
             let repodata =
@@ -2216,6 +2375,266 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn indexer_canonicalizes_original_and_patched_v3_dependencies() {
+        let channel = tempfile::tempdir().unwrap();
+        let mut config = FsConfig::default();
+        config.root = Some(channel.path().to_string_lossy().to_string());
+        let op = Operator::new(config.into_builder()).unwrap().finish();
+        op.create_dir("noarch/").await.unwrap();
+
+        let identifier = ArchiveIdentifier::from_str("v3-demo-1.0-0").unwrap();
+        let mut v3_record = PackageRecord::new(
+            PackageName::new_unchecked("v3-demo"),
+            Version::from_str("1.0").unwrap(),
+            "0".to_string(),
+        );
+        v3_record.depends = vec!["python >=3.10".to_string()];
+        v3_record.constrains = vec!["python <3.13".to_string()];
+        v3_record.extra_depends =
+            BTreeMap::from([("test".to_string(), vec!["pytest >=8".to_string()])]);
+
+        let legacy_filename = "legacy-1.0-0.tar.bz2";
+        let mut legacy_record = PackageRecord::new(
+            PackageName::new_unchecked("legacy"),
+            Version::from_str("1.0").unwrap(),
+            "0".to_string(),
+        );
+        legacy_record.depends = vec!["python >=3.10".to_string()];
+        legacy_record.constrains = vec!["python <3.13".to_string()];
+        legacy_record.extra_depends =
+            BTreeMap::from([("test".to_string(), vec!["pytest >=8".to_string()])]);
+
+        let mut repodata = RepoData {
+            info: None,
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            v3: V3Packages::default(),
+            removed: HashSet::default(),
+            version: Some(1),
+        };
+        repodata.packages.insert(
+            DistArchiveIdentifier::try_from_filename(legacy_filename).unwrap(),
+            legacy_record,
+        );
+        repodata.v3.conda.insert(identifier.clone(), v3_record);
+
+        let mut patched_conda = serde_json::Map::new();
+        patched_conda.insert(
+            identifier.to_string(),
+            serde_json::json!({
+                "depends": ["python >=3.11"],
+                "constrains": ["python <3.14"],
+                "extra_depends": { "test": ["pytest >=9"] }
+            }),
+        );
+        let patched = serde_json::from_value::<PatchInstructions>(serde_json::json!({
+            "v3": { "conda": patched_conda }
+        }))
+        .unwrap();
+        let metadata = RepodataMetadataCollection::new(
+            &op,
+            Platform::NoArch,
+            true,
+            false,
+            false,
+            PreconditionChecks::Disabled,
+        )
+        .await
+        .unwrap();
+        write_repodata(repodata, Some(patched), Platform::NoArch, op, &metadata)
+            .await
+            .unwrap();
+
+        let source: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(channel.path().join("noarch/repodata_from_packages.json")).unwrap(),
+        )
+        .unwrap();
+        let published: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(channel.path().join("noarch/repodata.json")).unwrap(),
+        )
+        .unwrap();
+        let identifier = identifier.to_string();
+
+        for (repodata, expected) in [
+            (
+                &source,
+                serde_json::json!({
+                    "depends": ["python[version=\">=3.10\"]"],
+                    "constrains": ["python[version=\"<3.13\"]"],
+                    "extra_depends": { "test": ["pytest[version=\">=8\"]"] }
+                }),
+            ),
+            (
+                &published,
+                serde_json::json!({
+                    "depends": ["python[version=\">=3.11\"]"],
+                    "constrains": ["python[version=\"<3.14\"]"],
+                    "extra_depends": { "test": ["pytest[version=\">=9\"]"] }
+                }),
+            ),
+        ] {
+            let record = &repodata["v3"]["conda"][identifier.as_str()];
+            assert_eq!(record["depends"], expected["depends"]);
+            assert_eq!(record["constrains"], expected["constrains"]);
+            assert_eq!(record["extra_depends"], expected["extra_depends"]);
+            assert_eq!(
+                repodata["packages"][legacy_filename]["depends"],
+                serde_json::json!(["python >=3.10"])
+            );
+            assert_eq!(
+                repodata["packages"][legacy_filename]["constrains"],
+                serde_json::json!(["python <3.13"])
+            );
+            assert_eq!(
+                repodata["packages"][legacy_filename]["extra_depends"],
+                serde_json::json!({ "test": ["pytest >=8"] })
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_patched_v3_dependency_is_rejected_before_any_repodata_write() {
+        let channel = tempfile::tempdir().unwrap();
+        let mut config = FsConfig::default();
+        config.root = Some(channel.path().to_string_lossy().to_string());
+        let op = Operator::new(config.into_builder()).unwrap().finish();
+        op.create_dir("noarch/").await.unwrap();
+        op.write("noarch/repodata_from_packages.json", "source sentinel")
+            .await
+            .unwrap();
+        op.write("noarch/repodata.json", "published sentinel")
+            .await
+            .unwrap();
+
+        let identifier = ArchiveIdentifier::from_str("v3-demo-1.0-0").unwrap();
+        let mut repodata = RepoData {
+            info: None,
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            v3: V3Packages::default(),
+            removed: HashSet::default(),
+            version: Some(1),
+        };
+        repodata.v3.conda.insert(
+            identifier.clone(),
+            PackageRecord::new(
+                PackageName::new_unchecked("v3-demo"),
+                Version::from_str("1.0").unwrap(),
+                "0".to_string(),
+            ),
+        );
+        let patch = serde_json::from_value::<PatchInstructions>(serde_json::json!({
+            "v3": {
+                "conda": {
+                    (identifier.to_string()): { "depends": ["python[version="] }
+                }
+            }
+        }))
+        .unwrap();
+        let metadata = RepodataMetadataCollection::new(
+            &op,
+            Platform::NoArch,
+            true,
+            false,
+            false,
+            PreconditionChecks::Disabled,
+        )
+        .await
+        .unwrap();
+
+        let error = write_repodata(repodata, Some(patch), Platform::NoArch, op, &metadata)
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("failed to parse depends MatchSpec")
+        );
+        assert_eq!(
+            std::fs::read_to_string(channel.path().join("noarch/repodata_from_packages.json"))
+                .unwrap(),
+            "source sentinel"
+        );
+        assert_eq!(
+            std::fs::read_to_string(channel.path().join("noarch/repodata.json")).unwrap(),
+            "published sentinel"
+        );
+    }
+
+    async fn index_empty_channel(base_url: Option<String>) -> serde_json::Value {
+        let channel = tempfile::tempdir().unwrap();
+        index_fs_with_channel_metadata(
+            IndexFsConfig {
+                channel: channel.path().to_path_buf(),
+                target_platform: Some(Platform::NoArch),
+                repodata_patch: None,
+                write_zst: false,
+                write_shards: false,
+                repodata_revisions: Vec::new(),
+                package_revision_assignment: PackageRevisionAssignment::default(),
+                force: false,
+                max_parallel: 1,
+                multi_progress: None,
+            },
+            ChannelMetadata {
+                base_url,
+                ..ChannelMetadata::default()
+            },
+        )
+        .await
+        .unwrap();
+        serde_json::from_slice(&std::fs::read(channel.path().join("noarch/repodata.json")).unwrap())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn indexer_writes_empty_v3_and_base_url_appropriate_repodata_version() {
+        let without_base_url = index_empty_channel(None).await;
+        let with_base_url = index_empty_channel(Some("../packages/".to_string())).await;
+
+        for repodata in [&without_base_url, &with_base_url] {
+            for map in ["packages", "packages.conda", "v3"] {
+                assert_eq!(repodata[map], serde_json::json!({}), "missing {map}");
+            }
+        }
+        assert_eq!(without_base_url["repodata_version"], 1);
+        assert_eq!(with_base_url["repodata_version"], 2);
+        assert_eq!(with_base_url["info"]["base_url"], "../packages/");
+    }
+
+    #[tokio::test]
+    async fn indexer_preflights_unsupported_revisions_before_writing() {
+        let channel = tempfile::tempdir().unwrap();
+        let error = index_fs_with_channel_metadata(
+            IndexFsConfig {
+                channel: channel.path().to_path_buf(),
+                target_platform: None,
+                repodata_patch: None,
+                write_zst: false,
+                write_shards: false,
+                repodata_revisions: vec![RepodataRevisionSelection {
+                    revision: RepodataRevision::from(4),
+                    message: None,
+                }],
+                package_revision_assignment: PackageRevisionAssignment::default(),
+                force: false,
+                max_parallel: 1,
+                multi_progress: None,
+            },
+            ChannelMetadata::default(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains(
+                "repodata revision v4 cannot be configured; only v3 is selectable and the legacy layout is implicit"
+            )
+        );
+        assert!(!channel.path().join("noarch/repodata.json").exists());
+    }
+
     #[test]
     fn indexer_only_produces_legacy_and_v3_package_layouts() {
         let filename = DistArchiveIdentifier::try_from_filename("demo-1.0-0.tar.bz2").unwrap();
@@ -2259,5 +2678,416 @@ mod tests {
             .unwrap_err();
             assert!(err.to_string().contains(&revision.to_string()));
         }
+    }
+
+    #[tokio::test]
+    async fn indexer_canonicalizes_all_v3_buckets_in_zstd_and_shards_after_patching() {
+        fn record(name: &str, dependency: &str) -> PackageRecord {
+            let mut record = PackageRecord::new(
+                PackageName::new_unchecked(name),
+                Version::from_str("1.0").unwrap(),
+                "0".to_string(),
+            );
+            record.depends = vec![dependency.to_string()];
+            record.constrains = vec!["python <3.13".to_string()];
+            record.extra_depends =
+                BTreeMap::from([("test".to_string(), vec!["pytest >=8".to_string()])]);
+            record
+        }
+
+        fn assert_canonical_dependencies(
+            record: &serde_json::Value,
+            python_version: &str,
+            python_constraint: &str,
+            pytest_version: &str,
+        ) {
+            assert_eq!(
+                record["depends"],
+                serde_json::json!([format!("python[version=\"{python_version}\"]")])
+            );
+            assert_eq!(
+                record["constrains"],
+                serde_json::json!([format!("python[version=\"{python_constraint}\"]")])
+            );
+            assert_eq!(
+                record["extra_depends"],
+                serde_json::json!({
+                    "test": [format!("pytest[version=\"{pytest_version}\"]")]
+                })
+            );
+        }
+
+        let channel = tempfile::tempdir().unwrap();
+        let mut config = FsConfig::default();
+        config.root = Some(channel.path().to_string_lossy().to_string());
+        let op = Operator::new(config.into_builder()).unwrap().finish();
+        op.create_dir("noarch/").await.unwrap();
+
+        let tar_identifier = ArchiveIdentifier::from_str("tar-demo-1.0-0").unwrap();
+        let conda_identifier = ArchiveIdentifier::from_str("conda-demo-1.0-0").unwrap();
+        let wheel_identifier = ArchiveIdentifier::from_str("wheel-demo-1.0-py_0").unwrap();
+        let legacy_filename = "legacy-demo-1.0-0.tar.bz2";
+
+        let mut repodata = RepoData {
+            info: None,
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            v3: V3Packages::default(),
+            removed: HashSet::default(),
+            version: Some(1),
+        };
+        repodata.packages.insert(
+            DistArchiveIdentifier::try_from_filename(legacy_filename).unwrap(),
+            record("legacy-demo", "python >=3.10"),
+        );
+        repodata
+            .v3
+            .tar_bz2
+            .insert(tar_identifier.clone(), record("tar-demo", "python >=3.10"));
+        repodata.v3.conda.insert(
+            conda_identifier.clone(),
+            record("conda-demo", "python >=3.10"),
+        );
+        repodata.v3.whl.insert(
+            wheel_identifier.clone(),
+            WhlPackageRecord {
+                package_record: record("wheel-demo", "python >=3.10"),
+                url: UrlOrPath::Path("wheel-demo-1.0-py_0.whl".to_string()),
+            },
+        );
+        repodata
+            .v3
+            .extensions
+            .insert(
+                "zip",
+                serde_json::json!({
+                    "metadata": { "keep": true, "remove": true }
+                }),
+            )
+            .unwrap();
+
+        let package_patch = serde_json::json!({
+            "depends": ["python >=3.11"],
+            "constrains": ["python <3.14"],
+            "extra_depends": { "test": ["pytest >=9"] }
+        });
+        let mut tar_patches = serde_json::Map::new();
+        tar_patches.insert(tar_identifier.to_string(), package_patch.clone());
+        let mut conda_patches = serde_json::Map::new();
+        conda_patches.insert(conda_identifier.to_string(), package_patch.clone());
+        let mut wheel_patches = serde_json::Map::new();
+        wheel_patches.insert(wheel_identifier.to_string(), package_patch);
+        let patch: PatchInstructions = serde_json::from_value(serde_json::json!({
+            "v3": {
+                "tar.bz2": tar_patches,
+                "conda": conda_patches,
+                "whl": wheel_patches,
+                "zip": {
+                    "metadata": { "remove": null, "patched": true }
+                }
+            }
+        }))
+        .unwrap();
+
+        let metadata = RepodataMetadataCollection::new(
+            &op,
+            Platform::NoArch,
+            true,
+            true,
+            true,
+            PreconditionChecks::Disabled,
+        )
+        .await
+        .unwrap();
+        write_repodata(repodata, Some(patch), Platform::NoArch, op, &metadata)
+            .await
+            .unwrap();
+
+        let source: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(channel.path().join("noarch/repodata_from_packages.json")).unwrap(),
+        )
+        .unwrap();
+        let published: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(channel.path().join("noarch/repodata.json")).unwrap(),
+        )
+        .unwrap();
+
+        for (bucket, identifier) in [
+            ("tar.bz2", tar_identifier.to_string()),
+            ("conda", conda_identifier.to_string()),
+            ("whl", wheel_identifier.to_string()),
+        ] {
+            assert_canonical_dependencies(
+                &source["v3"][bucket][identifier.as_str()],
+                ">=3.10",
+                "<3.13",
+                ">=8",
+            );
+            assert_canonical_dependencies(
+                &published["v3"][bucket][identifier.as_str()],
+                ">=3.11",
+                "<3.14",
+                ">=9",
+            );
+        }
+        assert_eq!(
+            source["packages"][legacy_filename]["depends"],
+            serde_json::json!(["python >=3.10"])
+        );
+        assert_eq!(
+            published["packages"][legacy_filename]["depends"],
+            serde_json::json!(["python >=3.10"])
+        );
+        assert_eq!(
+            published["v3"]["zip"],
+            serde_json::json!({ "metadata": { "keep": true, "patched": true } })
+        );
+
+        let compressed: serde_json::Value = serde_json::from_slice(
+            &zstd::stream::decode_all(
+                std::fs::File::open(channel.path().join("noarch/repodata.json.zst")).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(compressed, published);
+
+        let sharded: ShardedRepodata = rmp_serde::from_slice(
+            &zstd::stream::decode_all(
+                std::fs::File::open(channel.path().join("noarch/repodata_shards.msgpack.zst"))
+                    .unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        for (package_name, bucket, identifier) in [
+            ("tar-demo", "tar.bz2", tar_identifier.to_string()),
+            ("conda-demo", "conda", conda_identifier.to_string()),
+            ("wheel-demo", "whl", wheel_identifier.to_string()),
+        ] {
+            let digest = sharded.shards.get(package_name).unwrap();
+            let shard: Shard = rmp_serde::from_slice(
+                &zstd::stream::decode_all(
+                    std::fs::File::open(
+                        channel
+                            .path()
+                            .join("noarch/shards")
+                            .join(format!("{}.msgpack.zst", hex::encode(digest))),
+                    )
+                    .unwrap(),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+            let identifier = ArchiveIdentifier::from_str(&identifier).unwrap();
+            let record = match bucket {
+                "tar.bz2" => shard.v3.tar_bz2.get(&identifier).unwrap(),
+                "conda" => shard.v3.conda.get(&identifier).unwrap(),
+                "whl" => &shard.v3.whl.get(&identifier).unwrap().package_record,
+                _ => unreachable!(),
+            };
+            assert_eq!(
+                record.depends,
+                vec!["python[version=\">=3.11\"]".to_string()]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn indexer_rejects_invalid_patched_v3_dependencies_before_writing() {
+        let channel = tempfile::tempdir().unwrap();
+        let mut config = FsConfig::default();
+        config.root = Some(channel.path().to_string_lossy().to_string());
+        let op = Operator::new(config.into_builder()).unwrap().finish();
+        op.create_dir("noarch/").await.unwrap();
+
+        let identifier = ArchiveIdentifier::from_str("demo-1.0-0").unwrap();
+        let mut repodata = RepoData {
+            info: None,
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            v3: V3Packages::default(),
+            removed: HashSet::default(),
+            version: Some(1),
+        };
+        repodata.v3.conda.insert(
+            identifier.clone(),
+            PackageRecord::new(
+                PackageName::new_unchecked("demo"),
+                Version::from_str("1.0").unwrap(),
+                "0".to_string(),
+            ),
+        );
+        let mut conda_patches = serde_json::Map::new();
+        conda_patches.insert(
+            identifier.to_string(),
+            serde_json::json!({ "depends": ["python[extras=[Invalid]]"] }),
+        );
+        let patch: PatchInstructions = serde_json::from_value(serde_json::json!({
+            "v3": { "conda": conda_patches }
+        }))
+        .unwrap();
+        let metadata = RepodataMetadataCollection::new(
+            &op,
+            Platform::NoArch,
+            true,
+            true,
+            true,
+            PreconditionChecks::Disabled,
+        )
+        .await
+        .unwrap();
+
+        let error = write_repodata(repodata, Some(patch), Platform::NoArch, op, &metadata)
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("failed to parse depends MatchSpec 'python[extras=[Invalid]]'")
+        );
+        for path in [
+            "noarch/repodata_from_packages.json",
+            "noarch/repodata.json",
+            "noarch/repodata.json.zst",
+            "noarch/repodata_shards.msgpack.zst",
+        ] {
+            assert!(
+                !channel.path().join(path).exists(),
+                "unexpected write to {path}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn indexer_rejects_legacy_extra_depends_patches_before_writing() {
+        let channel = tempfile::tempdir().unwrap();
+        let mut config = FsConfig::default();
+        config.root = Some(channel.path().to_string_lossy().to_string());
+        let op = Operator::new(config.into_builder()).unwrap().finish();
+        op.create_dir("noarch/").await.unwrap();
+
+        let patch: PatchInstructions = serde_json::from_value(serde_json::json!({
+            "packages": {
+                "demo-1.0-0.tar.bz2": {
+                    "extra_depends": { "test": ["pytest >=8"] }
+                }
+            }
+        }))
+        .unwrap();
+        let repodata = RepoData {
+            info: None,
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            v3: V3Packages::default(),
+            removed: HashSet::default(),
+            version: Some(1),
+        };
+        let metadata = RepodataMetadataCollection::new(
+            &op,
+            Platform::NoArch,
+            true,
+            true,
+            true,
+            PreconditionChecks::Disabled,
+        )
+        .await
+        .unwrap();
+
+        let error = write_repodata(repodata, Some(patch), Platform::NoArch, op, &metadata)
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("legacy repodata patches cannot set extra_depends")
+        );
+        for path in [
+            "noarch/repodata_from_packages.json",
+            "noarch/repodata.json",
+            "noarch/repodata.json.zst",
+            "noarch/repodata_shards.msgpack.zst",
+        ] {
+            assert!(
+                !channel.path().join(path).exists(),
+                "unexpected write to {path}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn force_reindex_preserves_v3_extensions_and_recalculates_empty_stats() {
+        let channel = tempfile::tempdir().unwrap();
+        let noarch = channel.path().join("noarch");
+        std::fs::create_dir(&noarch).unwrap();
+        std::fs::write(
+            noarch.join("repodata.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "info": {
+                    "subdir": "noarch",
+                    "repodata_revisions": {
+                        "v3": {
+                            "message": "keep this message",
+                            "n_packages": 99,
+                            "oldest": 1,
+                            "newest": 2
+                        }
+                    }
+                },
+                "packages": {},
+                "packages.conda": {},
+                "v3": { "zip": { "future": true } },
+                "repodata_version": 1
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let mut config = FsConfig::default();
+        config.root = Some(channel.path().to_string_lossy().to_string());
+        let op = Operator::new(config.into_builder()).unwrap().finish();
+        let stats = index(
+            Some(Platform::NoArch),
+            op,
+            None,
+            false,
+            false,
+            Vec::new(),
+            PackageRevisionAssignment::default(),
+            true,
+            1,
+            None,
+            PreconditionChecks::Disabled,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stats.subdirs[&Platform::NoArch].packages_added, 0);
+        assert_eq!(stats.subdirs[&Platform::NoArch].packages_removed, 0);
+
+        let repodata: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(noarch.join("repodata.json")).unwrap()).unwrap();
+        for map in ["packages", "packages.conda"] {
+            assert_eq!(repodata[map], serde_json::json!({}), "missing {map}");
+        }
+        assert_eq!(repodata["v3"]["zip"], serde_json::json!({ "future": true }));
+        assert_eq!(
+            repodata["info"]["repodata_revisions"]["v3"]["message"],
+            "keep this message"
+        );
+        assert_eq!(
+            repodata["info"]["repodata_revisions"]["v3"]["n_packages"],
+            0
+        );
+        assert!(
+            repodata["info"]["repodata_revisions"]["v3"]
+                .get("oldest")
+                .is_none()
+        );
+        assert!(
+            repodata["info"]["repodata_revisions"]["v3"]
+                .get("newest")
+                .is_none()
+        );
     }
 }

--- a/crates/rattler_index/tests/integration/basic_indexing.rs
+++ b/crates/rattler_index/tests/integration/basic_indexing.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fs,
     fs::File,
     path::{Path, PathBuf},
@@ -611,6 +612,127 @@ async fn test_force_reindex_with_patch_preserves_and_merge_patches_v3_extensions
             "unchanged-array": ["opaque", { "nested-null": null }]
         })
     );
+}
+
+async fn assert_invalid_multi_subdir_patch_is_preflighted(
+    linux_patch: Value,
+    expected_error: &str,
+) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut original_repodata = HashMap::new();
+    for subdir in ["noarch", "linux-64"] {
+        let subdir_path = temp_dir.path().join(subdir);
+        fs::create_dir_all(&subdir_path).unwrap();
+        let bytes = serde_json::to_vec(&serde_json::json!({
+            "info": { "subdir": subdir },
+            "packages": {},
+            "packages.conda": {},
+            "v3": {},
+            "repodata_version": 1
+        }))
+        .unwrap();
+        fs::write(subdir_path.join("repodata.json"), &bytes).unwrap();
+        original_repodata.insert(subdir, bytes);
+    }
+
+    let patch_source = temp_dir.path().join("invalid-patch-source");
+    let patch_info_dir = patch_source.join("info");
+    let patch_noarch_dir = patch_source.join("noarch");
+    let patch_linux_dir = patch_source.join("linux-64");
+    fs::create_dir_all(&patch_info_dir).unwrap();
+    fs::create_dir_all(&patch_noarch_dir).unwrap();
+    fs::create_dir_all(&patch_linux_dir).unwrap();
+    fs::write(
+        patch_info_dir.join("index.json"),
+        r#"{
+            "build": "0",
+            "build_number": 0,
+            "name": "repodata-patches",
+            "noarch": "generic",
+            "subdir": "noarch",
+            "version": "1.0"
+        }"#,
+    )
+    .unwrap();
+    fs::write(patch_noarch_dir.join("patch_instructions.json"), "{}").unwrap();
+    fs::write(
+        patch_linux_dir.join("patch_instructions.json"),
+        serde_json::to_vec(&linux_patch).unwrap(),
+    )
+    .unwrap();
+
+    let patch_name = "repodata-patches-1.0-0.conda";
+    write_conda_package(
+        File::create(temp_dir.path().join("noarch").join(patch_name)).unwrap(),
+        &patch_source,
+        &[
+            patch_info_dir.join("index.json"),
+            patch_noarch_dir.join("patch_instructions.json"),
+            patch_linux_dir.join("patch_instructions.json"),
+        ],
+        CompressionLevel::Default,
+        None,
+        "repodata-patches-1.0-0",
+        None,
+        None,
+    )
+    .unwrap();
+
+    let error = index_fs(IndexFsConfig {
+        channel: temp_dir.path().into(),
+        target_platform: None,
+        repodata_patch: Some(patch_name.to_string()),
+        write_zst: false,
+        write_shards: false,
+        repodata_revisions: Vec::new(),
+        package_revision_assignment: PackageRevisionAssignment::default(),
+        force: true,
+        max_parallel: 1,
+        multi_progress: None,
+    })
+    .await
+    .unwrap_err();
+    let error = error.to_string();
+    assert!(error.contains("invalid repodata patch for subdir linux-64"));
+    assert!(error.contains(expected_error), "unexpected error: {error}");
+
+    for (subdir, expected) in original_repodata {
+        assert_eq!(
+            fs::read(temp_dir.path().join(subdir).join("repodata.json")).unwrap(),
+            expected,
+            "{subdir} repodata changed before global patch preflight completed"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_legacy_patch_preflight_rejects_invalid_subdir_before_any_subdir_write() {
+    assert_invalid_multi_subdir_patch_is_preflighted(
+        serde_json::json!({
+            "packages": {
+                "demo-1.0-0.tar.bz2": {
+                    "extra_depends": { "test": ["pytest >=8"] }
+                }
+            }
+        }),
+        "legacy repodata patches cannot set extra_depends",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_v3_patch_preflight_rejects_invalid_subdir_before_any_subdir_write() {
+    assert_invalid_multi_subdir_patch_is_preflighted(
+        serde_json::json!({
+            "v3": {
+                "conda": {
+                    "demo-1.0-0": { "depends": ["python[version="] }
+                }
+            }
+        }),
+        "failed to parse depends MatchSpec",
+    )
+    .await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Description

The indexer can currently advertise revision metadata that does not match what it writes. Caller-provided statistics, missing revision maps, patched non-canonical dependencies, or failures halfway through a multi-subdir patch can leave repodata internally inconsistent.

This makes v0/v3 output producer-owned and consistent. Revision statistics are derived from emitted records, configured unsupported revisions fail before publication, empty supported maps are written explicitly, and `repodata_version` reflects whether `base_url` is present. Final v3 dependencies are canonicalized after patches while legacy maps stay unchanged.

Patch packages are globally preflighted before any subdir task starts. This includes legacy-only field restrictions and every v3 dependency field in tar.bz2, conda, and wheel buckets, so an invalid patch cannot partially update a channel.

### How Has This Been Tested?

647 tests pass across `rattler_index`, `rattler_config`, and `rattler_conda_types`, including multi-subdir no-write regressions, zstd, shards, JSON Merge Patch, force reindexing, message limits, revision statistics, opaque extensions, and canonicalized patched dependencies. `cargo fmt --all` and scoped clippy with `-D warnings` pass.

Full repository clippy is currently blocked by unrelated existing Windows lints in `rattler_menuinst`.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Pi, GPT-5.6 Terra

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes
