### PR TITLE
feat(repodata_gateway): collect virtual package plugins

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
@@ -1,5 +1,7 @@
 use std::{path::Path, sync::Arc};
 
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{Channel, ChannelRelations, PackageName, RepodataRevisions};
 
 use crate::{
@@ -114,5 +116,10 @@ impl SubdirClient for LocalSubdirClient {
 
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.sparse.channel_relations()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        self.sparse.virtual_package_plugins()
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -35,9 +35,13 @@ use coalesced_map::{CoalescedGetError, CoalescedMap};
 pub use error::GatewayError;
 #[cfg(feature = "indicatif")]
 pub use indicatif::{IndicatifReporter, IndicatifReporterBuilder};
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub use query::SubdirVirtualPackagePlugins;
 pub use query::{NamesQuery, NamesQueryOutput, RepoDataQuery, RepoDataQueryOutput};
 #[cfg(not(target_arch = "wasm32"))]
 use rattler_cache::package_cache::PackageCache;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{Channel, ChannelRelations, MatchSpec, Platform, RepoDataRecord};
 use rattler_networking::LazyClient;
 pub use repo_data::RepoData;
@@ -227,6 +231,35 @@ impl Gateway {
             // for every platform except noarch; catch the noarch
             // error so `None` holds for all platforms.
             Err(GatewayError::SubdirNotFoundError(_)) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Returns the virtual package detection plugins registered by the
+    /// given `(channel, platform)` subdirectory, keyed by the name of the
+    /// package providing the plugin. Empty if the subdirectory registers
+    /// none or doesn't exist.
+    ///
+    /// Needs no specs, unlike [`Gateway::query`], because the plugin
+    /// packages cannot be named until this metadata has been read.
+    ///
+    /// Reuses the internal subdir cache: if the pair has already been
+    /// fetched by a [`Gateway::query`] this is free.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub async fn virtual_package_plugins(
+        &self,
+        channel: &Channel,
+        platform: Platform,
+    ) -> Result<VirtualPackagePlugins, GatewayError> {
+        match self
+            .inner
+            .get_or_create_subdir(channel, platform, None)
+            .await
+        {
+            Ok(subdir) => Ok(subdir.virtual_package_plugins().clone()),
+            // As above: noarch reports its absence as an error rather
+            // than `NotFound`, so an empty map holds for all platforms.
+            Err(GatewayError::SubdirNotFoundError(_)) => Ok(VirtualPackagePlugins::default()),
             Err(err) => Err(err),
         }
     }
@@ -2891,6 +2924,238 @@ mod test {
         );
     }
 
+    /// Writes a linux-64 subdir whose `info.virtual_package_plugins` is the
+    /// given JSON object body, e.g. `"cuda-detect": ["__cuda"]`.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn write_test_subdir_with_plugins(root: &std::path::Path, pkg: &str, plugins: &str) {
+        let subdir = root.join("linux-64");
+        std::fs::create_dir_all(&subdir).unwrap();
+        let json = format!(
+            r#"{{
+    "info": {{
+        "subdir": "linux-64",
+        "virtual_package_plugins": {{{plugins}}}
+    }},
+    "packages.conda": {{
+        "{pkg}-1.0.0-0.conda": {{
+            "build": "0",
+            "build_number": 0,
+            "depends": [],
+            "md5": "00000000000000000000000000000000",
+            "name": "{pkg}",
+            "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+            "size": 1000,
+            "subdir": "linux-64",
+            "timestamp": 1700000000000,
+            "version": "1.0.0"
+        }}
+    }}
+}}"#
+        );
+        std::fs::write(subdir.join("repodata.json"), json).unwrap();
+    }
+
+    /// One reported registration as
+    /// `(channel_suffix, platform, [(plugin, [virtual packages])])`.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    type FlatPlugins = Vec<(String, Platform, Vec<(String, Vec<String>)>)>;
+
+    /// Flattens the reported registrations for order-sensitive comparison.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn flatten_plugins(output: &crate::RepoDataQueryOutput) -> FlatPlugins {
+        output
+            .virtual_package_plugins
+            .iter()
+            .map(|entry| {
+                (
+                    entry.channel.url().path().trim_matches('/').to_string(),
+                    entry.platform,
+                    entry
+                        .plugins
+                        .iter()
+                        .map(|(plugin, provided)| {
+                            (
+                                plugin.as_source().to_string(),
+                                provided.iter().map(|v| v.as_source().to_string()).collect(),
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect()
+    }
+
+    /// A channel registering one plugin that provides several virtual packages
+    /// is reported with its channel and subdir.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_reported_per_subdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        write_test_subdir_with_plugins(&a, "shared", r#""cuda-detect": ["__cuda", "__cuda_arch"]"#);
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let output = Gateway::new()
+            .query(
+                vec![Channel::from_url(server.url().join("a/").unwrap())],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("shared", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            flatten_plugins(&output),
+            vec![(
+                "a".to_string(),
+                Platform::Linux64,
+                vec![(
+                    "cuda-detect".to_string(),
+                    vec!["__cuda".to_string(), "__cuda_arch".to_string()],
+                )],
+            )]
+        );
+        assert!(output.warnings.is_empty(), "{:?}", output.warnings);
+    }
+
+    /// Two channels claiming the same virtual package are both reported, in
+    /// channel-priority order. Resolving the conflict is the caller's job, so
+    /// the gateway must not drop either one or warn about it.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_conflicting_channels_both_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            &dir.path().join("a"),
+            "shared",
+            r#""a-detect": ["__rocm"]"#,
+        );
+        write_test_subdir_with_plugins(
+            &dir.path().join("b"),
+            "shared",
+            r#""b-detect": ["__rocm"]"#,
+        );
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let a = Channel::from_url(server.url().join("a/").unwrap());
+        let b = Channel::from_url(server.url().join("b/").unwrap());
+
+        let output = Gateway::new()
+            .query(
+                vec![a, b],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("shared", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        let reported: Vec<String> = flatten_plugins(&output)
+            .into_iter()
+            .map(|(channel, _, plugins)| format!("{channel}:{}", plugins[0].0))
+            .collect();
+        assert_eq!(reported, vec!["a:a-detect", "b:b-detect"]);
+        assert!(output.warnings.is_empty(), "{:?}", output.warnings);
+    }
+
+    /// Two plugins in one channel may claim the same virtual package; both
+    /// survive because inverting the mapping is the caller's job.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_duplicate_claim_within_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            &dir.path().join("a"),
+            "shared",
+            r#""first-detect": ["__rocm"], "second-detect": ["__rocm"]"#,
+        );
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let output = Gateway::new()
+            .query(
+                vec![Channel::from_url(server.url().join("a/").unwrap())],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("shared", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        let plugins = flatten_plugins(&output);
+        assert_eq!(
+            plugins[0].2,
+            vec![
+                ("first-detect".to_string(), vec!["__rocm".to_string()]),
+                ("second-detect".to_string(), vec!["__rocm".to_string()]),
+            ]
+        );
+    }
+
+    /// Registrations are read off the subdir itself, so a spec that matches no
+    /// record still reports them. Callers cannot query for the plugin packages
+    /// by name: the registration is the only place those names come from.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_reported_for_unmatched_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            &dir.path().join("a"),
+            "shared",
+            r#""cuda-detect": ["__cuda"]"#,
+        );
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let output = Gateway::new()
+            .query(
+                vec![Channel::from_url(server.url().join("a/").unwrap())],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("no-such-package", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        assert!(
+            output.iter().all(RepoData::is_empty),
+            "the spec must not match any record"
+        );
+        assert_eq!(
+            flatten_plugins(&output),
+            vec![(
+                "a".to_string(),
+                Platform::Linux64,
+                vec![("cuda-detect".to_string(), vec!["__cuda".to_string()])],
+            )]
+        );
+    }
+
+    /// A channel without the metadata reports nothing.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir(&dir.path().join("a"), "shared", "1.0.0", None, None);
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let output = Gateway::new()
+            .query(
+                vec![Channel::from_url(server.url().join("a/").unwrap())],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("shared", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        assert!(output.virtual_package_plugins.is_empty());
+    }
+
     /// Repodata with CEP-42 `channel_relations` in `info`.
     fn make_repodata_with_relations(
         name: &str,
@@ -3011,6 +3276,88 @@ mod test {
                 .await
                 .unwrap_or_else(|e| panic!("{platform} must return None, not error: {e}"));
             assert!(relations.is_none());
+        }
+    }
+
+    /// `Gateway::virtual_package_plugins` round-trips the registration
+    /// without any spec, which is the point: the plugin package names only
+    /// exist inside the metadata being fetched.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_gateway_virtual_package_plugins_roundtrip() {
+        let channel_dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            channel_dir.path(),
+            "testpkg",
+            r#""cuda-detect": ["__cuda", "__cuda_arch"], "rocm-detect": ["__rocm"]"#,
+        );
+
+        let server = SimpleChannelServer::new(channel_dir.path()).await;
+        let plugins = Gateway::new()
+            .virtual_package_plugins(&server.channel(), Platform::Linux64)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plugins
+                .iter()
+                .map(|(plugin, provided)| (
+                    plugin.as_source(),
+                    provided
+                        .iter()
+                        .map(PackageName::as_source)
+                        .collect::<Vec<_>>()
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("cuda-detect", vec!["__cuda", "__cuda_arch"]),
+                ("rocm-detect", vec!["__rocm"]),
+            ]
+        );
+    }
+
+    /// A channel registering no plugins yields an empty map, not an error.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_gateway_virtual_package_plugins_absent() {
+        let channel_dir = tempfile::tempdir().unwrap();
+        let subdir_path = channel_dir.path().join("linux-64");
+        std::fs::create_dir_all(&subdir_path).unwrap();
+        std::fs::write(
+            subdir_path.join("repodata.json"),
+            make_repodata("testpkg", "1.0.0"),
+        )
+        .unwrap();
+
+        let server = SimpleChannelServer::new(channel_dir.path()).await;
+        let plugins = Gateway::new()
+            .virtual_package_plugins(&server.channel(), Platform::Linux64)
+            .await
+            .unwrap();
+        assert!(plugins.is_empty());
+    }
+
+    /// A subdir the channel doesn't publish yields an empty map, not an
+    /// error. noarch matters: the subdir builder propagates its absence as
+    /// an error instead of `NotFound`.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_gateway_virtual_package_plugins_missing_subdir() {
+        let channel_dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            channel_dir.path(),
+            "testpkg",
+            r#""cuda-detect": ["__cuda"]"#,
+        );
+
+        let server = SimpleChannelServer::new(channel_dir.path()).await;
+        let gateway = Gateway::new();
+        for platform in [Platform::Osx64, Platform::NoArch] {
+            let plugins = gateway
+                .virtual_package_plugins(&server.channel(), platform)
+                .await
+                .unwrap_or_else(|e| panic!("{platform} must return empty, not error: {e}"));
+            assert!(plugins.is_empty(), "{platform} declared none");
         }
     }
 

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -5,6 +5,8 @@ use std::{
 };
 
 use futures::{FutureExt, StreamExt, select_biased, stream::FuturesUnordered};
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{
     Channel, ChannelUrl, MatchSpec, Matches, PackageName, PackageNameMatcher, Platform,
     RepoDataRecord,
@@ -37,6 +39,29 @@ pub struct RepoDataQueryOutput {
     /// Non-fatal warnings encountered during the query. Also streamed
     /// to [`Reporter::on_gateway_warning`] as they are recorded.
     pub warnings: Vec<GatewayWarning>,
+    /// Virtual package detection plugins declared by the queried channel
+    /// subdirs, in resolved channel-priority order.
+    ///
+    /// Reported exactly as declared: duplicate claims on the same virtual
+    /// package are not resolved, and no plugin is fetched or executed.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub virtual_package_plugins: Vec<SubdirVirtualPackagePlugins>,
+}
+
+/// Plugin registrations declared by a single channel subdir.
+///
+/// Kept per subdir rather than per channel because different subdirs of one
+/// channel may declare different metadata; collapsing them would silently drop
+/// registrations.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+#[derive(Debug, Clone)]
+pub struct SubdirVirtualPackagePlugins {
+    /// The channel that declared these plugins.
+    pub channel: ChannelUrl,
+    /// The subdir the declaration was read from.
+    pub platform: Platform,
+    /// Plugin package name mapped to the virtual packages it provides.
+    pub plugins: VirtualPackagePlugins,
 }
 
 impl std::ops::Deref for RepoDataQueryOutput {
@@ -354,6 +379,11 @@ struct QueryExecutor {
 
     /// CEP-6 notice collection state.
     notices: NoticeCollector,
+
+    /// Plugin registrations collected from each resolved channel subdir.
+    /// Emitted in channel-priority order once the final order is known.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    virtual_package_plugins: ahash::HashMap<(ChannelUrl, Platform), VirtualPackagePlugins>,
 }
 
 /// Collects CEP-6 notices while a query runs. Fetches are queued as channels
@@ -566,6 +596,8 @@ impl QueryExecutor {
             pending_records: FuturesUnordered::new(),
             expander,
             notices,
+            #[cfg(feature = "experimental-virtual-package-plugins")]
+            virtual_package_plugins: ahash::HashMap::default(),
         })
     }
 
@@ -905,6 +937,14 @@ impl QueryExecutor {
                     }
                     self.expand_pattern_specs_for_subdir(subdir.as_ref());
                     if let Some((url, platform)) = kind_url_and_platform {
+                        #[cfg(feature = "experimental-virtual-package-plugins")]
+                        {
+                            let plugins = subdir.virtual_package_plugins();
+                            if !plugins.is_empty() {
+                                self.virtual_package_plugins
+                                    .insert((url.clone(), platform), plugins.clone());
+                            }
+                        }
                         self.expand_relations_for_subdir(&url, platform, subdir.as_ref())?;
                     }
                     if self.pending_subdirs.is_empty() {
@@ -1087,6 +1127,27 @@ impl QueryExecutor {
             handles = tagged.into_iter().map(|(_, h)| h).collect();
         }
 
+        // `handles` is already in channel-priority order, so walking it yields
+        // the registrations in that order too. Custom sources have no channel.
+        #[cfg(feature = "experimental-virtual-package-plugins")]
+        let virtual_package_plugins = handles
+            .iter()
+            .filter_map(|h| match &h.kind {
+                SubdirKind::Channel { url, platform } => {
+                    let key = (url.clone(), *platform);
+                    self.virtual_package_plugins.remove(&key).map(|plugins| {
+                        let (channel, platform) = key;
+                        SubdirVirtualPackagePlugins {
+                            channel,
+                            platform,
+                            plugins,
+                        }
+                    })
+                }
+                SubdirKind::Custom => None,
+            })
+            .collect();
+
         let mut repodata: Vec<RepoData> =
             Vec::with_capacity(handles.len() + usize::from(direct.is_some()));
         if let Some(d) = direct {
@@ -1102,6 +1163,8 @@ impl QueryExecutor {
                 .into_iter()
                 .map(GatewayWarning::from)
                 .collect(),
+            #[cfg(feature = "experimental-virtual-package-plugins")]
+            virtual_package_plugins,
         })
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/mod.rs
@@ -1,5 +1,7 @@
 use crate::gateway::subdir::{PackageRecords, SubdirClient};
 use crate::{GatewayError, Reporter};
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{ChannelRelations, PackageName, RepodataRevisions};
 
 cfg_if::cfg_if! {
@@ -33,5 +35,10 @@ impl SubdirClient for RemoteSubdirClient {
 
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.sparse.channel_relations()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        self.sparse.virtual_package_plugins()
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -183,6 +183,8 @@ mod tests {
         routing::get,
     };
     use rattler_conda_types::{Channel, RepodataRevisions, ShardedRepodata, ShardedSubdirInfo};
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    use rattler_conda_types::{PackageName, VirtualPackagePlugins};
     use rattler_digest::{Sha256, parse_digest_from_hex};
     use std::future::IntoFuture;
     use std::net::SocketAddr;
@@ -223,11 +225,15 @@ mod tests {
                     created_at: Some(jiff::Timestamp::now()),
                     repodata_revisions: RepodataRevisions::default(),
                     channel_relations: None,
+                    #[cfg(feature = "experimental-virtual-package-plugins")]
+                    virtual_package_plugins: mock_virtual_package_plugins(),
                 },
                 shards,
             };
 
-            // Encode the index as msgpack and compress with zstd
+            // Encode the index by name, matching what the indexer writes for
+            // real channels. Positional encoding misaligns as soon as a
+            // skipped field precedes a present one.
             let index_bytes = rmp_serde::to_vec_named(&sharded_index).unwrap();
             let compressed_index = zstd::encode_all(index_bytes.as_slice(), 3).unwrap();
 
@@ -308,6 +314,49 @@ mod tests {
     enum MockShardResponse {
         Empty,
         Truncated,
+    }
+
+    /// Registrations served by the mock index, so the sharded path is covered
+    /// end to end through msgpack encoding and the HTTP fetch.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn mock_virtual_package_plugins() -> VirtualPackagePlugins {
+        [(
+            PackageName::new_unchecked("cuda-detect"),
+            vec![
+                PackageName::new_unchecked("__cuda"),
+                PackageName::new_unchecked("__cuda_arch"),
+            ],
+        )]
+        .into_iter()
+        .collect()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_sharded_index_reports_virtual_package_plugins() {
+        let server = MockShardedServer::new(MockShardResponse::Empty).await;
+        let cache_dir = tempfile::tempdir().unwrap();
+
+        let subdir = ShardedSubdir::new(
+            server.channel(),
+            "linux-64".to_string(),
+            rattler_networking::LazyClient::default(),
+            cache_dir.path().to_path_buf(),
+            ShardCachePolicy {
+                action: CacheAction::NoCache,
+                missing_shards_are_empty: false,
+            },
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            subdir.virtual_package_plugins(),
+            &mock_virtual_package_plugins()
+        );
     }
 
     #[tokio::test]

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
@@ -7,6 +7,8 @@ use std::{
 };
 
 use rattler_conda_types::Platform;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 
 use super::{
     add_trailing_slash, decode_zst_bytes_async, is_missing_sharded_repodata_status, parse_records,
@@ -320,6 +322,11 @@ impl SubdirClient for ShardedSubdir {
 
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.sharded_repodata.info.channel_relations.as_ref()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        &self.sharded_repodata.info.virtual_package_plugins
     }
 }
 

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
 use futures::future::OptionFuture;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{
     Channel, ChannelRelations, PackageName, RepodataRevisions, ShardedRepodata,
 };
@@ -176,5 +178,10 @@ impl SubdirClient for ShardedSubdir {
 
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.sharded_repodata.info.channel_relations.as_ref()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        &self.sharded_repodata.info.virtual_package_plugins
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir.rs
@@ -1,11 +1,15 @@
 use std::sync::Arc;
 
 use ahash::HashMap;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{ChannelRelations, PackageName, RepoDataRecord, RepodataRevisions};
 
 use super::GatewayError;
 use crate::Reporter;
 use crate::sparse::empty_repodata_revisions;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use crate::sparse::empty_virtual_package_plugins;
 use coalesced_map::{CoalescedGetError, CoalescedMap};
 
 /// Records for a single package, with precomputed unique dependency strings
@@ -114,6 +118,16 @@ impl Subdir {
             Subdir::NotFound => None,
         }
     }
+
+    /// Virtual package detection plugins registered by this subdir, or empty
+    /// if none are registered / the subdir was not found.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        match self {
+            Subdir::Found(subdir) => subdir.virtual_package_plugins(),
+            Subdir::NotFound => empty_virtual_package_plugins(),
+        }
+    }
 }
 
 /// Fetches and caches repodata records by package name for a specific
@@ -172,6 +186,12 @@ impl SubdirData {
     pub fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.client.channel_relations()
     }
+
+    /// Virtual package detection plugins registered by this subdir.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        self.client.virtual_package_plugins()
+    }
 }
 
 /// A client that can be used to fetch repodata for a specific subdirectory.
@@ -200,6 +220,13 @@ pub trait SubdirClient: Send + Sync {
     /// [CEP-42]: https://github.com/conda/ceps/blob/main/cep-0042.md
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         None
+    }
+
+    /// Virtual package detection plugins registered by this subdir. Sources
+    /// that cannot carry the metadata (e.g. custom) keep the empty default.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        empty_virtual_package_plugins()
     }
 }
 

--- a/crates/rattler_repodata_gateway/src/lib.rs
+++ b/crates/rattler_repodata_gateway/src/lib.rs
@@ -73,6 +73,8 @@ pub use reporter::{SUPPORTED_REPODATA_REVISION, UnsupportedRepodataRevision};
 #[cfg(feature = "gateway")]
 mod gateway;
 
+#[cfg(all(feature = "gateway", feature = "experimental-virtual-package-plugins"))]
+pub use gateway::SubdirVirtualPackagePlugins;
 #[cfg(feature = "gateway")]
 pub use gateway::{
     CacheClearMode, ChannelConfig, ChannelNoticeResult, ChannelRelationsMode,

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -14,6 +14,8 @@ use std::{
 
 use bytes::Bytes;
 use itertools::Itertools;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{
     Channel, ChannelInfo, ChannelRelations, MatchSpec, Matches, PackageName, PackageRecord,
     RepoDataRecord, RepodataRevisions, UrlOrPath, WhlPackageRecord, compute_package_url,
@@ -34,6 +36,14 @@ use thiserror::Error;
 /// Shared empty revisions, returned by accessors when none are advertised.
 pub(crate) fn empty_repodata_revisions() -> &'static RepodataRevisions {
     static EMPTY: LazyLock<RepodataRevisions> = LazyLock::new(RepodataRevisions::new);
+    &EMPTY
+}
+
+/// Shared empty plugin registrations, returned by accessors when a subdir
+/// registers none.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub(crate) fn empty_virtual_package_plugins() -> &'static VirtualPackagePlugins {
+    static EMPTY: LazyLock<VirtualPackagePlugins> = LazyLock::new(VirtualPackagePlugins::new);
     &EMPTY
 }
 
@@ -495,6 +505,16 @@ impl SparseRepoData {
             .as_ref()?
             .channel_relations
             .as_ref()
+    }
+
+    /// Virtual package detection plugins registered in
+    /// `info.virtual_package_plugins`.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        match &self.inner.borrow_repo_data().info {
+            Some(info) => &info.virtual_package_plugins,
+            None => empty_virtual_package_plugins(),
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Second PR in stack #2686. Depends on #2683.

Collects virtual-package plugin registrations from local, remote, and sharded subdirs. The gateway now exposes:

- `Gateway::virtual_package_plugins(channel, platform)` for direct metadata lookup without specs
- `RepoDataQueryOutput::virtual_package_plugins` for registrations and their provided/required virtual package names in resolved channel-priority order, including CEP-42-discovered channels

Duplicate claims are preserved for the executor/caller to resolve; the gateway does not execute plugins or choose winners.

Next: #2685 adds CLI inspection and documents the proposed executor protocol. The executor itself remains a follow-up because its trust/confirmation model is not implemented yet.

### How Has This Been Tested?

- `pixi run cargo-fmt -- --check`
- `pixi run -- cargo test -p rattler_repodata_gateway --features gateway,experimental-virtual-package-plugins` (199 passed, 1 ignored)
- `pixi run -- cargo check -p rattler_index --features experimental-virtual-package-plugins`
- Focused clippy for the changed crates and experimental feature

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: pi coding agent

Prompt:
```plaintext
Can you split up these commits into three (stacked, if possible) PRs (or more or less, feel free to adjust). I propose: Würde sagen, ein PR für das index zeug / repodata änderungen. Einer für den gateway collector. Dann einer für eine execution engine oder so?

Although the execution engine afaik doesn't exist yet. The gateway should return registered plugins & required virtual packages. I'd propose an executor to resolve the virtual packages (that asks for confirmation, creates envs, executes plugins and returns the objects).
```

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes
