### PR TITLE
fix: resolve build backends from conda-forge without a version pin

### DIFF
--- a/crates/rattler-bin/pixi.toml
+++ b/crates/rattler-bin/pixi.toml
@@ -3,11 +3,7 @@ name = "rattler"
 
 [package.build.backend]
 name = "pixi-build-rust"
-version = "0.5.*"
-channels = [
-    "https://prefix.dev/pixi-build-backends",
-    "https://prefix.dev/conda-forge"
-]
+channels = ["https://prefix.dev/conda-forge"]
 
 # Use cmake to build aws-lc-sys, because conda's CFLAGS inject -O2 which
 # overrides the -O0 required by jitterentropy-base.c, causing a build failure.

--- a/crates/rattler_index/pixi.toml
+++ b/crates/rattler_index/pixi.toml
@@ -3,11 +3,7 @@ name = "rattler_index"
 
 [package.build.backend]
 name = "pixi-build-rust"
-version = "0.5.*"
-channels = [
-    "https://prefix.dev/pixi-build-backends",
-    "https://prefix.dev/conda-forge"
-]
+channels = ["https://prefix.dev/conda-forge"]
 
 # Use cmake to build aws-lc-sys, because conda's CFLAGS inject -O2 which
 # overrides the -O0 required by jitterentropy-base.c, causing a build failure.


### PR DESCRIPTION
### Description

Resolve `pixi-build-rust` from conda-forge only and drop the version pin in `crates/rattler-bin/pixi.toml` and `crates/rattler_index/pixi.toml`.
`pixi lock` considers the lock file up-to-date with this change, so no relock is needed.
Fixes CI on PRs based on main.

### How Has This Been Tested?

- `pixi install --locked -e lint` with pixi 0.76.2 (the version CI uses) fails on a pristine `main` checkout and passes with this change

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude


### Checklist:
- [x] I have performed a self-review of my own code
