### PR TITLE
feat(js): support custom fetch and record queries in the gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5440,6 +5440,7 @@ dependencies = [
  "insta",
  "itertools 0.15.0",
  "jiff",
+ "js-sys",
  "json-patch",
  "libc",
  "memmap2",
@@ -5459,6 +5460,7 @@ dependencies = [
  "rmp-serde",
  "rstest",
  "self_cell",
+ "send_wrapper",
  "serde",
  "serde_json",
  "serde_with",
@@ -5474,7 +5476,10 @@ dependencies = [
  "tracing",
  "tracing-test",
  "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasmtimer",
+ "web-sys",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -6249,6 +6254,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ indexmap = "2"
 indicatif = "0.18"
 insta = { version = "1" }
 itertools = "0.15"
+js-sys = "0.3"
 json-patch = "4"
 keyring-core = "1"
 lazy-regex = "3"
@@ -150,6 +151,7 @@ rustix = { version = "1.1", default-features = false }
 simd-json = { version = "0.17", features = ["serde_impl"] }
 self_cell = "1"
 semver = "1"
+send_wrapper = "0.6"
 serde = { version = "1" }
 serde_bytes = { version = "0.11" }
 serde_ignored = "0.1"
@@ -198,7 +200,10 @@ urlencoding = "2"
 unicode-normalization = "0.1"
 uuid = { version = "1", default-features = false }
 walkdir = "2"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 wasmtimer = "0.4"
+web-sys = "0.3"
 which = "8"
 windows-sys = { version = "0.61", default-features = false }
 windows-native-keyring-store = "1"

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -77,7 +77,12 @@ tokio = { workspace = true, features = ["rt", "io-util"] }
 rattler_package_streaming = { workspace = true, default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = { workspace = true }
+send_wrapper = { workspace = true }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 wasmtimer = { workspace = true }
+web-sys = { workspace = true, features = ["Request", "RequestInit", "Response"] }
 
 [target.'cfg(any(unix, windows))'.dependencies]
 memmap2 = { workspace = true, optional = true }

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -27,6 +27,12 @@ pub enum RepoDataNotFoundError {
     /// There was a file system error
     #[error(transparent)]
     FileSystemError(#[from] std::io::Error),
+
+    /// The JavaScript fetch implementation reported that the resource does
+    /// not exist.
+    #[cfg(target_arch = "wasm32")]
+    #[error(transparent)]
+    JsFetchError(#[from] crate::utils::js_fetch::JsFetchError),
 }
 
 #[allow(missing_docs)]
@@ -64,6 +70,10 @@ pub enum FetchRepoDataError {
 
     #[error("the operation was cancelled")]
     Cancelled,
+
+    #[cfg(target_arch = "wasm32")]
+    #[error(transparent)]
+    JsFetchError(crate::utils::js_fetch::JsFetchError),
 }
 
 impl From<reqwest_middleware::Error> for FetchRepoDataError {

--- a/crates/rattler_repodata_gateway/src/fetch/no_cache.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/no_cache.rs
@@ -77,6 +77,18 @@ impl From<Compression> for Encoding {
     }
 }
 
+/// Returns the URL of the repodata file for the given variant and
+/// compression.
+fn repo_data_variant_url(subdir_url: &Url, variant: Variant, method: Compression) -> Url {
+    let file_name = variant.file_name();
+    match method {
+        Compression::Zst => subdir_url.join(&format!("{file_name}.zst")),
+        Compression::Bz2 => subdir_url.join(&format!("{file_name}.bz2")),
+        Compression::None => subdir_url.join(file_name),
+    }
+    .expect("must be valid url at this point")
+}
+
 /// Try to execute a request for a certain kind of repodata with a given
 /// compression.
 async fn execute_request(
@@ -87,13 +99,7 @@ async fn execute_request(
 ) -> Result<(Request, Response, SystemTime), reqwest_middleware::Error> {
     // Determine the URL of the repodata file based on the compression and the
     // variant
-    let file_name = variant.file_name();
-    let repo_data_url = match method {
-        Compression::Zst => subdir_url.join(&format!("{file_name}.zst")),
-        Compression::Bz2 => subdir_url.join(&format!("{file_name}.bz2")),
-        Compression::None => subdir_url.join(variant.file_name()),
-    }
-    .expect("must be valid url at this point");
+    let repo_data_url = repo_data_variant_url(&subdir_url, variant, method);
 
     // Construct a request
     let request_builder = client.get(repo_data_url.clone());
@@ -290,6 +296,66 @@ pub async fn fetch_repo_data(
     }
 
     Ok(bytes)
+}
+
+/// Fetch the repodata.json file for the given subdirectory through a
+/// JavaScript fetch implementation. The semantics mirror
+/// [`fetch_repo_data`]: the compressed variants are probed before the plain
+/// `repodata.json`, and a missing file is reported as
+/// [`FetchRepoDataError::NotFound`]. Retrying is left to the fetch
+/// implementation.
+#[cfg(target_arch = "wasm32")]
+pub async fn fetch_repo_data_js(
+    subdir_url: Url,
+    fetcher: crate::utils::js_fetch::JsFetcher,
+    options: FetchRepoDataOptions,
+) -> Result<Bytes, FetchRepoDataError> {
+    // Try with supported compression methods.
+    for compression in [
+        options.zstd_enabled.then_some(Compression::Zst),
+        options.bz2_enabled.then_some(Compression::Bz2),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        let repo_data_url = repo_data_variant_url(&subdir_url, options.variant, compression);
+        match fetcher.get(&repo_data_url).await {
+            Ok(response) => {
+                return decode_repo_data_bytes(response.bytes, compression, repo_data_url).await;
+            }
+            Err(err) if err.status() == Some(StatusCode::NOT_FOUND) => continue,
+            Err(err) => return Err(FetchRepoDataError::JsFetchError(err)),
+        }
+    }
+
+    // If none of the compressed variants are available, try the uncompressed
+    // one.
+    let repo_data_url = repo_data_variant_url(&subdir_url, options.variant, Compression::None);
+    match fetcher.get(&repo_data_url).await {
+        Ok(response) => Ok(response.bytes),
+        Err(err) if err.status() == Some(StatusCode::NOT_FOUND) => Err(
+            FetchRepoDataError::NotFound(RepoDataNotFoundError::JsFetchError(err)),
+        ),
+        Err(err) => Err(FetchRepoDataError::JsFetchError(err)),
+    }
+}
+
+/// Decompresses repodata bytes based on the compression derived from the
+/// file extension. The transfer encoding is already decoded by the
+/// JavaScript fetch implementation.
+#[cfg(target_arch = "wasm32")]
+async fn decode_repo_data_bytes(
+    bytes: Bytes,
+    compression: Compression,
+    repo_data_url: Url,
+) -> Result<Bytes, FetchRepoDataError> {
+    let mut decoded = Vec::new();
+    tokio::io::BufReader::new(bytes.as_ref())
+        .decode(compression.into())
+        .read_to_end(&mut decoded)
+        .await
+        .map_err(|e| FetchRepoDataError::FailedToDownload(repo_data_url.redact(), e))?;
+    Ok(Bytes::from(decoded))
 }
 
 async fn stream_response_body(

--- a/crates/rattler_repodata_gateway/src/gateway/builder.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/builder.rs
@@ -44,6 +44,8 @@ impl From<Arc<tokio::sync::Semaphore>> for MaxConcurrency {
 pub struct GatewayBuilder {
     channel_config: ChannelConfig,
     client: Option<LazyClient>,
+    #[cfg(target_arch = "wasm32")]
+    js_fetch: Option<crate::utils::js_fetch::JsFetcher>,
     #[cfg(not(target_arch = "wasm32"))]
     cache: Option<std::path::PathBuf>,
     #[cfg(not(target_arch = "wasm32"))]
@@ -69,6 +71,25 @@ impl GatewayBuilder {
     /// Set the client to use for fetching repodata.
     pub fn set_client(&mut self, client: impl Into<LazyClient>) -> &mut Self {
         self.client = Some(client.into());
+        self
+    }
+
+    /// Set a `fetch`-like JavaScript function to use for all requests
+    /// instead of the client. Only needed when the host must route the
+    /// gateway's traffic through its own HTTP stack; see [`crate::JsFetcher`].
+    #[cfg(target_arch = "wasm32")]
+    #[must_use]
+    pub fn with_js_fetch(mut self, fetch: js_sys::Function) -> Self {
+        self.set_js_fetch(fetch);
+        self
+    }
+
+    /// Set a `fetch`-like JavaScript function to use for all requests
+    /// instead of the client. Only needed when the host must route the
+    /// gateway's traffic through its own HTTP stack; see [`crate::JsFetcher`].
+    #[cfg(target_arch = "wasm32")]
+    pub fn set_js_fetch(&mut self, fetch: js_sys::Function) -> &mut Self {
+        self.js_fetch = Some(crate::utils::js_fetch::JsFetcher::new(fetch));
         self
     }
 
@@ -223,6 +244,8 @@ impl GatewayBuilder {
             inner: Arc::new(GatewayInner {
                 subdirs: CoalescedMap::new(),
                 client,
+                #[cfg(target_arch = "wasm32")]
+                js_fetch: self.js_fetch,
                 channel_config: self.channel_config,
                 notices: dashmap::DashMap::new(),
                 notice_fetch_locks: dashmap::DashMap::new(),

--- a/crates/rattler_repodata_gateway/src/gateway/error.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/error.rs
@@ -61,6 +61,10 @@ pub enum GatewayError {
     #[error("{0}")]
     CacheError(String),
 
+    #[cfg(target_arch = "wasm32")]
+    #[error(transparent)]
+    JsFetchError(#[from] crate::utils::js_fetch::JsFetchError),
+
     /// No usable sharded index for a subdir while the gateway may only read
     /// from the cache. Callers fall back to `repodata.json` for the subdir
     /// rather than failing: the sharded index is one way to read a channel,
@@ -116,6 +120,10 @@ pub enum HttpOrFilesystemError {
 
     #[error(transparent)]
     Filesystem(#[from] io::Error),
+
+    #[cfg(target_arch = "wasm32")]
+    #[error(transparent)]
+    JsFetch(#[from] crate::utils::js_fetch::JsFetchError),
 }
 
 impl From<fetch::RepoDataNotFoundError> for HttpOrFilesystemError {
@@ -123,6 +131,8 @@ impl From<fetch::RepoDataNotFoundError> for HttpOrFilesystemError {
         match value {
             RepoDataNotFoundError::HttpError(err) => HttpOrFilesystemError::Http(err),
             RepoDataNotFoundError::FileSystemError(err) => HttpOrFilesystemError::Filesystem(err),
+            #[cfg(target_arch = "wasm32")]
+            RepoDataNotFoundError::JsFetchError(err) => HttpOrFilesystemError::JsFetch(err),
         }
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -338,6 +338,11 @@ struct GatewayInner {
     /// The client to use to fetch repodata.
     client: LazyClient,
 
+    /// A fetch implementation provided by the host JavaScript environment.
+    /// When set, it is used for all requests instead of the client.
+    #[cfg(target_arch = "wasm32")]
+    js_fetch: Option<crate::utils::js_fetch::JsFetcher>,
+
     /// The channel configuration
     channel_config: ChannelConfig,
 

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/wasm.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/wasm.rs
@@ -7,11 +7,12 @@ use crate::{
     Reporter,
     fetch::{
         FetchRepoDataError,
-        no_cache::{FetchRepoDataOptions, fetch_repo_data},
+        no_cache::{FetchRepoDataOptions, fetch_repo_data, fetch_repo_data_js},
     },
     gateway::{
         GatewayError, SourceConfig, error::SubdirNotFoundError, local_subdir::LocalSubdirClient,
     },
+    utils::js_fetch::JsFetcher,
 };
 
 pub struct RemoteSubdirClient {
@@ -23,23 +24,22 @@ impl RemoteSubdirClient {
         channel: Channel,
         platform: Platform,
         client: LazyClient,
+        js_fetch: Option<JsFetcher>,
         source_config: SourceConfig,
         reporter: Option<Arc<dyn Reporter>>,
     ) -> Result<Self, GatewayError> {
         let subdir_url = channel.platform_url(platform);
+        let options = FetchRepoDataOptions {
+            zstd_enabled: source_config.zstd_enabled,
+            bz2_enabled: source_config.bz2_enabled,
+            ..FetchRepoDataOptions::default()
+        };
 
         // Fetch the repodata from the remote server
-        let repodata_bytes = fetch_repo_data(
-            subdir_url,
-            client,
-            FetchRepoDataOptions {
-                zstd_enabled: source_config.zstd_enabled,
-                bz2_enabled: source_config.bz2_enabled,
-                ..FetchRepoDataOptions::default()
-            },
-            reporter,
-        )
-        .await
+        let repodata_bytes = match js_fetch {
+            Some(fetcher) => fetch_repo_data_js(subdir_url, fetcher, options).await,
+            None => fetch_repo_data(subdir_url, client, options, reporter).await,
+        }
         .map_err(|e| match e {
             FetchRepoDataError::NotFound(e) => {
                 GatewayError::SubdirNotFoundError(Box::new(SubdirNotFoundError {

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/index.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/index.rs
@@ -8,7 +8,7 @@ use url::Url;
 use super::ShardedRepodata;
 use crate::{
     GatewayError, Reporter, gateway::sharded_subdir::decode_zst_bytes_async,
-    reporter::ResponseReporterExt,
+    reporter::ResponseReporterExt, utils::js_fetch::JsFetcher,
 };
 
 const REPODATA_SHARDS_FILENAME: &str = "repodata_shards.msgpack.zst";
@@ -16,6 +16,7 @@ const REPODATA_SHARDS_FILENAME: &str = "repodata_shards.msgpack.zst";
 // Fetches the shard index from the url or read it from the cache.
 pub async fn fetch_index(
     client: LazyClient,
+    js_fetch: Option<JsFetcher>,
     channel_base_url: &Url,
     concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
     reporter: Option<&dyn Reporter>,
@@ -25,6 +26,42 @@ pub async fn fetch_index(
         .join(REPODATA_SHARDS_FILENAME)
         .expect("invalid shard base url");
 
+    // Acquire a permit to do a request
+    let request_permit = OptionFuture::from(
+        concurrent_requests_semaphore.map(tokio::sync::Semaphore::acquire_owned),
+    )
+    .await;
+
+    let (bytes, response_url) = match js_fetch {
+        Some(fetcher) => (fetcher.get(&shards_url).await?.bytes, shards_url.clone()),
+        None => fetch_index_bytes(client, &shards_url, reporter).await?,
+    };
+
+    // Decompress the bytes
+    let decoded_bytes = Bytes::from(decode_zst_bytes_async(bytes, response_url.clone()).await?);
+
+    // Release the permit
+    drop(request_permit);
+
+    // Parse the bytes
+    let sharded_index = rmp_serde::from_slice(&decoded_bytes)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))
+        .map_err(|e| {
+            GatewayError::IoError(
+                format!("failed to parse shard index from {response_url}"),
+                e,
+            )
+        })?;
+
+    Ok(sharded_index)
+}
+
+/// Fetches the bytes of the shard index through the reqwest client.
+async fn fetch_index_bytes(
+    client: LazyClient,
+    shards_url: &Url,
+    reporter: Option<&dyn Reporter>,
+) -> Result<(Bytes, Url), GatewayError> {
     // Construct the actual request that we will send
     let request = client
         .client()
@@ -32,16 +69,10 @@ pub async fn fetch_index(
         .build()
         .expect("failed to build request for shard index");
 
-    // Acquire a permit to do a request
-    let request_permit = OptionFuture::from(
-        concurrent_requests_semaphore.map(tokio::sync::Semaphore::acquire_owned),
-    )
-    .await;
-
     // Do a fresh requests
     let reporter = reporter
         .and_then(Reporter::download_reporter)
-        .map(|r| (r, r.on_download_start(&shards_url)));
+        .map(|r| (r, r.on_download_start(shards_url)));
     let response = client
         .client()
         .execute(
@@ -61,21 +92,5 @@ pub async fn fetch_index(
         reporter.on_download_complete(&response_url, index);
     }
 
-    // Decompress the bytes
-    let decoded_bytes = Bytes::from(decode_zst_bytes_async(bytes, response_url.clone()).await?);
-
-    // Release the permit
-    drop(request_permit);
-
-    // Parse the bytes
-    let sharded_index = rmp_serde::from_slice(&decoded_bytes)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))
-        .map_err(|e| {
-            GatewayError::IoError(
-                format!("failed to parse shard index from {response_url}"),
-                e,
-            )
-        })?;
-
-    Ok(sharded_index)
+    Ok((Bytes::from(bytes), response_url))
 }

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
@@ -22,11 +22,13 @@ use crate::{
         subdir::{PackageRecords, SubdirClient},
     },
     reporter::ResponseReporterExt,
+    utils::js_fetch::JsFetcher,
 };
 
 pub struct ShardedSubdir {
     channel: Channel,
     client: LazyClient,
+    js_fetch: Option<JsFetcher>,
     shards_base_url: Url,
     package_base_url: Url,
     sharded_repodata: ShardedRepodata,
@@ -38,6 +40,7 @@ impl ShardedSubdir {
         channel: Channel,
         subdir: String,
         client: LazyClient,
+        js_fetch: Option<JsFetcher>,
         concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
         reporter: Option<&dyn Reporter>,
     ) -> Result<Self, GatewayError> {
@@ -51,6 +54,7 @@ impl ShardedSubdir {
         // Fetch the shard index
         let sharded_repodata = index::fetch_index(
             client.clone(),
+            js_fetch.clone(),
             &index_base_url,
             concurrent_requests_semaphore.clone(),
             reporter,
@@ -58,6 +62,15 @@ impl ShardedSubdir {
         .await
         .map_err(|e| match e {
             GatewayError::ReqwestError(e)
+                if e.status().is_some_and(is_missing_sharded_repodata_status) =>
+            {
+                GatewayError::SubdirNotFoundError(Box::new(SubdirNotFoundError {
+                    channel: channel.clone(),
+                    subdir: subdir.clone(),
+                    source: e.into(),
+                }))
+            }
+            GatewayError::JsFetchError(e)
                 if e.status().is_some_and(is_missing_sharded_repodata_status) =>
             {
                 GatewayError::SubdirNotFoundError(Box::new(SubdirNotFoundError {
@@ -92,6 +105,7 @@ impl ShardedSubdir {
         Ok(Self {
             channel,
             client,
+            js_fetch,
             shards_base_url: add_trailing_slash(&shards_base_url).into_owned(),
             package_base_url: add_trailing_slash(&package_base_url).into_owned(),
             sharded_repodata,
@@ -118,13 +132,6 @@ impl SubdirClient for ShardedSubdir {
             .join(&format!("{}.msgpack.zst", hex::encode(shard)))
             .expect("invalid shard url");
 
-        let shard_request = self
-            .client
-            .client()
-            .get(shard_url.clone())
-            .build()
-            .expect("failed to build shard request");
-
         let shard_bytes = {
             let _request_permit = OptionFuture::from(
                 self.concurrent_requests_semaphore
@@ -132,27 +139,40 @@ impl SubdirClient for ShardedSubdir {
                     .map(tokio::sync::Semaphore::acquire),
             )
             .await;
-            let reporter = reporter
-                .and_then(Reporter::download_reporter)
-                .map(|r| (r, r.on_download_start(&shard_url)));
-            let shard_response = self
-                .client
-                .client()
-                .execute(shard_request)
-                .await
-                .and_then(|r| r.error_for_status().map_err(Into::into))
-                .map_err(FetchRepoDataError::from)?;
 
-            let bytes = shard_response
-                .bytes_with_progress(reporter)
-                .await
-                .map_err(FetchRepoDataError::from)?;
+            match &self.js_fetch {
+                Some(fetcher) => fetcher.get(&shard_url).await?.bytes,
+                None => {
+                    let shard_request = self
+                        .client
+                        .client()
+                        .get(shard_url.clone())
+                        .build()
+                        .expect("failed to build shard request");
 
-            if let Some((reporter, index)) = reporter {
-                reporter.on_download_complete(&shard_url, index);
+                    let reporter = reporter
+                        .and_then(Reporter::download_reporter)
+                        .map(|r| (r, r.on_download_start(&shard_url)));
+                    let shard_response = self
+                        .client
+                        .client()
+                        .execute(shard_request)
+                        .await
+                        .and_then(|r| r.error_for_status().map_err(Into::into))
+                        .map_err(FetchRepoDataError::from)?;
+
+                    let bytes = shard_response
+                        .bytes_with_progress(reporter)
+                        .await
+                        .map_err(FetchRepoDataError::from)?;
+
+                    if let Some((reporter, index)) = reporter {
+                        reporter.on_download_complete(&shard_url, index);
+                    }
+
+                    bytes::Bytes::from(bytes)
+                }
             }
-
-            bytes
         };
 
         let shard_bytes = decode_zst_bytes_async(shard_bytes, shard_url).await?;

--- a/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
@@ -131,6 +131,8 @@ impl<'g> SubdirBuilder<'g> {
             self.channel.clone(),
             self.platform,
             self.gateway.client.clone(),
+            #[cfg(target_arch = "wasm32")]
+            self.gateway.js_fetch.clone(),
             #[cfg(not(target_arch = "wasm32"))]
             self.gateway.cache.clone(),
             source_config.clone(),
@@ -148,6 +150,8 @@ impl<'g> SubdirBuilder<'g> {
             self.channel.clone(),
             self.platform.to_string(),
             self.gateway.client.clone(),
+            #[cfg(target_arch = "wasm32")]
+            self.gateway.js_fetch.clone(),
             #[cfg(not(target_arch = "wasm32"))]
             self.gateway.cache.clone(),
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/rattler_repodata_gateway/src/lib.rs
+++ b/crates/rattler_repodata_gateway/src/lib.rs
@@ -69,6 +69,8 @@ mod utils;
 pub use reporter::{DownloadReporter, Reporter};
 #[cfg(feature = "sparse")]
 pub use reporter::{SUPPORTED_REPODATA_REVISION, UnsupportedRepodataRevision};
+#[cfg(target_arch = "wasm32")]
+pub use utils::js_fetch::{JsFetchError, JsFetchResponse, JsFetcher};
 
 #[cfg(feature = "gateway")]
 mod gateway;

--- a/crates/rattler_repodata_gateway/src/utils/js_fetch.rs
+++ b/crates/rattler_repodata_gateway/src/utils/js_fetch.rs
@@ -1,0 +1,140 @@
+//! A fetch implementation provided by the host JavaScript environment.
+//!
+//! On wasm targets all HTTP requests normally go through the global `fetch`
+//! function, which offers hosts no way to intercept the traffic of a single
+//! [`crate::Gateway`]. A [`JsFetcher`] holds a `fetch`-like JavaScript
+//! function that a gateway uses for all its requests instead, so hosts can
+//! add authentication, route requests through their own HTTP stack, or
+//! intercept them in tests.
+
+use std::fmt;
+
+use bytes::Bytes;
+use js_sys::{Promise, Uint8Array};
+use rattler_redaction::Redact;
+use reqwest::StatusCode;
+use send_wrapper::SendWrapper;
+use url::Url;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{Request, RequestInit, Response};
+
+/// A `fetch` implementation provided by the host JavaScript environment.
+///
+/// The wrapped function receives a `Request` object and must return a
+/// promise resolving to a `Response`, mirroring the WHATWG `fetch`
+/// function.
+#[derive(Clone)]
+pub struct JsFetcher {
+    function: SendWrapper<js_sys::Function>,
+}
+
+impl fmt::Debug for JsFetcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JsFetcher").finish_non_exhaustive()
+    }
+}
+
+/// The successful result of a [`JsFetcher`] request.
+pub struct JsFetchResponse {
+    /// The status code of the response.
+    pub status: StatusCode,
+
+    /// The body of the response.
+    pub bytes: Bytes,
+}
+
+/// An error returned by a [`JsFetcher`] request.
+#[derive(Debug, thiserror::Error)]
+pub enum JsFetchError {
+    /// The server responded with a non-success status code.
+    #[error("http status {status} for {url}")]
+    Status {
+        /// The status code of the response.
+        status: StatusCode,
+        /// The requested URL.
+        url: Url,
+    },
+
+    /// The fetch function rejected or returned an unusable value.
+    #[error("fetch failed for {url}: {message}")]
+    Fetch {
+        /// The requested URL.
+        url: Url,
+        /// A description of the failure.
+        message: String,
+    },
+}
+
+impl JsFetchError {
+    /// Returns the status code of the response if the error was caused by a
+    /// non-success status.
+    pub fn status(&self) -> Option<StatusCode> {
+        match self {
+            JsFetchError::Status { status, .. } => Some(*status),
+            JsFetchError::Fetch { .. } => None,
+        }
+    }
+}
+
+/// Extracts a human readable message from a JavaScript error value.
+fn error_message(value: &JsValue) -> String {
+    if let Some(error) = value.dyn_ref::<js_sys::Error>() {
+        return String::from(error.message());
+    }
+    value.as_string().unwrap_or_else(|| format!("{value:?}"))
+}
+
+impl JsFetcher {
+    /// Constructs a new instance from a `fetch`-like JavaScript function.
+    pub fn new(function: js_sys::Function) -> Self {
+        Self {
+            function: SendWrapper::new(function),
+        }
+    }
+
+    /// Executes a GET request for the given URL.
+    pub async fn get(&self, url: &Url) -> Result<JsFetchResponse, JsFetchError> {
+        let fetch_error = |value: &JsValue| JsFetchError::Fetch {
+            url: url.clone().redact(),
+            message: error_message(value),
+        };
+        let invalid = |message: &str| JsFetchError::Fetch {
+            url: url.clone().redact(),
+            message: message.to_string(),
+        };
+
+        let init = RequestInit::new();
+        init.set_method("GET");
+        let request =
+            Request::new_with_str_and_init(url.as_str(), &init).map_err(|err| fetch_error(&err))?;
+
+        let promise: Promise = self
+            .function
+            .call1(&JsValue::NULL, &request)
+            .map_err(|err| fetch_error(&err))?
+            .dyn_into()
+            .map_err(|_| invalid("the fetch function did not return a promise"))?;
+        let response: Response = JsFuture::from(promise)
+            .await
+            .map_err(|err| fetch_error(&err))?
+            .dyn_into()
+            .map_err(|_| invalid("the fetch function did not resolve to a response"))?;
+
+        let status = StatusCode::from_u16(response.status())
+            .map_err(|_| invalid("the response has an invalid status code"))?;
+        if !status.is_success() {
+            return Err(JsFetchError::Status {
+                status,
+                url: url.clone().redact(),
+            });
+        }
+
+        let buffer = JsFuture::from(response.array_buffer().map_err(|err| fetch_error(&err))?)
+            .await
+            .map_err(|err| fetch_error(&err))?;
+        let bytes = Bytes::from(Uint8Array::new(&buffer).to_vec());
+
+        Ok(JsFetchResponse { status, bytes })
+    }
+}

--- a/crates/rattler_repodata_gateway/src/utils/mod.rs
+++ b/crates/rattler_repodata_gateway/src/utils/mod.rs
@@ -14,6 +14,8 @@ pub(crate) mod simple_channel_server;
 mod body;
 #[cfg(not(target_arch = "wasm32"))]
 mod flock;
+#[cfg(target_arch = "wasm32")]
+pub mod js_fetch;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use flock::LockedFile;

--- a/js-rattler/.gitignore
+++ b/js-rattler/.gitignore
@@ -10,3 +10,4 @@ wasm-pack.log
 # pixi environments
 .pixi/*
 !.pixi/config.toml
+*.tgz

--- a/js-rattler/Cargo.lock
+++ b/js-rattler/Cargo.lock
@@ -2310,6 +2310,7 @@ dependencies = [
  "humantime",
  "itertools 0.15.0",
  "jiff",
+ "js-sys",
  "json-patch",
  "libc",
  "memmap2",
@@ -2325,6 +2326,7 @@ dependencies = [
  "retry-policies",
  "rmp-serde",
  "self_cell",
+ "send_wrapper",
  "serde",
  "serde_json",
  "serde_with",
@@ -2337,7 +2339,10 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasmtimer",
+ "web-sys",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -2768,6 +2773,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"

--- a/js-rattler/crate/gateway.rs
+++ b/js-rattler/crate/gateway.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
-use rattler_conda_types::{Channel, ChannelNoticeLevel, Platform};
+use rattler_conda_types::{
+    Channel, ChannelNoticeLevel, MatchSpec, ParseMatchSpecOptions, Platform, RepoDataRecord,
+    RepodataRevision,
+};
 use rattler_repodata_gateway::{
     ChannelConfig, Gateway, GatewayWarning, SourceConfig, fetch::CacheAction,
 };
@@ -165,11 +168,19 @@ impl From<JsSourceConfig> for SourceConfig {
 #[wasm_bindgen]
 impl JsGateway {
     #[wasm_bindgen(constructor)]
-    pub fn new(input: JsValue) -> JsResult<Self> {
+    pub fn new(
+        input: JsValue,
+        #[wasm_bindgen(param_description = "A custom fetch implementation used for all requests")]
+        fetch: Option<js_sys::Function>,
+    ) -> JsResult<Self> {
+        let options: Option<JsGatewayOptions> = serde_wasm_bindgen::from_value(input)?;
+
         // Creating the Gateway with a default client to avoid adding a user-agent header
         // (Not supported from the browser)
         let mut builder = Gateway::builder().with_client(ClientWithMiddleware::from(Client::new()));
-        let options: Option<JsGatewayOptions> = serde_wasm_bindgen::from_value(input)?;
+        if let Some(fetch) = fetch {
+            builder.set_js_fetch(fetch);
+        }
         if let Some(options) = options {
             if let Some(max_concurrent_requests) = options.max_concurrent_requests {
                 builder.set_max_concurrent_requests(max_concurrent_requests);
@@ -240,5 +251,70 @@ impl JsGateway {
                 .collect(),
             notices: output.notices.into_iter().map(Notice::from).collect(),
         })?)
+    }
+
+    /// Queries the given channels and platforms for records matching the
+    /// given match specs. Returns the matching records as plain objects in
+    /// the same shape as they appear in `repodata.json`, extended with the
+    /// `fn`, `url` and `channel` fields, together with any non-fatal
+    /// warnings encountered during the query.
+    pub async fn query(
+        &self,
+        channels: Vec<String>,
+        platforms: Vec<String>,
+        specs: Vec<String>,
+        #[wasm_bindgen(
+            param_description = "Whether to recursively fetch the records of dependencies as well"
+        )]
+        recursive: bool,
+    ) -> Result<JsValue, JsError> {
+        // TODO: Dont hardcode
+        let channel_config =
+            rattler_conda_types::ChannelConfig::default_with_root_dir(PathBuf::from(""));
+
+        let channels = channels
+            .into_iter()
+            .map(|s| Channel::from_str(&s, &channel_config))
+            .collect::<Result<Vec<_>, _>>()?;
+        let platforms = platforms
+            .into_iter()
+            .map(|p| Platform::from_str(&p))
+            .collect::<Result<Vec<_>, _>>()?;
+        let specs = specs
+            .into_iter()
+            .map(|s| {
+                MatchSpec::from_str(
+                    &s,
+                    ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let output = self
+            .inner
+            .query(channels, platforms, specs)
+            .recursive(recursive)
+            .execute()
+            .await?;
+        let warnings = output
+            .warnings
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        emit_gateway_warnings(output.warnings);
+
+        #[derive(Serialize)]
+        struct QueryOutput<'a> {
+            records: Vec<&'a RepoDataRecord>,
+            warnings: Vec<String>,
+        }
+
+        let records = output
+            .repodata
+            .iter()
+            .flat_map(|repodata| repodata.iter())
+            .collect::<Vec<_>>();
+        let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+        Ok(QueryOutput { records, warnings }.serialize(&serializer)?)
     }
 }

--- a/js-rattler/src/Gateway.test.ts
+++ b/js-rattler/src/Gateway.test.ts
@@ -61,4 +61,185 @@ describe("Gateway", () => {
                 });
         });
     });
+    describe("query", () => {
+        it("can query prefix.dev", async () => {
+            const gateway = new Gateway();
+            const records = await gateway.query(
+                ["https://prefix.dev/emscripten-forge-dev"],
+                ["noarch", "emscripten-wasm32"],
+                ["regex"],
+            );
+            expect(records.length).toBeGreaterThanOrEqual(1);
+            for (const record of records) {
+                expect(record.name).toBe("regex");
+                expect(record.url).toContain(
+                    "https://prefix.dev/emscripten-forge-dev/",
+                );
+            }
+        });
+    });
+    describe("custom fetch", () => {
+        const repodata = JSON.stringify({
+            info: { subdir: "noarch" },
+            packages: {},
+            "packages.conda": {
+                "foo-1.0-h123_0.conda": {
+                    name: "foo",
+                    version: "1.0",
+                    build: "h123_0",
+                    build_number: 0,
+                    subdir: "noarch",
+                    depends: [],
+                    timestamp: 1700000000000,
+                },
+            },
+        });
+
+        // Disable all repodata variants so the gateway requests exactly one
+        // URL per subdir: the plain `repodata.json`.
+        const plainOnly = {
+            default: {
+                shardedEnabled: false,
+                zstdEnabled: false,
+                bz2Enabled: false,
+            },
+        };
+
+        it("routes requests through the provided fetch", async () => {
+            const seen: Request[] = [];
+            const globalFetch = globalThis.fetch;
+            const gateway = new Gateway({
+                channelConfig: plainOnly,
+                fetch: (request) => {
+                    seen.push(request);
+                    return Promise.resolve(
+                        new Response(repodata, {
+                            status: 200,
+                            headers: { "content-type": "application/json" },
+                        }),
+                    );
+                },
+            });
+
+            const records = await gateway.query(
+                ["https://example.com/test-channel"],
+                ["noarch"],
+                ["foo"],
+            );
+
+            // The custom fetch is scoped to the gateway instance and must
+            // not leak into the global fetch.
+            expect(globalThis.fetch).toBe(globalFetch);
+
+            expect(seen.length).toBeGreaterThanOrEqual(1);
+            for (const request of seen) {
+                expect(request.method).toBe("GET");
+                expect(request.url).toContain("/test-channel/noarch/");
+            }
+            expect(records).toHaveLength(1);
+            expect(records[0].name).toBe("foo");
+            expect(records[0].version).toBe("1.0");
+            expect(records[0].build).toBe("h123_0");
+            expect(records[0].fn).toBe("foo-1.0-h123_0.conda");
+            expect(records[0].url).toBe(
+                "https://example.com/test-channel/noarch/foo-1.0-h123_0.conda",
+            );
+            expect(records.warnings).toEqual([]);
+        });
+
+        it("returns gateway warnings on the query result", async () => {
+            // Repodata that points at a CEP-42 base channel that fails to
+            // load, which surfaces as a non-fatal warning on the result.
+            const relatedRepodata = JSON.stringify({
+                info: {
+                    subdir: "noarch",
+                    channel_relations: {
+                        base: "https://example.com/missing-base",
+                    },
+                },
+                packages: {},
+                "packages.conda": {},
+            });
+            const gateway = new Gateway({
+                channelConfig: plainOnly,
+                fetch: (request) => {
+                    if (request.url.includes("/missing-base/")) {
+                        return Promise.resolve(
+                            new Response("nope", { status: 500 }),
+                        );
+                    }
+                    return Promise.resolve(
+                        new Response(relatedRepodata, { status: 200 }),
+                    );
+                },
+            });
+
+            const records = await gateway.query(
+                ["https://example.com/test-channel"],
+                ["noarch"],
+                ["foo"],
+            );
+
+            expect(records).toHaveLength(0);
+            expect(records.warnings.length).toBeGreaterThanOrEqual(1);
+        });
+
+        it("routes each gateway to its own fetch", async () => {
+            const seenA: string[] = [];
+            const seenB: string[] = [];
+            const respond = (seen: string[]) => (request: Request) => {
+                seen.push(request.url);
+                return Promise.resolve(
+                    new Response(repodata, {
+                        status: 200,
+                        headers: { "content-type": "application/json" },
+                    }),
+                );
+            };
+            const gatewayA = new Gateway({
+                channelConfig: plainOnly,
+                fetch: respond(seenA),
+            });
+            const gatewayB = new Gateway({
+                channelConfig: plainOnly,
+                fetch: respond(seenB),
+            });
+
+            await gatewayA.query(
+                ["https://example.com/channel-a"],
+                ["noarch"],
+                ["foo"],
+            );
+            await gatewayB.query(
+                ["https://example.com/channel-b"],
+                ["noarch"],
+                ["foo"],
+            );
+
+            expect(seenA.length).toBeGreaterThanOrEqual(1);
+            expect(seenB.length).toBeGreaterThanOrEqual(1);
+            expect(seenA.every((url) => url.includes("/channel-a/"))).toBe(
+                true,
+            );
+            expect(seenB.every((url) => url.includes("/channel-b/"))).toBe(
+                true,
+            );
+        });
+
+        it("reports http errors from the provided fetch", async () => {
+            const gateway = new Gateway({
+                channelConfig: plainOnly,
+                fetch: () =>
+                    Promise.resolve(new Response("nope", { status: 500 })),
+            });
+
+            await expect(
+                gateway.query(
+                    ["https://example.com/broken-channel"],
+                    ["noarch"],
+                    ["foo"],
+                ),
+            ).rejects.toBeDefined();
+        });
+    });
 });

--- a/js-rattler/src/Gateway.ts
+++ b/js-rattler/src/Gateway.ts
@@ -1,4 +1,4 @@
-import { JsGateway } from "../pkg";
+import { JsGateway, PackageRecordJson } from "../pkg";
 import { Platform } from "./Platform";
 import { NormalizedPackageName } from "./PackageName";
 
@@ -57,6 +57,14 @@ export type GatewayNamesResult = NormalizedPackageName[] & {
     notices: ChannelNotice[];
 };
 
+/**
+ * A fetch implementation used to execute the HTTP requests of a {@link Gateway}.
+ * Compatible with the WHATWG `fetch` function.
+ *
+ * @public
+ */
+export type GatewayFetch = (request: Request) => Promise<Response>;
+
 export type GatewayOptions = {
     /**
      * The maximum number of concurrent requests the gateway can execute. By
@@ -66,6 +74,60 @@ export type GatewayOptions = {
 
     /** Defines how to access channels. */
     channelConfig?: GatewayChannelConfig;
+
+    /**
+     * A custom fetch implementation used for all HTTP requests made by this
+     * gateway. When omitted, the global `fetch` function is used, which is the
+     * right choice for browsers and plain Node.
+     *
+     * Set this only when requests must go through the host's own HTTP stack:
+     * authentication, proxies, caching, or request mocking in tests.
+     */
+    fetch?: GatewayFetch;
+};
+
+/**
+ * Per-query options for {@link Gateway.query}.
+ *
+ * @public
+ */
+export type GatewayRecordsQueryOptions = {
+    /**
+     * Whether the records of dependencies are recursively fetched as well.
+     * Defaults to `false`.
+     */
+    recursive?: boolean;
+};
+
+/**
+ * A single record in the Conda repodata as returned by {@link Gateway.query}.
+ * This is the `repodata.json` representation of a package extended with the
+ * filename, the canonical download URL, and the channel it came from.
+ *
+ * @public
+ */
+export type RepoDataRecordJson = PackageRecordJson & {
+    /** The filename of the package archive. */
+    fn: string;
+
+    /** The canonical URL from where to download this package. */
+    url: string;
+
+    /** The channel the package came from. */
+    channel?: string | null;
+};
+
+/**
+ * The result of {@link Gateway.query}: the matching records, with the non-fatal
+ * warnings encountered during the query attached. The warnings are also
+ * forwarded to `console.warn` as they are recorded, so they surface even when
+ * this field is ignored.
+ *
+ * @public
+ */
+export type GatewayQueryResult = RepoDataRecordJson[] & {
+    /** Non-fatal warnings encountered during the query. */
+    warnings: string[];
 };
 
 /**
@@ -92,7 +154,12 @@ export class Gateway {
      * @param options - The options to configure the Gateway with.
      */
     constructor(options?: GatewayOptions | null) {
-        this.native = new JsGateway(options);
+        if (options?.fetch !== undefined) {
+            const { fetch: fetchImpl, ...rest } = options;
+            this.native = new JsGateway(rest, fetchImpl);
+        } else {
+            this.native = new JsGateway(options);
+        }
     }
 
     /** Fetches CEP-6 notices for the given channels. */
@@ -136,6 +203,33 @@ export class Gateway {
         const result = output.names as GatewayNamesResult;
         result.names = result;
         result.notices = output.notices;
+        return result;
+    }
+
+    /**
+     * Returns all records matching the given match specs in the given channels
+     * and platforms.
+     *
+     * @param channels - The channels to query
+     * @param platforms - The platforms to query
+     * @param specs - The match specs to query for. A bare package name matches
+     *   every version of that package.
+     * @param options - Per-query options
+     */
+    public async query(
+        channels: string[],
+        platforms: Platform[],
+        specs: string[],
+        options?: GatewayRecordsQueryOptions,
+    ): Promise<GatewayQueryResult> {
+        const output = (await this.native.query(
+            channels,
+            platforms,
+            specs,
+            options?.recursive ?? false,
+        )) as { records: RepoDataRecordJson[]; warnings: string[] };
+        const result = output.records as GatewayQueryResult;
+        result.warnings = output.warnings;
         return result;
     }
 }

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -4349,6 +4349,7 @@ dependencies = [
  "indicatif",
  "itertools 0.15.0",
  "jiff",
+ "js-sys",
  "json-patch",
  "libc",
  "memmap2",
@@ -4364,6 +4365,7 @@ dependencies = [
  "retry-policies",
  "rmp-serde",
  "self_cell",
+ "send_wrapper",
  "serde",
  "serde_json",
  "serde_with",
@@ -4376,7 +4378,10 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasmtimer",
+ "web-sys",
  "windows-sys 0.61.2",
  "zstd",
 ]
@@ -4988,6 +4993,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"


### PR DESCRIPTION
### Description

Renovate is already using rattler-js, but not for repodata fetching. That's because our API wasn't powerful enough for Renovate's needs.
Renovate needs two things the bindings don't offer:
- the full version list of a package (`simpleSolve` returns a single solved set), and
- a way to send the gateway's HTTP through Renovate's own stack for authentication, proxies, caching, and test mocking.

### How Has This Been Tested?

- Offline jest tests drive a gateway through a custom fetch, plus a live query against prefix.dev (let me know if you want to rather not have online tests)
- Consumed from my local Renovate work

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
