### PR TITLE
feat(py): expose pip injection for solve APIs

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -1425,6 +1425,120 @@ mod test {
         )
     }
 
+    #[tokio::test]
+    async fn test_record_patch_is_query_local() {
+        fn names(output: &crate::RepoDataQueryOutput) -> std::collections::BTreeSet<String> {
+            output
+                .iter()
+                .flat_map(RepoData::iter)
+                .map(|record| record.package_record.name.as_normalized().to_string())
+                .collect()
+        }
+
+        let channel_dir = tempfile::tempdir().unwrap();
+        let subdir = channel_dir.path().join("linux-64");
+        fs_err::create_dir_all(&subdir).unwrap();
+        fs_err::write(
+            subdir.join("repodata.json"),
+            serde_json::json!({
+                "info": {"subdir": "linux-64"},
+                "packages": {
+                    "application-1.0-0.tar.bz2": {
+                        "name": "application",
+                        "version": "1.0",
+                        "build": "0",
+                        "build_number": 0,
+                        "depends": ["python"],
+                        "subdir": "linux-64"
+                    },
+                    "python-3.12.0-0.tar.bz2": {
+                        "name": "python",
+                        "version": "3.12.0",
+                        "build": "0",
+                        "build_number": 0,
+                        "depends": [],
+                        "subdir": "linux-64"
+                    },
+                    "pip-25.0-0.tar.bz2": {
+                        "name": "pip",
+                        "version": "25.0",
+                        "build": "0",
+                        "build_number": 0,
+                        "depends": [],
+                        "subdir": "linux-64"
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let gateway = Gateway::new();
+        let channel = Channel::try_from_directory(channel_dir.path()).unwrap();
+        let application = || MatchSpec::from_str("application", Lenient).unwrap();
+
+        let unpatched = gateway
+            .query(
+                vec![channel.clone()],
+                vec![Platform::Linux64],
+                vec![application()],
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+        assert_eq!(
+            names(&unpatched),
+            ["application", "python"]
+                .into_iter()
+                .map(String::from)
+                .collect()
+        );
+
+        let patched = gateway
+            .query(
+                vec![channel.clone()],
+                vec![Platform::Linux64],
+                vec![application()],
+            )
+            .recursive(true)
+            .with_record_patch(|record| {
+                if record.package_record.name.as_normalized() != "python" {
+                    return None;
+                }
+                let mut record = record.clone();
+                record.package_record.depends.push("pip".to_string());
+                Some(record)
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            names(&patched),
+            ["application", "pip", "python"]
+                .into_iter()
+                .map(String::from)
+                .collect()
+        );
+
+        let unpatched_again = gateway
+            .query(vec![channel], vec![Platform::Linux64], vec![application()])
+            .recursive(true)
+            .await
+            .unwrap();
+        assert_eq!(
+            names(&unpatched_again),
+            ["application", "python"]
+                .into_iter()
+                .map(String::from)
+                .collect()
+        );
+        let python = unpatched_again
+            .iter()
+            .flat_map(RepoData::iter)
+            .find(|record| record.package_record.name.as_normalized() == "python")
+            .unwrap();
+        assert!(python.package_record.depends.is_empty());
+    }
+
     /// Integration test that verifies cache clearing actually works end-to-end.
     /// Creates a simple channel with a single package, queries it, modifies
     /// the source data, and verifies that memory-only cache clearing still

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -16,9 +16,11 @@ use super::{
     channel_expander::{ChannelExpander, ChannelRelationsMode, ChannelRelationsWarning},
     channel_relations::DEFAULT_CHANNEL_RELATIONS_MAX_DEPTH,
     source::{CustomSourceClient, Source},
-    subdir::{PackageRecords, Subdir, SubdirData},
+    subdir::{PackageRecords, Subdir, SubdirData, extract_unique_deps_split},
 };
 use crate::Reporter;
+
+type RecordPatch = dyn Fn(&RepoDataRecord) -> Option<RepoDataRecord> + Send + Sync;
 
 /// Result of a successful [`RepoDataQuery::execute`].
 ///
@@ -136,6 +138,9 @@ pub struct RepoDataQuery {
     /// Whether to recursively fetch dependencies
     recursive: bool,
 
+    /// A query-local patch applied to repodata records.
+    record_patch: Option<Arc<RecordPatch>>,
+
     /// The reporter to use by the query.
     reporter: Option<Arc<dyn Reporter>>,
 
@@ -236,6 +241,7 @@ impl RepoDataQuery {
             specs,
 
             recursive: false,
+            record_patch: None,
             reporter: None,
             channel_notices: false,
             channel_relations_mode: ChannelRelationsMode::default(),
@@ -284,6 +290,25 @@ impl RepoDataQuery {
         Self { recursive, ..self }
     }
 
+    /// Applies a query-local patch to repodata records.
+    ///
+    /// The patch runs after records are retrieved, including from the gateway
+    /// cache, and before recursive dependency discovery. Returning `Some`
+    /// replaces the record for this query, while returning `None` reuses the
+    /// original record. Replacement records are never written to the gateway
+    /// cache. Patches must preserve record identity fields such as the package
+    /// name, identifier, and URL.
+    #[must_use]
+    pub fn with_record_patch(
+        self,
+        patch: impl Fn(&RepoDataRecord) -> Option<RepoDataRecord> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            record_patch: Some(Arc::new(patch)),
+            ..self
+        }
+    }
+
     /// Sets the reporter to use for this query.
     ///
     /// The reporter is notified of important evens during the execution of the
@@ -314,6 +339,7 @@ struct QueryExecutor {
     #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     gateway: Arc<GatewayInner>,
     recursive: bool,
+    record_patch: Option<Arc<RecordPatch>>,
     reporter: Option<Arc<dyn Reporter>>,
 
     // Specs categorized at construction
@@ -420,6 +446,7 @@ impl QueryExecutor {
             platforms,
             specs,
             recursive,
+            record_patch,
             reporter,
             channel_notices,
             channel_relations_mode,
@@ -551,6 +578,7 @@ impl QueryExecutor {
         Ok(Self {
             gateway,
             recursive,
+            record_patch,
             reporter,
             direct_url_specs,
             direct_url_result,
@@ -709,6 +737,28 @@ impl QueryExecutor {
                 }
             }
         }
+    }
+
+    /// Apply the query-local record patch and rebuild derived dependency data.
+    fn patch_package_records(&self, mut pkg: PackageRecords) -> PackageRecords {
+        let Some(patch) = &self.record_patch else {
+            return pkg;
+        };
+
+        let mut changed = false;
+        for record in &mut pkg.records {
+            if let Some(patched) = patch(record.as_ref()) {
+                *record = Arc::new(patched);
+                changed = true;
+            }
+        }
+
+        if changed {
+            (pkg.unique_base_deps, pkg.unique_extra_deps) =
+                extract_unique_deps_split(pkg.records.iter().map(AsRef::as_ref));
+        }
+
+        pkg
     }
 
     /// Walk the deps of newly-active extras against records that have
@@ -916,6 +966,7 @@ impl QueryExecutor {
                 // Handle any records that were fetched
                 records = self.pending_records.select_next_some() => {
                     let (target, request, pkg) = records?;
+                    let pkg = self.patch_package_records(pkg);
 
                     if self.recursive {
                         let entry =

--- a/py-rattler/CHANGELOG.md
+++ b/py-rattler/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Add an `add_pip_as_python_dependency` option to `solve_with_sparse_repodata`.
-
 ## [0.25.0] - 2026-06-09
 
 ### Changed

--- a/py-rattler/CHANGELOG.md
+++ b/py-rattler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an `add_pip_as_python_dependency` option to `solve_with_sparse_repodata`.
+
 ## [0.25.0] - 2026-06-09
 
 ### Changed

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -152,6 +152,7 @@ async def solve_with_sparse_repodata(
     strategy: SolveStrategy = "highest",
     constraints: Optional[Sequence[MatchSpec | str]] = None,
     package_format_selection: PackageFormatSelection = PackageFormatSelection.PREFER_CONDA,
+    add_pip_as_python_dependency: bool = False,
 ) -> List[RepoDataRecord]:
     """
     Resolve the dependencies and return the `RepoDataRecord`s
@@ -198,6 +199,8 @@ async def solve_with_sparse_repodata(
             Packages included in the `constraints` are not necessarily installed,
             but they must be satisfied by the solution.
         package_format_selection: Defines which package formats are selected
+        add_pip_as_python_dependency: Add `pip` as a dependency of Python 2 and 3
+            package records before solving.
 
     Returns:
         Resolved list of `RepoDataRecord`s.
@@ -228,6 +231,7 @@ async def solve_with_sparse_repodata(
             if isinstance(exclude_newer, datetime.timedelta)
             else None,
             strategy=strategy,
+            add_pip_as_python_dependency=add_pip_as_python_dependency,
             constraints=[
                 constraint._match_spec
                 if isinstance(constraint, MatchSpec)

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -36,6 +36,7 @@ async def solve(
     constraints: Optional[Sequence[MatchSpec | str]] = None,
     channel_relations: Optional[ChannelRelationsMode] = None,
     channel_relations_max_depth: Optional[int] = None,
+    add_pip_as_python_dependency: bool = False,
 ) -> List[RepoDataRecord]:
     """
     Resolve the dependencies and return the `RepoDataRecord`s
@@ -89,6 +90,8 @@ async def solve(
             ``"strict"`` to raise on malformed relation metadata.
         channel_relations_max_depth: Maximum recursion depth when following
             ``channel_relations``. ``0`` behaves like ``channel_relations="disabled"``.
+        add_pip_as_python_dependency: Add `pip` as a dependency of Python 2 and 3
+            package records before solving.
 
     Returns:
         Resolved list of `RepoDataRecord`s.
@@ -136,6 +139,7 @@ async def solve(
             else [],
             channel_relations=channel_relations,
             channel_relations_max_depth=channel_relations_max_depth,
+            add_pip_as_python_dependency=add_pip_as_python_dependency,
         )
     ]
 

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -64,20 +64,34 @@ fn parse_exclude_newer(
     }
 }
 
-fn add_pip_to_python(record: &mut PackageRecord) {
+fn is_python_2_or_3(record: &PackageRecord) -> bool {
     static PYTHON_VERSION: LazyLock<VersionSpec> = LazyLock::new(|| {
         VersionSpec::from_str("2.*|3.*", ParseStrictness::Strict)
             .expect("the Python version spec is valid")
     });
 
-    if record.name.as_normalized() == "python" && PYTHON_VERSION.matches(&record.version) {
+    record.name.as_normalized() == "python" && PYTHON_VERSION.matches(&record.version)
+}
+
+fn add_pip_to_python(record: &mut PackageRecord) {
+    if is_python_2_or_3(record) {
         record.depends.push("pip".to_owned());
     }
 }
 
+fn patch_python_with_pip(record: &RepoDataRecord) -> Option<RepoDataRecord> {
+    if !is_python_2_or_3(&record.package_record) {
+        return None;
+    }
+
+    let mut patched = record.clone();
+    add_pip_to_python(&mut patched.package_record);
+    Some(patched)
+}
+
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (sources, platforms, specs, constraints, gateway, locked_packages, pinned_packages, virtual_packages, channel_priority, timeout=None, exclude_newer_timestamp_ms=None, exclude_newer_duration_seconds=None, strategy=None, channel_relations=None, channel_relations_max_depth=None)
+#[pyo3(signature = (sources, platforms, specs, constraints, gateway, locked_packages, pinned_packages, virtual_packages, channel_priority, timeout=None, exclude_newer_timestamp_ms=None, exclude_newer_duration_seconds=None, strategy=None, channel_relations=None, channel_relations_max_depth=None, add_pip_as_python_dependency=false)
 )]
 pub fn py_solve<'a>(
     py: Python<'a>,
@@ -96,6 +110,7 @@ pub fn py_solve<'a>(
     strategy: Option<Wrap<SolveStrategy>>,
     channel_relations: Option<Wrap<rattler_repodata_gateway::ChannelRelationsMode>>,
     channel_relations_max_depth: Option<usize>,
+    add_pip_as_python_dependency: bool,
 ) -> PyResult<Bound<'a, PyAny>> {
     // Convert Python sources to Rust Source enum
     let rust_sources: Vec<rattler_repodata_gateway::Source> = sources
@@ -117,6 +132,9 @@ pub fn py_solve<'a>(
         }
         if let Some(depth) = channel_relations_max_depth {
             query = query.channel_relations_max_depth(depth);
+        }
+        if add_pip_as_python_dependency {
+            query = query.with_record_patch(patch_python_with_pip);
         }
         let output = query.execute().await.map_err(PyRattlerError::from)?;
         emit_gateway_warnings(output.warnings)?;

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+};
 
 use jiff::Timestamp;
 use pyo3::{
@@ -6,7 +9,7 @@ use pyo3::{
     pybacked::PyBackedStr, pyfunction,
 };
 use pyo3_async_runtimes::tokio::future_into_py;
-use rattler_conda_types::RepoDataRecord;
+use rattler_conda_types::{PackageRecord, ParseStrictness, RepoDataRecord, VersionSpec};
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use rattler_solve::{
     ExcludeNewer, RepoDataIter, SolveStrategy, SolverImpl, SolverTask, resolvo::Solver,
@@ -58,6 +61,17 @@ fn parse_exclude_newer(
             std::time::Duration::from_secs(seconds),
         ))),
         (None, None) => Ok(None),
+    }
+}
+
+fn add_pip_to_python(record: &mut PackageRecord) {
+    static PYTHON_VERSION: LazyLock<VersionSpec> = LazyLock::new(|| {
+        VersionSpec::from_str("2.*|3.*", ParseStrictness::Strict)
+            .expect("the Python version spec is valid")
+    });
+
+    if record.name.as_normalized() == "python" && PYTHON_VERSION.matches(&record.version) {
+        record.depends.push("pip".to_owned());
     }
 }
 
@@ -167,7 +181,7 @@ pub fn py_solve<'a>(
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (specs, sparse_repodata, constraints, locked_packages, pinned_packages, virtual_packages, channel_priority, package_format_selection, timeout=None, exclude_newer_timestamp_ms=None, exclude_newer_duration_seconds=None, strategy=None)
+#[pyo3(signature = (specs, sparse_repodata, constraints, locked_packages, pinned_packages, virtual_packages, channel_priority, package_format_selection, timeout=None, exclude_newer_timestamp_ms=None, exclude_newer_duration_seconds=None, strategy=None, add_pip_as_python_dependency=false)
 )]
 pub fn py_solve_with_sparse_repodata<'py>(
     py: Python<'py>,
@@ -183,6 +197,7 @@ pub fn py_solve_with_sparse_repodata<'py>(
     exclude_newer_timestamp_ms: Option<i64>,
     exclude_newer_duration_seconds: Option<u64>,
     strategy: Option<Wrap<SolveStrategy>>,
+    add_pip_as_python_dependency: bool,
 ) -> PyResult<Bound<'py, PyAny>> {
     // Acquire read locks on the SparseRepoData instances. This allows us to safely access the
     // object in another thread.
@@ -212,7 +227,7 @@ pub fn py_solve_with_sparse_repodata<'py>(
             let available_packages = SparseRepoData::load_records_recursive(
                 repo_data_refs,
                 package_names,
-                None,
+                add_pip_as_python_dependency.then_some(add_pip_to_python),
                 package_format_selection.into(),
             )?;
 

--- a/py-rattler/tests/unit/test_solver.py
+++ b/py-rattler/tests/unit/test_solver.py
@@ -167,7 +167,8 @@ async def test_solve_with_repodata() -> None:
 
 
 def python_repodata(tmp_path: Path, python_version: str = "3.12.0") -> SparseRepoData:
-    repodata_path = tmp_path / "repodata.json"
+    repodata_path = tmp_path / "noarch" / "repodata.json"
+    repodata_path.parent.mkdir()
     repodata_path.write_text(
         json.dumps(
             {
@@ -197,6 +198,14 @@ def python_repodata(tmp_path: Path, python_version: str = "3.12.0") -> SparseRep
                         "subdir": "noarch",
                         "version": "1.0",
                     },
+                    "application-1.0-0.tar.bz2": {
+                        "name": "application",
+                        "version": "1.0",
+                        "build": "0",
+                        "build_number": 0,
+                        "depends": ["python"],
+                        "subdir": "noarch",
+                    },
                 },
             }
         )
@@ -206,6 +215,39 @@ def python_repodata(tmp_path: Path, python_version: str = "3.12.0") -> SparseRep
         subdir="noarch",
         path=repodata_path,
     )
+
+
+@pytest.mark.asyncio
+async def test_solve_adds_pip_to_cached_python(tmp_path: Path) -> None:
+    python_repodata(tmp_path)
+    channel = Channel(str(tmp_path))
+    gateway = Gateway()
+
+    without_pip = await solve(
+        [channel],
+        ["application"],
+        platforms=["noarch"],
+        gateway=gateway,
+    )
+    with_pip = await solve(
+        [channel],
+        ["application"],
+        platforms=["noarch"],
+        gateway=gateway,
+        add_pip_as_python_dependency=True,
+    )
+
+    assert {record.name.normalized for record in without_pip} == {
+        "application",
+        "python",
+    }
+    assert {record.name.normalized for record in with_pip} == {
+        "application",
+        "python",
+        "pip",
+    }
+    python_record = next(record for record in with_pip if record.name.normalized == "python")
+    assert "pip" in python_record.depends
 
 
 @pytest.mark.parametrize(

--- a/py-rattler/tests/unit/test_solver.py
+++ b/py-rattler/tests/unit/test_solver.py
@@ -1,5 +1,7 @@
 import datetime
+import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -162,6 +164,94 @@ async def test_solve_with_repodata() -> None:
     assert isinstance(solved_data, list)
     assert isinstance(solved_data[0], RepoDataRecord)
     assert len(solved_data) == 2
+
+
+def python_repodata(tmp_path: Path, python_version: str = "3.12.0") -> SparseRepoData:
+    repodata_path = tmp_path / "repodata.json"
+    repodata_path.write_text(
+        json.dumps(
+            {
+                "info": {"subdir": "noarch"},
+                "packages": {
+                    f"python-{python_version}-0.tar.bz2": {
+                        "build": "0",
+                        "build_number": 0,
+                        "depends": [],
+                        "name": "python",
+                        "subdir": "noarch",
+                        "version": python_version,
+                    },
+                    "pip-1.0-0.tar.bz2": {
+                        "build": "0",
+                        "build_number": 0,
+                        "depends": [],
+                        "name": "pip",
+                        "subdir": "noarch",
+                        "version": "1.0",
+                    },
+                    "standalone-1.0-0.tar.bz2": {
+                        "build": "0",
+                        "build_number": 0,
+                        "depends": [],
+                        "name": "standalone",
+                        "subdir": "noarch",
+                        "version": "1.0",
+                    },
+                },
+            }
+        )
+    )
+    return SparseRepoData(
+        channel=Channel(str(tmp_path)),
+        subdir="noarch",
+        path=repodata_path,
+    )
+
+
+@pytest.mark.parametrize(
+    ("python_version", "add_pip", "expected_names"),
+    [
+        ("2.7.18", True, {"python", "pip"}),
+        ("3.12.0", True, {"python", "pip"}),
+        ("4.0.0", True, {"python"}),
+        ("3.12.0", False, {"python"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_solve_with_sparse_repodata_adds_pip_to_python(
+    tmp_path: Path,
+    python_version: str,
+    add_pip: bool,
+    expected_names: set[str],
+) -> None:
+    sparse_repodata = python_repodata(tmp_path, python_version)
+
+    solved_data = await solve_with_sparse_repodata(
+        ["python"],
+        [sparse_repodata],
+        add_pip_as_python_dependency=add_pip,
+    )
+
+    assert {record.name.normalized for record in solved_data} == expected_names
+    python_record = next(record for record in solved_data if record.name.normalized == "python")
+    assert ("pip" in python_record.depends) is (add_pip and python_version[0] in "23")
+
+
+@pytest.mark.asyncio
+async def test_add_pip_does_not_patch_locked_python(tmp_path: Path) -> None:
+    sparse_repodata = python_repodata(tmp_path)
+    locked_python = sparse_repodata.load_records("python")[0]
+
+    solved_data = await solve_with_sparse_repodata(
+        ["python", "standalone"],
+        [sparse_repodata],
+        locked_packages=[locked_python],
+        add_pip_as_python_dependency=True,
+    )
+
+    assert {record.name.normalized for record in solved_data} == {"python", "standalone"}
+    python_record = next(record for record in solved_data if record.name.normalized == "python")
+    assert "pip" not in python_record.depends
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description

Expose an `add_pip_as_python_dependency` option on `solve` and `solve_with_sparse_repodata`. The option applies conda's existing pip-injection rule to Python versions matching `2.*` or `3.*` before dependency discovery. It defaults to `False`.

Gateway solves use a query-local record patch after records are read from cache and before recursive dependency discovery. Replacements are not written back to the cache. Sparse solves continue to use the existing record patch hook. Locked and pinned packages remain unchanged.

This lets conda preserve its current behavior across solver implementations without rewriting repodata or changing installed prefix records.

Fixes #2676

### How Has This Been Tested?

Unit coverage exercises both solve paths, enabled and disabled behavior, the Python version boundary, recursive pip discovery, query-local cache behavior, and locked package behavior.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

```plaintext
Expose add_pip_as_python_dependency on both solver APIs. Implement gateway behavior with a query-local record patch that does not mutate cached records. Cover enabled and disabled behavior, the Python version boundary, recursive discovery, cache isolation, and locked record behavior.
```

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
