### PR TITLE
feat: preserve extra dependencies in JavaScript records

### DIFF
--- a/js-rattler/crate/package_record.d.ts
+++ b/js-rattler/crate/package_record.d.ts
@@ -12,6 +12,7 @@ export declare type PackageRecordJson = {
     arch?: Arch;
     constrains?: string[];
     depends?: string[];
+    extra_depends?: Record<string, string[]>;
     features?: string;
     flags?: string[];
     license?: string;

--- a/js-rattler/crate/package_record.rs
+++ b/js-rattler/crate/package_record.rs
@@ -1,4 +1,5 @@
 use rattler_conda_types::{Flag, PackageName, PackageRecord};
+use serde::Serialize;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::js_sys;
 
@@ -65,7 +66,8 @@ impl JsPackageRecord {
     /// PackageRecord.
     #[wasm_bindgen(js_name = "toJson")]
     pub fn to_json(&self) -> Result<JsPackageRecordJson, crate::error::JsError> {
-        Ok(serde_wasm_bindgen::to_value(&self.inner)?.into())
+        let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+        Ok(self.inner.serialize(&serializer)?.into())
     }
 }
 
@@ -141,6 +143,33 @@ macro_rules! impl_package_record {
             #[wasm_bindgen::prelude::wasm_bindgen(setter)]
             pub fn set_depends(&mut self, depends: Vec<String>) {
                 AsMut::<PackageRecord>::as_mut(self).depends = depends;
+            }
+
+            /// Conditional or optional dependencies. Maps an extra name to the
+            /// dependency specifications required when that extra is active.
+            #[wasm_bindgen::prelude::wasm_bindgen(
+                getter,
+                js_name = "extraDepends",
+                unchecked_return_type = "Record<string, string[]>"
+            )]
+            pub fn extra_depends(&self) -> Result<JsValue, crate::error::JsError> {
+                let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+                Ok(AsRef::<PackageRecord>::as_ref(self)
+                    .extra_depends
+                    .serialize(&serializer)?)
+            }
+
+            #[wasm_bindgen::prelude::wasm_bindgen(setter, js_name = "extraDepends")]
+            pub fn set_extra_depends(
+                &mut self,
+                #[wasm_bindgen::prelude::wasm_bindgen(
+                    unchecked_param_type = "Record<string, string[]>"
+                )]
+                extra_depends: JsValue,
+            ) -> Result<(), crate::error::JsError> {
+                AsMut::<PackageRecord>::as_mut(self).extra_depends =
+                    serde_wasm_bindgen::from_value(extra_depends)?;
+                Ok(())
             }
 
             /// Features are a deprecated way to specify different feature sets for the
@@ -469,7 +498,7 @@ macro_rules! impl_package_record {
 
             /// Track features are nowadays only used to downweight packages (ie. give
             /// them less priority). To that effect, the package is downweighted
-            /// by the number of track_features.
+            /// by the number of `track_features`.
             #[wasm_bindgen::prelude::wasm_bindgen(getter, js_name = "trackFeatures")]
             pub fn track_features(&self) -> Vec<String> {
                 AsRef::<PackageRecord>::as_ref(self).track_features.clone()

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -36,8 +36,26 @@ pub struct SolvedPackage {
     pub sha256: Option<String>,
     pub version: String,
     pub depends: Option<Vec<String>>,
+    extra_depends: Option<BTreeMap<String, Vec<String>>>,
     pub subdir: Option<String>,
     pub flags: Option<Vec<String>>,
+}
+
+#[wasm_bindgen]
+impl SolvedPackage {
+    /// Conditional or optional dependencies keyed by extra name.
+    #[wasm_bindgen(
+        getter,
+        js_name = "extraDepends",
+        unchecked_return_type = "Record<string, string[]> | undefined"
+    )]
+    pub fn extra_depends(&self) -> Result<JsValue, JsError> {
+        let Some(extra_depends) = &self.extra_depends else {
+            return Ok(JsValue::UNDEFINED);
+        };
+        let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+        Ok(extra_depends.serialize(&serializer)?)
+    }
 }
 
 /// Solve a set of specs with the given channels and platforms.
@@ -104,7 +122,7 @@ pub async fn simple_solve(
                 platform: None,
                 depends: pkg.depends.unwrap_or_default(),
                 subdir: pkg.subdir.unwrap_or_else(|| "unknown".to_string()),
-                extra_depends: BTreeMap::new(),
+                extra_depends: pkg.extra_depends.unwrap_or_default(),
                 constrains: vec![],
                 track_features: vec![],
                 features: None,
@@ -167,30 +185,32 @@ pub async fn simple_solve(
     crate::gateway::emit_gateway_warnings(output.warnings);
     let repodata = output.repodata;
 
-    // We need this to find depends for locked packages
-    let repodata_keys: HashMap<(String, String, &String), &Vec<String>> = repodata
+    // Use matching repodata metadata when older locked packages omit dependencies.
+    // The URL identifies the exact artifact, avoiding metadata from an identically named
+    // package in another channel or subdirectory.
+    let repodata_metadata: HashMap<
+        &Url,
+        (&Vec<String>, &BTreeMap<String, Vec<String>>),
+    > = repodata
         .iter()
         .flat_map(|r| r.iter())
         .map(|rec| {
-            let name = rec.package_record.name.as_normalized().to_string();
-            let version = rec.package_record.version.to_string();
-            let build = &rec.package_record.build;
-            ((name, version, build), &rec.package_record.depends)
+            (
+                &rec.url,
+                (&rec.package_record.depends, &rec.package_record.extra_depends),
+            )
         })
         .collect();
 
-    // if a locked package does not include depends then depends will be taken from repodata
+    // If a locked package omits dependencies, restore them from repodata.
     for records in installed_packages.iter_mut() {
-        let key = (
-            records.package_record.name.as_normalized().to_string(),
-            records.package_record.version.to_string(),
-            &records.package_record.build,
-        );
-
-        if records.package_record.depends.is_empty()
-            && let Some(deps) = repodata_keys.get(&key)
-        {
-            records.package_record.depends = (*deps).clone();
+        if let Some((depends, extra_depends)) = repodata_metadata.get(&records.url) {
+            if records.package_record.depends.is_empty() {
+                records.package_record.depends = (*depends).clone();
+            }
+            if records.package_record.extra_depends.is_empty() {
+                records.package_record.extra_depends = (*extra_depends).clone();
+            }
         }
     }
 
@@ -217,6 +237,7 @@ pub async fn simple_solve(
             sha256: r.package_record.sha256.as_ref().map(hex::encode),
             size: r.package_record.size,
             depends: Some(r.package_record.depends.clone()),
+            extra_depends: Some(r.package_record.extra_depends.clone()),
             subdir: Some(r.package_record.subdir.clone()),
             flags: Some(
                 r.package_record

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -188,28 +188,20 @@ pub async fn simple_solve(
     // Use matching repodata metadata when older locked packages omit dependencies.
     // The URL identifies the exact artifact, avoiding metadata from an identically named
     // package in another channel or subdirectory.
-    let repodata_metadata: HashMap<&Url, (&Vec<String>, &BTreeMap<String, Vec<String>>)> = repodata
+    let repodata_metadata: HashMap<&Url, &PackageRecord> = repodata
         .iter()
         .flat_map(|r| r.iter())
-        .map(|rec| {
-            (
-                &rec.url,
-                (
-                    &rec.package_record.depends,
-                    &rec.package_record.extra_depends,
-                ),
-            )
-        })
+        .map(|record| (&record.url, &record.package_record))
         .collect();
 
     // If a locked package omits dependencies, restore them from repodata.
     for records in installed_packages.iter_mut() {
-        if let Some((depends, extra_depends)) = repodata_metadata.get(&records.url) {
+        if let Some(metadata) = repodata_metadata.get(&records.url) {
             if records.package_record.depends.is_empty() {
-                records.package_record.depends = (*depends).clone();
+                records.package_record.depends = metadata.depends.clone();
             }
             if records.package_record.extra_depends.is_empty() {
-                records.package_record.extra_depends = (*extra_depends).clone();
+                records.package_record.extra_depends = metadata.extra_depends.clone();
             }
         }
     }

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -188,16 +188,16 @@ pub async fn simple_solve(
     // Use matching repodata metadata when older locked packages omit dependencies.
     // The URL identifies the exact artifact, avoiding metadata from an identically named
     // package in another channel or subdirectory.
-    let repodata_metadata: HashMap<
-        &Url,
-        (&Vec<String>, &BTreeMap<String, Vec<String>>),
-    > = repodata
+    let repodata_metadata: HashMap<&Url, (&Vec<String>, &BTreeMap<String, Vec<String>>)> = repodata
         .iter()
         .flat_map(|r| r.iter())
         .map(|rec| {
             (
                 &rec.url,
-                (&rec.package_record.depends, &rec.package_record.extra_depends),
+                (
+                    &rec.package_record.depends,
+                    &rec.package_record.extra_depends,
+                ),
             )
         })
         .collect();

--- a/js-rattler/src/PackageRecord.test.ts
+++ b/js-rattler/src/PackageRecord.test.ts
@@ -29,6 +29,7 @@ describe("PackageRecord", () => {
                 build: "py36h1af98f8_1",
                 build_number: 1,
                 depends: [],
+                extra_depends: { test: ["pytest >=8"] },
                 license: "MIT",
                 license_family: "MIT",
                 md5: "d65ab674acf3b7294ebacaec05fc5b54",
@@ -43,6 +44,7 @@ describe("PackageRecord", () => {
             build: "py36h1af98f8_1",
             build_number: 1,
             depends: [],
+            extra_depends: { test: ["pytest >=8"] },
             license: "MIT",
             license_family: "MIT",
             md5: "d65ab674acf3b7294ebacaec05fc5b54",
@@ -72,6 +74,7 @@ describe("PackageRecord", () => {
             build_number: 1,
             depends: ["bar"],
             constrains: ["baz"],
+            extra_depends: { test: ["pytest >=8"] },
             license: "MIT",
             license_family: "MIT",
             md5: "d65ab674acf3b7294ebacaec05fc5b54",
@@ -87,6 +90,7 @@ describe("PackageRecord", () => {
         expect(record.buildNumber).toBe(1);
         expect(record.depends).toEqual(["bar"]);
         expect(record.constrains).toEqual(["baz"]);
+        expect(record.extraDepends).toEqual({ test: ["pytest >=8"] });
         expect(record.license).toEqual("MIT");
         expect(record.licenseFamily).toEqual("MIT");
         expect(record.md5).toEqual("d65ab674acf3b7294ebacaec05fc5b54");
@@ -136,6 +140,13 @@ describe("PackageRecord", () => {
     it("constrains can be modified", () => {
         record.constrains = ["bar", "baz"];
         expect(record.constrains).toEqual(["bar", "baz"]);
+    });
+    it("extraDepends can be modified", () => {
+        record.extraDepends = { dev: ["ruff", "pytest >=8"] };
+        expect(record.extraDepends).toEqual({ dev: ["ruff", "pytest >=8"] });
+        expect(record.toJson().extra_depends).toEqual({
+            dev: ["ruff", "pytest >=8"],
+        });
     });
     it("license can be modified", () => {
         record.license = "BSD-3-Clause";

--- a/js-rattler/src/solve.test.ts
+++ b/js-rattler/src/solve.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
+import { createServer } from "node:http";
 import { simpleSolve } from "./solve";
 
 describe("solving", () => {
@@ -33,6 +34,7 @@ describe("solving", () => {
                         "emscripten-abi >=3.1.73,<3.1.74.0a0",
                         "python_abi 3.13.* *_cp313",
                     ],
+                    extraDepends: { test: ["pytest >=8"] },
                     filename: "numpy-2.2.0-h7223423_0.tar.bz2",
                     packageName: "numpy",
                     repoName: "https://prefix.dev/emscripten-forge-dev/",
@@ -51,7 +53,111 @@ describe("solving", () => {
             expect(numpy?.url).toBe(
                 "https://prefix.dev/emscripten-forge-dev/emscripten-wasm32/numpy-2.2.0-h7223423_0.tar.bz2",
             );
+            expect(numpy?.extraDepends).toEqual({ test: ["pytest >=8"] });
         });
+    });
+
+    it("uses extras from the locked package's channel", async () => {
+        const repodata = (child: string) =>
+            JSON.stringify({
+                info: { subdir: "noarch" },
+                packages: {},
+                "packages.conda": {},
+                repodata_version: 1,
+                v3: {
+                    "tar.bz2": {
+                        [`${child}-1.0-0`]: {
+                            build: "0",
+                            build_number: 0,
+                            name: child,
+                            subdir: "noarch",
+                            version: "1.0",
+                        },
+                        "parent-1.0-0": {
+                            build: "0",
+                            build_number: 0,
+                            extra_depends: { test: [child] },
+                            name: "parent",
+                            subdir: "noarch",
+                            version: "1.0",
+                        },
+                    },
+                },
+            });
+        const repodata_by_path = new Map([
+            ["/first/noarch/repodata.json", repodata("first-child")],
+            ["/second/noarch/repodata.json", repodata("second-child")],
+        ]);
+        const server = createServer((request, response) => {
+            const repodata = repodata_by_path.get(request.url ?? "");
+            if (repodata !== undefined) {
+                response.setHeader("content-type", "application/json");
+                response.end(repodata);
+            } else {
+                response.statusCode = 404;
+                response.end();
+            }
+        });
+        await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+        const address = server.address();
+        if (address === null || typeof address === "string") {
+            throw new Error("test server did not expose a TCP address");
+        }
+        const first_channel = `http://127.0.0.1:${address.port}/first`;
+        const second_channel = `http://127.0.0.1:${address.port}/second`;
+
+        try {
+            const locked_parent = (channel: string) => ({
+                build: "0",
+                buildNumber: 0n,
+                depends: [],
+                filename: "parent-1.0-0.tar.bz2",
+                packageName: "parent",
+                repoName: `${channel}/`,
+                subdir: "noarch",
+                url: `${channel}/noarch/parent-1.0-0.tar.bz2`,
+                version: "1.0",
+            });
+            const result = await simpleSolve(
+                ["parent[extras=[test]]"],
+                // The locked artifact is from `first_channel`, despite `second_channel`
+                // having higher priority. This makes the assertion exercise URL matching.
+                [second_channel, first_channel],
+                ["noarch"],
+                [locked_parent(first_channel)],
+            );
+
+            expect(result.find((pkg) => pkg.packageName === "first-child")).toBeDefined();
+            expect(result.find((pkg) => pkg.packageName === "second-child")).toBeUndefined();
+            expect(result.find((pkg) => pkg.packageName === "parent")?.extraDepends).toEqual({
+                test: ["first-child"],
+            });
+
+            // A name/version/build lookup would retain `first_channel`, the last
+            // matching record in repodata. Locking `second_channel` proves the
+            // metadata is selected by the artifact URL instead.
+            const high_priority_locked_result = await simpleSolve(
+                ["parent[extras=[test]]"],
+                [second_channel, first_channel],
+                ["noarch"],
+                [locked_parent(second_channel)],
+            );
+
+            expect(
+                high_priority_locked_result.find((pkg) => pkg.packageName === "second-child"),
+            ).toBeDefined();
+            expect(
+                high_priority_locked_result.find((pkg) => pkg.packageName === "first-child"),
+            ).toBeUndefined();
+            expect(
+                high_priority_locked_result.find((pkg) => pkg.packageName === "parent")
+                    ?.extraDepends,
+            ).toEqual({ test: ["second-child"] });
+        } finally {
+            await new Promise<void>((resolve, reject) =>
+                server.close((error) => (error === undefined ? resolve() : reject(error))),
+            );
+        }
     });
 
     it("numpy 2.2.0 should be returned", () => {


### PR DESCRIPTION
### Description

`extra_depends` is represented in Rust repodata records and used by the solver, but it is missing from the JavaScript package-record API. JavaScript consumers therefore lose optional dependency groups when records cross the binding boundary.

This adds `extraDepends` to the JavaScript JSON type and runtime object, including the getter, setter, JSON round trip, and solved-package conversion.

### Example

```ts
const record = new PackageRecord({
    name: "demo",
    version: "1.0",
    build: "0",
    build_number: 0,
    subdir: "noarch",
    extra_depends: { test: ["pytest >=8"] },
});

expect(record.extraDepends).toEqual({ test: ["pytest >=8"] });
```

### How Has This Been Tested?

The full stacked JavaScript build and test suite passes with 82 tests. The added coverage exercises JSON construction and round trips, runtime getter/setter updates, and a local two-channel `simpleSolve` fixture where a locked package omits `extraDepends`, restores metadata only from its artifact's source, and resolves the dependency requested by an extra. Rust formatting also passes.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Pi, GPT-5.6 Terra

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes
