### PR TITLE
feat(js): add error codes and a warning callback to the gateway

### DIFF
--- a/js-rattler/crate/error.rs
+++ b/js-rattler/crate/error.rs
@@ -3,10 +3,10 @@ use rattler_conda_types::{
     InvalidPackageNameError, ParseChannelError, ParseMatchSpecError, ParsePlatformError,
     ParseVersionError, VersionBumpError, VersionExtendError,
 };
-use rattler_repodata_gateway::GatewayError;
+use rattler_repodata_gateway::{GatewayError, fetch::FetchRepoDataError};
 use rattler_solve::SolveError;
 use thiserror::Error;
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsCast, JsValue};
 
 #[derive(Debug, Error)]
 pub enum JsError {
@@ -40,11 +40,48 @@ pub enum JsError {
 
 pub type JsResult<T> = Result<T, JsError>;
 
+impl JsError {
+    /// The stable error code exposed to JavaScript as the `code` property
+    /// of the thrown error. Callers use it to classify failures without
+    /// matching on message strings.
+    fn code(&self) -> &'static str {
+        match self {
+            JsError::InvalidVersion(_) => "PARSE_VERSION",
+            JsError::VersionExtendError(_) => "VERSION_EXTEND",
+            JsError::VersionBumpError(_) => "VERSION_BUMP",
+            JsError::ParseVersionSpecError(_) => "PARSE_VERSION_SPEC",
+            JsError::ParseChannel(_) => "PARSE_CHANNEL",
+            JsError::ParsePlatform(_) => "PARSE_PLATFORM",
+            JsError::ParseMatchSpec(_) => "PARSE_MATCH_SPEC",
+            JsError::GatewayError(error) => match error {
+                GatewayError::SubdirNotFoundError(_) => "SUBDIR_NOT_FOUND",
+                GatewayError::JsFetchError(_)
+                | GatewayError::FetchRepoDataError(FetchRepoDataError::JsFetchError(_)) => "FETCH",
+                _ => "GATEWAY",
+            },
+            JsError::SolveError(_) => "SOLVE",
+            JsError::Serde(_) => "SERDE",
+            JsError::PackageNameError(_) => "PARSE_PACKAGE_NAME",
+            JsError::InvalidHexMd5(_) => "PARSE_MD5",
+            JsError::InvalidHexSha256(_) => "PARSE_SHA256",
+        }
+    }
+}
+
 impl From<JsError> for JsValue {
     fn from(error: JsError) -> Self {
-        match error {
-            JsError::Serde(error) => error.into(),
-            error => JsValue::from_str(&error.to_string()),
-        }
+        let code = error.code();
+        let js_error: js_sys::Error = match error {
+            // The serde error already carries a useful JavaScript error
+            // object, only the code needs to be attached.
+            JsError::Serde(error) => JsValue::from(error).unchecked_into(),
+            error => js_sys::Error::new(&error.to_string()),
+        };
+        let _ = js_sys::Reflect::set(
+            &js_error,
+            &JsValue::from_str("code"),
+            &JsValue::from_str(code),
+        );
+        js_error.into()
     }
 }

--- a/js-rattler/crate/gateway.rs
+++ b/js-rattler/crate/gateway.rs
@@ -69,15 +69,18 @@ impl From<rattler_repodata_gateway::ChannelNoticeResult> for Notice {
 }
 
 #[wasm_bindgen]
-#[repr(transparent)]
 #[derive(Clone)]
 pub struct JsGateway {
     inner: Gateway,
+    on_warning: Option<js_sys::Function>,
 }
 
 impl From<Gateway> for JsGateway {
     fn from(value: Gateway) -> Self {
-        JsGateway { inner: value }
+        JsGateway {
+            inner: value,
+            on_warning: None,
+        }
     }
 }
 
@@ -172,6 +175,8 @@ impl JsGateway {
         input: JsValue,
         #[wasm_bindgen(param_description = "A custom fetch implementation used for all requests")]
         fetch: Option<js_sys::Function>,
+        #[wasm_bindgen(param_description = "A callback invoked for every gateway warning")]
+        on_warning: Option<js_sys::Function>,
     ) -> JsResult<Self> {
         let options: Option<JsGatewayOptions> = serde_wasm_bindgen::from_value(input)?;
 
@@ -190,6 +195,7 @@ impl JsGateway {
 
         Ok(Self {
             inner: builder.finish(),
+            on_warning,
         })
     }
 
@@ -210,12 +216,28 @@ impl JsGateway {
         Ok(serde_wasm_bindgen::to_value(&notices)?)
     }
 
+    /// Forward each [`GatewayWarning`] to the configured warning callback,
+    /// or to JS's `console.warn` when none is set. CEP-42's default `Warn`
+    /// mode produces non-fatal warnings that the Rust API surfaces on the
+    /// query output; forwarding them ensures they cannot be silently lost.
+    fn emit_warnings(&self, warnings: Vec<GatewayWarning>) {
+        for warning in warnings {
+            let message = warning.to_string();
+            match &self.on_warning {
+                Some(callback) => {
+                    let _ = callback.call1(&JsValue::NULL, &JsValue::from_str(&message));
+                }
+                None => console_warn(&message),
+            }
+        }
+    }
+
     pub async fn names(
         &self,
         channels: Vec<String>,
         platforms: Vec<String>,
         channel_notices: bool,
-    ) -> Result<JsValue, JsError> {
+    ) -> JsResult<JsValue> {
         // TODO: Dont hardcode
         let channel_config =
             rattler_conda_types::ChannelConfig::default_with_root_dir(PathBuf::from(""));
@@ -235,7 +257,7 @@ impl JsGateway {
             .channel_notices(channel_notices)
             .execute()
             .await?;
-        emit_gateway_warnings(output.warnings);
+        self.emit_warnings(output.warnings);
 
         #[derive(Serialize)]
         struct NamesOutput {
@@ -267,7 +289,7 @@ impl JsGateway {
             param_description = "Whether to recursively fetch the records of dependencies as well"
         )]
         recursive: bool,
-    ) -> Result<JsValue, JsError> {
+    ) -> JsResult<JsValue> {
         // TODO: Dont hardcode
         let channel_config =
             rattler_conda_types::ChannelConfig::default_with_root_dir(PathBuf::from(""));
@@ -301,7 +323,7 @@ impl JsGateway {
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>();
-        emit_gateway_warnings(output.warnings);
+        self.emit_warnings(output.warnings);
 
         #[derive(Serialize)]
         struct QueryOutput<'a> {

--- a/js-rattler/src/Gateway.test.ts
+++ b/js-rattler/src/Gateway.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "@jest/globals";
 import { Gateway } from "./Gateway";
+import { Platform } from "./Platform";
+import { isRattlerError } from "./RattlerError";
+
+// Disable all repodata variants so the gateway requests exactly one URL per
+// subdir: the plain `repodata.json`.
+const plainOnly = {
+    default: {
+        shardedEnabled: false,
+        zstdEnabled: false,
+        bz2Enabled: false,
+    },
+};
 
 describe("Gateway", () => {
     describe("constructor", () => {
@@ -94,16 +106,6 @@ describe("Gateway", () => {
                 },
             },
         });
-
-        // Disable all repodata variants so the gateway requests exactly one
-        // URL per subdir: the plain `repodata.json`.
-        const plainOnly = {
-            default: {
-                shardedEnabled: false,
-                zstdEnabled: false,
-                bz2Enabled: false,
-            },
-        };
 
         it("routes requests through the provided fetch", async () => {
             const seen: Request[] = [];
@@ -240,6 +242,115 @@ describe("Gateway", () => {
                     ["foo"],
                 ),
             ).rejects.toBeDefined();
+        });
+    });
+    describe("error codes", () => {
+        it("marks a missing channel with SUBDIR_NOT_FOUND", async () => {
+            const gateway = new Gateway({
+                channelConfig: plainOnly,
+                fetch: () =>
+                    Promise.resolve(new Response(null, { status: 404 })),
+            });
+
+            const error: unknown = await gateway
+                .query(
+                    ["https://example.com/missing-channel"],
+                    ["noarch"],
+                    ["foo"],
+                )
+                .then(
+                    () => null,
+                    (err: unknown) => err,
+                );
+
+            expect(isRattlerError(error)).toBe(true);
+            if (isRattlerError(error)) {
+                expect(error.code).toBe("SUBDIR_NOT_FOUND");
+            }
+        });
+
+        it("marks fetch failures with FETCH", async () => {
+            const gateway = new Gateway({
+                channelConfig: plainOnly,
+                fetch: () =>
+                    Promise.resolve(new Response("nope", { status: 500 })),
+            });
+
+            const error: unknown = await gateway
+                .query(
+                    ["https://example.com/broken-channel"],
+                    ["noarch"],
+                    ["foo"],
+                )
+                .then(
+                    () => null,
+                    (err: unknown) => err,
+                );
+
+            expect(isRattlerError(error)).toBe(true);
+            if (isRattlerError(error)) {
+                expect(error.code).toBe("FETCH");
+                expect(error.message).toContain("500");
+            }
+        });
+
+        it("marks invalid platforms with PARSE_PLATFORM", async () => {
+            const gateway = new Gateway();
+
+            const error: unknown = await gateway
+                .query(
+                    ["https://example.com/channel"],
+                    ["not-a-platform" as Platform],
+                    ["foo"],
+                )
+                .then(
+                    () => null,
+                    (err: unknown) => err,
+                );
+
+            expect(isRattlerError(error)).toBe(true);
+            if (isRattlerError(error)) {
+                expect(error.code).toBe("PARSE_PLATFORM");
+            }
+        });
+    });
+    describe("onWarning", () => {
+        it("routes gateway warnings to the callback", async () => {
+            const relatedRepodata = JSON.stringify({
+                info: {
+                    subdir: "noarch",
+                    channel_relations: {
+                        base: "https://example.com/missing-base",
+                    },
+                },
+                packages: {},
+                "packages.conda": {},
+            });
+            const warnings: string[] = [];
+            const gateway = new Gateway({
+                channelConfig: plainOnly,
+                fetch: (request) => {
+                    if (request.url.includes("/missing-base/")) {
+                        return Promise.resolve(
+                            new Response("nope", { status: 500 }),
+                        );
+                    }
+                    return Promise.resolve(
+                        new Response(relatedRepodata, { status: 200 }),
+                    );
+                },
+                onWarning: (message) => {
+                    warnings.push(message);
+                },
+            });
+
+            await gateway.query(
+                ["https://example.com/test-channel"],
+                ["noarch"],
+                ["foo"],
+            );
+
+            expect(warnings.length).toBeGreaterThanOrEqual(1);
         });
     });
 });

--- a/js-rattler/src/Gateway.ts
+++ b/js-rattler/src/Gateway.ts
@@ -84,6 +84,13 @@ export type GatewayOptions = {
      * authentication, proxies, caching, or request mocking in tests.
      */
     fetch?: GatewayFetch;
+
+    /**
+     * A callback invoked for every warning the gateway emits, for example for
+     * malformed CEP-42 channel relations. When omitted, warnings are forwarded
+     * to `console.warn`.
+     */
+    onWarning?: (message: string) => void;
 };
 
 /**
@@ -120,8 +127,8 @@ export type RepoDataRecordJson = PackageRecordJson & {
 /**
  * The result of {@link Gateway.query}: the matching records, with the non-fatal
  * warnings encountered during the query attached. The warnings are also
- * forwarded to `console.warn` as they are recorded, so they surface even when
- * this field is ignored.
+ * forwarded to the `onWarning` callback (or `console.warn` when none is set)
+ * as they are recorded, so they surface even when this field is ignored.
  *
  * @public
  */
@@ -154,9 +161,9 @@ export class Gateway {
      * @param options - The options to configure the Gateway with.
      */
     constructor(options?: GatewayOptions | null) {
-        if (options?.fetch !== undefined) {
-            const { fetch: fetchImpl, ...rest } = options;
-            this.native = new JsGateway(rest, fetchImpl);
+        if (options && typeof options === "object") {
+            const { fetch: fetchImpl, onWarning, ...rest } = options;
+            this.native = new JsGateway(rest, fetchImpl, onWarning);
         } else {
             this.native = new JsGateway(options);
         }

--- a/js-rattler/src/RattlerError.ts
+++ b/js-rattler/src/RattlerError.ts
@@ -1,0 +1,44 @@
+/**
+ * The stable error codes carried by errors thrown by the bindings.
+ *
+ * @public
+ */
+export type RattlerErrorCode =
+    | "PARSE_VERSION"
+    | "VERSION_EXTEND"
+    | "VERSION_BUMP"
+    | "PARSE_VERSION_SPEC"
+    | "PARSE_CHANNEL"
+    | "PARSE_PLATFORM"
+    | "PARSE_MATCH_SPEC"
+    | "PARSE_PACKAGE_NAME"
+    | "PARSE_MD5"
+    | "PARSE_SHA256"
+    | "SUBDIR_NOT_FOUND"
+    | "FETCH"
+    | "GATEWAY"
+    | "SOLVE"
+    | "SERDE";
+
+/**
+ * An error thrown by the bindings. The `code` identifies the kind of failure
+ * without having to match on the message.
+ *
+ * @public
+ */
+export interface RattlerError extends Error {
+    /** A stable code identifying the kind of failure. */
+    code: RattlerErrorCode;
+}
+
+/**
+ * Returns `true` if the given value is an error thrown by the bindings.
+ *
+ * @public
+ */
+export function isRattlerError(value: unknown): value is RattlerError {
+    return (
+        value instanceof Error &&
+        typeof (value as { code?: unknown }).code === "string"
+    );
+}

--- a/js-rattler/src/index.ts
+++ b/js-rattler/src/index.ts
@@ -7,3 +7,4 @@ export * from "./PackageName";
 export * from "./typeUtils";
 export * from "./PackageRecord";
 export * from "./Gateway";
+export * from "./RattlerError";


### PR DESCRIPTION
### Description

Stacked on #2687. Renovate has to tell "this channel does not exist" apart from real failures, and gateway warnings should land in its logger instead of on stderr.

- Errors thrown by the bindings now carry a stable `code` property, so callers don't have to match on message strings
- Add `new Gateway({ onWarning })`, routing gateway warnings to a callback instead of `console.warn`

### How Has This Been Tested?

- jest tests assert the codes for the common failures and that a warning reaches the callback

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

```plaintext
Implement the API improvements in their own commit and make a GitHub stacked
PR: one PR for the new fetch API and one PR for the API improvements.
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
