### PR TITLE
feat(rattler_conda_types): Implment virtual package plugins

### DIFF
--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -13,6 +13,7 @@ readme.workspace = true
 
 [features]
 default = ["rayon"]
+experimental-virtual-package-plugins = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/rattler_conda_types/src/lib.rs
+++ b/crates/rattler_conda_types/src/lib.rs
@@ -32,6 +32,8 @@ pub mod prefix;
 pub mod prefix_data;
 pub mod prefix_record;
 mod record_traits;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+mod sourced_virtual_package;
 
 #[cfg(test)]
 use std::path::{Path, PathBuf};
@@ -66,6 +68,8 @@ pub use platform::{Arch, ParseArchError, ParsePlatformError, Platform};
 pub use prefix_data::PrefixData;
 pub use prefix_record::PrefixRecord;
 pub use record_traits::HasArtifactIdentificationRefs;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub use repo_data::VirtualPackagePlugins;
 pub use repo_data::{
     ChannelInfo, ChannelRelations, ConvertSubdirError, PackageRecord, RecordFromPath, RepoData,
     RepodataRevision, RepodataRevisionInfo, RepodataRevisionMetadata, RepodataRevisionSelection,
@@ -76,6 +80,8 @@ pub use repo_data::{
 };
 pub use repo_data_record::{RepoDataRecord, SolverResult};
 pub use run_export::RunExportKind;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub use sourced_virtual_package::{SourcedVirtualPackage, VirtualPackageSource};
 #[cfg(feature = "semver")]
 pub use version::VersionToSemverError;
 pub use version::{

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -24,6 +24,8 @@ use serde_with::{
 use thiserror::Error;
 use url::Url;
 
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use crate::utils::serde::DeserializeVirtualPackagePlugins;
 use crate::{
     Arch, Channel, Flag, MatchSpec, Matches, NoArchType, PackageName, PackageUrl,
     ParseMatchSpecError, ParseStrictness, Platform, RepoDataRecord, VersionWithSource,
@@ -107,7 +109,22 @@ pub struct ChannelInfo {
     /// [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
     #[serde(default, skip_serializing_if = "ChannelRelations::is_none_or_empty")]
     pub channel_relations: Option<ChannelRelations>,
+
+    /// Virtual package detection plugins registered by the channel.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[serde_as(deserialize_as = "DeserializeVirtualPackagePlugins")]
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub virtual_package_plugins: VirtualPackagePlugins,
 }
+
+/// Virtual package detection plugins registered by a channel: the name of the
+/// package providing the plugin, mapped to the virtual packages it provides.
+///
+/// One plugin may provide several virtual packages, e.g. a `foobar-detect`
+/// providing both `__foobar` and `__something_else`. The executable to run is
+/// named after the plugin package.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub type VirtualPackagePlugins = IndexMap<PackageName, Vec<PackageName>>;
 
 /// Repodata revisions keyed by revision, mirroring the `vN` dictionary of the
 /// CEP draft <https://github.com/conda/ceps/pull/146>. Keying encodes
@@ -1226,6 +1243,8 @@ mod test {
         package::DistArchiveIdentifier,
         repo_data::{compute_package_url, determine_subdir},
     };
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    use crate::{PackageName, repo_data::VirtualPackagePlugins};
 
     // isl-0.12.2-1.tar.bz2
     // gmp-5.1.2-6.tar.bz2
@@ -1308,6 +1327,8 @@ mod test {
                     base: Some("../conda-forge".to_string()),
                     overrides: None,
                 }),
+                #[cfg(feature = "experimental-virtual-package-plugins")]
+                virtual_package_plugins: VirtualPackagePlugins::default(),
             }),
             packages: IndexMap::default(),
             conda_packages: IndexMap::default(),
@@ -1330,6 +1351,8 @@ mod test {
                     base_url: None,
                     repodata_revisions: IndexMap::default(),
                     channel_relations,
+                    #[cfg(feature = "experimental-virtual-package-plugins")]
+                    virtual_package_plugins: VirtualPackagePlugins::default(),
                 }),
                 packages: IndexMap::default(),
                 conda_packages: IndexMap::default(),
@@ -1339,6 +1362,414 @@ mod test {
             let json = serde_json::to_string(&repodata).unwrap();
             assert!(!json.contains("channel_relations"));
         }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins() {
+        // A single plugin may provide several virtual packages; the order of
+        // both the plugins and their virtual packages is preserved.
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "foobar-detect": ["__foobar", "__something_else"],
+                    "rocm-detect": ["__rocm"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        let plugins = &repodata.info.as_ref().unwrap().virtual_package_plugins;
+
+        assert_eq!(
+            plugins
+                .keys()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["foobar-detect", "rocm-detect"]
+        );
+        assert_eq!(
+            plugins[&PackageName::new_unchecked("foobar-detect")]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__foobar", "__something_else"]
+        );
+        assert_eq!(
+            plugins[&PackageName::new_unchecked("rocm-detect")]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__rocm"]
+        );
+
+        let json = serde_json::to_string(&repodata).unwrap();
+        assert!(json.contains("\"virtual_package_plugins\""));
+        assert_eq!(serde_json::from_str::<RepoData>(&json).unwrap(), repodata);
+
+        let without = RepoData {
+            version: Some(2),
+            info: Some(ChannelInfo {
+                subdir: Some("linux-64".to_string()),
+                base_url: None,
+                repodata_revisions: IndexMap::default(),
+                channel_relations: None,
+                virtual_package_plugins: VirtualPackagePlugins::default(),
+            }),
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            v3: V3Packages::default(),
+            removed: ahash::HashSet::default(),
+        };
+        assert!(
+            !serde_json::to_string(&without)
+                .unwrap()
+                .contains("virtual_package_plugins")
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_contradictions_drop_the_whole_section() {
+        let seventeen: Vec<String> = (0..17).map(|index| format!("\"__v{index}\"")).collect();
+        for (label, body) in [
+            ("not a map", "null".to_string()),
+            ("not a map either", r#"["cuda-detect"]"#.to_string()),
+            (
+                "key is not a package name",
+                r#"{"invalid$plugin": ["__cuda"]}"#.to_string(),
+            ),
+            (
+                "key is a virtual package name",
+                r#"{"__leading": ["__cuda"]}"#.to_string(),
+            ),
+            (
+                "one package under two keys",
+                r#"{"A-Detect": ["__x"], "a-detect": ["__y"]}"#.to_string(),
+            ),
+            (
+                "the same key twice",
+                r#"{"a-detect": ["__x"], "a-detect": ["__y"]}"#.to_string(),
+            ),
+            (
+                "one virtual package from two plugins",
+                r#"{"cuda-detect": ["__cuda"], "other-detect": ["__cuda"]}"#.to_string(),
+            ),
+            (
+                "one virtual package twice in one plugin",
+                r#"{"cuda-detect": ["__cuda", "__cuda"]}"#.to_string(),
+            ),
+            (
+                "no virtual packages declared",
+                r#"{"empty-detect": []}"#.to_string(),
+            ),
+            (
+                "a registration value that is a string",
+                r#"{"cuda-detect": "__cuda"}"#.to_string(),
+            ),
+            (
+                "a registration value that is null",
+                r#"{"cuda-detect": null}"#.to_string(),
+            ),
+            (
+                "a registration value that is a number",
+                r#"{"cuda-detect": 5}"#.to_string(),
+            ),
+            (
+                "a registration value that is a map",
+                r#"{"cuda-detect": {"__cuda": true}}"#.to_string(),
+            ),
+            (
+                "a valid registration next to a malformed one",
+                r#"{"good-detect": ["__good"], "bad-detect": 5}"#.to_string(),
+            ),
+            (
+                "more than sixteen declared",
+                format!(r#"{{"big-detect": [{}]}}"#, seventeen.join(", ")),
+            ),
+        ] {
+            let raw = format!(
+                r#"{{
+                    "info": {{ "subdir": "linux-64", "virtual_package_plugins": {body} }},
+                    "packages": {{}},
+                    "packages.conda": {{}},
+                    "repodata_version": 2
+                }}"#
+            );
+            let repodata: RepoData = serde_json::from_str(&raw)
+                .unwrap_or_else(|err| panic!("{label} invalidated the repodata: {err}"));
+            assert!(
+                repodata
+                    .info
+                    .as_ref()
+                    .unwrap()
+                    .virtual_package_plugins
+                    .is_empty(),
+                "{label} left registrations behind"
+            );
+            assert_eq!(
+                repodata.info.as_ref().unwrap().subdir.as_deref(),
+                Some("linux-64"),
+                "{label} lost the rest of the info dictionary"
+            );
+        }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_virtual_names_are_lowercase_only() {
+        // CEP 26 states the virtual package pattern in lowercase and, unlike
+        // the distributable one, does not call it case-insensitive.
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "CUDA-Detect": ["__cuda", "__Foo_Bar"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        let plugins = &repodata.info.as_ref().unwrap().virtual_package_plugins;
+
+        assert_eq!(
+            plugins[&PackageName::try_from("cuda-detect").unwrap()]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda"],
+            "an uppercase virtual package name was kept"
+        );
+        assert_eq!(
+            plugins
+                .keys()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["CUDA-Detect"],
+            "a mixed-case plugin key was rejected, though CEP 26 calls that pattern \
+             case-insensitive"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_non_string_value_is_ignored() {
+        // Not a package name in any sense, so it is discarded like any other
+        // invalid name rather than invalidating the surrounding repodata.
+        for entry in ["5", "null", "[\"__x\"]", "{\"a\": 1}", "true"] {
+            let raw = format!(
+                r#"{{
+                    "info": {{
+                        "subdir": "linux-64",
+                        "virtual_package_plugins": {{ "cuda-detect": ["__cuda", {entry}] }}
+                    }},
+                    "packages": {{}},
+                    "packages.conda": {{}}
+                }}"#
+            );
+            let repodata: RepoData = serde_json::from_str(&raw)
+                .unwrap_or_else(|err| panic!("{entry} invalidated the repodata: {err}"));
+            assert_eq!(
+                repodata.info.as_ref().unwrap().virtual_package_plugins
+                    [&PackageName::try_from("cuda-detect").unwrap()]
+                    .iter()
+                    .map(PackageName::as_source)
+                    .collect::<Vec<_>>(),
+                ["__cuda"],
+                "{entry} did not leave the plugin's other names intact"
+            );
+        }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_invalid_value_is_ignored() {
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "cuda-detect": ["__cuda", "__", "cuda", "_cuda", "__a--b"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            repodata.info.as_ref().unwrap().virtual_package_plugins
+                [&PackageName::try_from("cuda-detect").unwrap()]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda"],
+            "a value CEP 26 does not allow as a virtual package name was kept"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_reject_non_virtual_names() {
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "cuda-detect": ["__cuda", "cuda", "_cuda"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        let plugins = &repodata.info.as_ref().unwrap().virtual_package_plugins;
+        assert_eq!(
+            plugins[&PackageName::try_from("cuda-detect").unwrap()]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda"],
+            "a name without the '__' prefix was registered as a virtual package"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_drop_plugins_providing_nothing() {
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "bogus-detect": ["cuda", "invalid$virtual"],
+                    "cuda-detect": ["__cuda"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            repodata
+                .info
+                .as_ref()
+                .unwrap()
+                .virtual_package_plugins
+                .keys()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["cuda-detect"],
+            "a plugin whose every declared name was invalid was kept"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_names_are_normalized() {
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": { "CUDA-Detect": ["__cuda"] }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        let plugins = &repodata.info.as_ref().unwrap().virtual_package_plugins;
+
+        let plugin = PackageName::try_from("cuda-detect").unwrap();
+        assert!(
+            plugins.contains_key(&plugin),
+            "a registration is unreachable by the plugin's normalized name"
+        );
+        assert!(
+            plugins[&plugin].contains(&PackageName::try_from("__cuda").unwrap()),
+            "a provided virtual package never matches the detected name"
+        );
+        assert_eq!(
+            plugins.keys().next().unwrap().as_source(),
+            "CUDA-Detect",
+            "the spelling the channel published was not preserved"
+        );
+    }
+
+    /// A client without this feature ignores the field's bytes iteratively, so
+    /// knowing the field must not turn nesting the schema never asks for into
+    /// a fatal parse error for the surrounding repodata.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_deep_nesting_does_not_reject_the_document() {
+        let deep = format!("{}{}", "[".repeat(150), "]".repeat(150));
+
+        // Nested junk where a name belongs is dropped alone.
+        let raw = format!(
+            r#"{{
+                "info": {{
+                    "subdir": "linux-64",
+                    "virtual_package_plugins": {{ "cuda-detect": ["__cuda", {deep}] }}
+                }},
+                "packages": {{}},
+                "packages.conda": {{}}
+            }}"#
+        );
+        let repodata: RepoData = serde_json::from_str(&raw)
+            .unwrap_or_else(|err| panic!("a nested element invalidated the repodata: {err}"));
+        assert_eq!(
+            repodata.info.as_ref().unwrap().virtual_package_plugins
+                [&PackageName::try_from("cuda-detect").unwrap()]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda"],
+            "a deeply nested element was not dropped alone"
+        );
+
+        // Nested junk where the registration array belongs drops the section.
+        let deep_maps = format!("{}0{}", r#"{"a":"#.repeat(150), "}".repeat(150));
+        let raw = format!(
+            r#"{{
+                "info": {{
+                    "subdir": "linux-64",
+                    "virtual_package_plugins": {{ "cuda-detect": {deep_maps} }}
+                }},
+                "packages": {{}},
+                "packages.conda": {{}}
+            }}"#
+        );
+        let repodata: RepoData = serde_json::from_str(&raw)
+            .unwrap_or_else(|err| panic!("a nested value invalidated the repodata: {err}"));
+        assert!(
+            repodata
+                .info
+                .as_ref()
+                .unwrap()
+                .virtual_package_plugins
+                .is_empty(),
+            "a registration value that is not an array was kept"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_roundtrip_keeps_identity() {
+        let mut plugins = VirtualPackagePlugins::default();
+        plugins.insert(
+            PackageName::try_from("CUDA-Detect").unwrap(),
+            vec![PackageName::try_from("__cuda").unwrap()],
+        );
+        let info = ChannelInfo {
+            subdir: Some("linux-64".to_string()),
+            base_url: None,
+            repodata_revisions: IndexMap::default(),
+            channel_relations: None,
+            virtual_package_plugins: plugins.clone(),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        let back: ChannelInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.virtual_package_plugins, plugins,
+            "a validated registration changed identity through a round trip ({json})"
+        );
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/repo_data/sharded.rs
+++ b/crates/rattler_conda_types/src/repo_data/sharded.rs
@@ -2,7 +2,11 @@
 
 use crate::PackageRecord;
 use crate::package::DistArchiveIdentifier;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use crate::repo_data::VirtualPackagePlugins;
 use crate::repo_data::{ChannelRelations, RepodataRevisions, V3Packages};
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use crate::utils::serde::DeserializeVirtualPackagePlugins;
 use crate::utils::serde::{sort_index_map_alphabetically, sort_set_alphabetically};
 use indexmap::IndexMap;
 use jiff::Timestamp;
@@ -60,6 +64,12 @@ pub struct ShardedSubdirInfo {
     /// [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
     #[serde(default, skip_serializing_if = "ChannelRelations::is_none_or_empty")]
     pub channel_relations: Option<ChannelRelations>,
+
+    /// Virtual package detection plugins registered by the channel.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[serde_as(deserialize_as = "DeserializeVirtualPackagePlugins")]
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub virtual_package_plugins: VirtualPackagePlugins,
 }
 
 #[cfg(test)]
@@ -121,6 +131,8 @@ mod tests {
                 created_at: None,
                 repodata_revisions: IndexMap::default(),
                 channel_relations: None,
+                #[cfg(feature = "experimental-virtual-package-plugins")]
+                virtual_package_plugins: VirtualPackagePlugins::default(),
             },
             shards: ahash::HashMap::default(),
         };
@@ -160,10 +172,193 @@ mod tests {
                 created_at: None,
                 repodata_revisions: IndexMap::default(),
                 channel_relations,
+                #[cfg(feature = "experimental-virtual-package-plugins")]
+                virtual_package_plugins: VirtualPackagePlugins::default(),
             };
             let json = serde_json::to_string(&info).unwrap();
             assert!(!json.contains("channel_relations"));
         }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_sharded_subdir_info_normalizes_plugin_names() {
+        let raw = r#"{
+            "subdir": "linux-64",
+            "base_url": "./",
+            "shards_base_url": "./shards/",
+            "virtual_package_plugins": { "CUDA-Detect": ["__cuda"] }
+        }"#;
+        let info: ShardedSubdirInfo = serde_json::from_str(raw).unwrap();
+        let plugin = PackageName::try_from("cuda-detect").unwrap();
+        assert!(
+            info.virtual_package_plugins.contains_key(&plugin),
+            "a sharded registration is unreachable by its normalized name"
+        );
+        assert!(
+            info.virtual_package_plugins[&plugin]
+                .contains(&PackageName::try_from("__cuda").unwrap()),
+            "a provided virtual package never matches the detected name"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_sharded_subdir_info_virtual_package_plugins() {
+        let raw = r#"{
+            "subdir": "linux-64",
+            "base_url": "./",
+            "shards_base_url": "./shards/",
+            "virtual_package_plugins": {
+                "cuda-detect": ["__cuda", "__cuda_arch"]
+            }
+        }"#;
+        let info: ShardedSubdirInfo = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            info.virtual_package_plugins[&PackageName::new_unchecked("cuda-detect")]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda", "__cuda_arch"]
+        );
+
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("\"virtual_package_plugins\""));
+
+        // Omitted entirely when no plugins are registered.
+        let info = ShardedSubdirInfo {
+            virtual_package_plugins: VirtualPackagePlugins::default(),
+            ..info
+        };
+        assert!(
+            !serde_json::to_string(&info)
+                .unwrap()
+                .contains("virtual_package_plugins")
+        );
+    }
+
+    /// A msgpack `ShardedSubdirInfo` document with the given already-encoded
+    /// msgpack bytes as the value of `virtual_package_plugins`. msgpack can
+    /// express shapes JSON cannot (binary data, non-string keys, invalid
+    /// UTF-8, ext types), and the shard index is remote data, so those shapes
+    /// are reachable in production.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn msgpack_info_with_plugins_section(section: &[u8]) -> Vec<u8> {
+        let fixstr = |out: &mut Vec<u8>, text: &str| {
+            out.push(0xa0 | u8::try_from(text.len()).unwrap());
+            out.extend_from_slice(text.as_bytes());
+        };
+        let mut out = vec![0x84];
+        fixstr(&mut out, "subdir");
+        fixstr(&mut out, "linux-64");
+        fixstr(&mut out, "base_url");
+        fixstr(&mut out, "./");
+        fixstr(&mut out, "shards_base_url");
+        fixstr(&mut out, "./shards/");
+        fixstr(&mut out, "virtual_package_plugins");
+        out.extend_from_slice(section);
+        out
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[track_caller]
+    fn parse_msgpack_plugins_section(section: &[u8]) -> ShardedSubdirInfo {
+        rmp_serde::from_slice(&msgpack_info_with_plugins_section(section)).unwrap_or_else(|err| {
+            panic!("the malformed section rejected the surrounding shard index: {err}")
+        })
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[track_caller]
+    fn assert_msgpack_plugins_section_dropped(section: &[u8]) {
+        let info = parse_msgpack_plugins_section(section);
+        assert!(
+            info.virtual_package_plugins.is_empty(),
+            "expected the whole section to be dropped, got {:?}",
+            info.virtual_package_plugins
+        );
+        assert_eq!(
+            info.subdir, "linux-64",
+            "the rest of the index info was lost"
+        );
+    }
+
+    /// A registration key that is not a string cannot be a package name, so
+    /// the section is not a map of registrations: an error that drops the
+    /// section -- and never the surrounding shard index, which is remote data
+    /// one hostile key must not be able to take down.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_sharded_subdir_info_drops_the_section_on_a_non_string_key() {
+        let value = [&[0x91, 0xa3][..], b"__x"].concat();
+        for (label, key) in [
+            ("an integer key", vec![0x05]),
+            ("a nil key", vec![0xc0]),
+            ("a binary key", [&[0xc4, 0x02][..], b"ab"].concat()),
+            ("an invalid UTF-8 str key", vec![0xa2, 0xff, 0xfe]),
+        ] {
+            let section = [&[0x81][..], &key, &value].concat();
+            let info = parse_msgpack_plugins_section(&section);
+            assert!(
+                info.virtual_package_plugins.is_empty(),
+                "{label} did not drop the section, got {:?}",
+                info.virtual_package_plugins
+            );
+        }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_sharded_subdir_info_drops_the_section_on_an_ext_value() {
+        // fixext1, type 1, one payload byte: not a map of registrations.
+        assert_msgpack_plugins_section_dropped(&[0xd4, 0x01, 0x2a]);
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_sharded_subdir_info_drops_a_binary_element_alone() {
+        // {"cuda-detect": ["__cuda", bin"__x"]}: binary data is not a name,
+        // however name-like its bytes, and must be dropped like any other
+        // shape that is not a string.
+        let section = [
+            &[0x81, 0xab][..],
+            b"cuda-detect",
+            &[0x92, 0xa6],
+            b"__cuda",
+            &[0xc4, 0x03],
+            b"__x",
+        ]
+        .concat();
+        let info = parse_msgpack_plugins_section(&section);
+        assert_eq!(
+            info.virtual_package_plugins[&PackageName::new_unchecked("cuda-detect")]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda"],
+            "a binary element was not dropped alone"
+        );
+    }
+
+    /// The shard index travels as msgpack, and the registration deserializer
+    /// relies on `deserialize_any` and an untagged enum, both of which a
+    /// self-describing format must support.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_sharded_subdir_info_plugins_survive_msgpack() {
+        let raw = r#"{
+            "subdir": "linux-64",
+            "base_url": "./",
+            "shards_base_url": "./shards/",
+            "virtual_package_plugins": { "cuda-detect": ["__cuda", "__cuda_arch"] }
+        }"#;
+        let info: ShardedSubdirInfo = serde_json::from_str(raw).unwrap();
+        let bytes = rmp_serde::to_vec_named(&info).unwrap();
+        let back: ShardedSubdirInfo = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(
+            back.virtual_package_plugins, info.virtual_package_plugins,
+            "the registrations changed through a msgpack round trip"
+        );
     }
 }
 

--- a/crates/rattler_conda_types/src/sourced_virtual_package.rs
+++ b/crates/rattler_conda_types/src/sourced_virtual_package.rs
@@ -1,0 +1,61 @@
+//! A virtual package together with what produced it.
+
+use rattler_digest::{Sha256Hash, serde::SerializableHash};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use crate::{ChannelUrl, GenericVirtualPackage, PackageName};
+
+/// A virtual package and the source that produced it.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SourcedVirtualPackage {
+    /// What produced this.
+    pub source: VirtualPackageSource,
+
+    /// The virtual package itself, as handed to the solver.
+    pub package: GenericVirtualPackage,
+}
+
+/// Where a virtual package came from.
+#[serde_as]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VirtualPackageSource {
+    /// Detected by this client itself, according to CEP 30.
+    BuiltIn,
+
+    /// Detected by a plugin a channel registered.
+    Plugin {
+        /// The channel that registered the plugin.
+        channel: ChannelUrl,
+
+        /// The package providing the plugin.
+        plugin: PackageName,
+
+        /// Identifies what actually ran: a hash over the plugin package *and*
+        /// every package installed alongside it, so it changes when any
+        /// dependency of the plugin does. That closure, rather than the package
+        /// the registration names, is what a user extends trust to.
+        #[serde_as(as = "SerializableHash::<rattler_digest::Sha256>")]
+        environment: Sha256Hash,
+    },
+
+    /// Taken from a `CONDA_OVERRIDE_*` variable instead of being detected.
+    Overridden {
+        /// The channel whose plugin would have answered.
+        channel: ChannelUrl,
+
+        /// The plugin that would have been run.
+        plugin: PackageName,
+    },
+}
+
+impl VirtualPackageSource {
+    /// Whether this came from the client rather than from a channel.
+    pub fn is_built_in(&self) -> bool {
+        match self {
+            Self::BuiltIn => true,
+            Self::Plugin { .. } | Self::Overridden { .. } => false,
+        }
+    }
+}

--- a/crates/rattler_conda_types/src/utils/serde.rs
+++ b/crates/rattler_conda_types/src/utils/serde.rs
@@ -229,6 +229,447 @@ impl Serialize for TimestampMs {
 /// string.
 pub struct DeserializeFromStrUnchecked;
 
+/// A helper struct to deserialize virtual package plugin registrations,
+/// validating every name and skipping the ones a channel got wrong.
+///
+/// A registration whose plugin name is invalid is dropped entirely; an invalid
+/// virtual package name is dropped from the plugin that claimed it. Each is
+/// reported as a warning. A malformed name is a mistake by one channel, so it
+/// must not fail the surrounding repodata, but it must not be handed on to a
+/// consumer that would resolve it to an executable either.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub struct DeserializeVirtualPackagePlugins;
+
+#[cfg(feature = "experimental-virtual-package-plugins")]
+impl<'de> DeserializeAs<'de, crate::repo_data::VirtualPackagePlugins>
+    for DeserializeVirtualPackagePlugins
+{
+    fn deserialize_as<D>(
+        deserializer: D,
+    ) -> Result<crate::repo_data::VirtualPackagePlugins, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Read the entries as a sequence of pairs rather than a map: a map
+        // resolves a repeated key last-wins, which would hide a collision the
+        // CEP makes an error. A value that is not a map at all -- an explicit
+        // null, a list, a string -- is itself an error, so it is accepted here
+        // and reported below rather than failing the surrounding repodata.
+        struct Entries;
+        impl<'de> serde::de::Visitor<'de> for Entries {
+            type Value = Option<Vec<(MaybeName, MaybeArray)>>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a map of plugin names to virtual package names")
+            }
+
+            // The key is read leniently too: JSON keys are always strings,
+            // but the shard index is msgpack, whose maps can carry keys of
+            // any type. A typed key would fail the surrounding document.
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut entries = Vec::new();
+                while let Some(entry) = map.next_entry::<MaybeName, MaybeArray>()? {
+                    entries.push(entry);
+                }
+                Ok(Some(entries))
+            }
+
+            fn visit_newtype_struct<D: Deserializer<'de>>(
+                self,
+                d: D,
+            ) -> Result<Self::Value, D::Error> {
+                serde::de::IgnoredAny::deserialize(d)?;
+                Ok(None)
+            }
+
+            // Anything that is not a map is reported by the caller, so every
+            // other shape a self-describing format can hand us resolves to
+            // "not a map" instead of failing the surrounding document.
+            fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+            fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+            fn visit_some<D: Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+                d.deserialize_any(self)
+            }
+            fn visit_bool<E: serde::de::Error>(self, _: bool) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+            fn visit_i64<E: serde::de::Error>(self, _: i64) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+            fn visit_u64<E: serde::de::Error>(self, _: u64) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+            fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+            fn visit_str<E: serde::de::Error>(self, _: &str) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+            fn visit_bytes<E: serde::de::Error>(self, _: &[u8]) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+                Ok(None)
+            }
+        }
+
+        let Some(raw) = deserializer.deserialize_any(Entries)? else {
+            tracing::warn!(
+                "ignoring info.virtual_package_plugins: it is not a map of plugin registrations"
+            );
+            return Ok(crate::repo_data::VirtualPackagePlugins::default());
+        };
+
+        // A channel that contradicted itself has not established what it meant,
+        // so the whole set goes rather than the offending entry.
+        match registrations_from(raw) {
+            Ok(registrations) => Ok(registrations),
+            Err(reason) => {
+                tracing::warn!("ignoring info.virtual_package_plugins entirely: {reason}");
+                Ok(crate::repo_data::VirtualPackagePlugins::default())
+            }
+        }
+    }
+}
+
+/// Builds the registrations, or names the contradiction that makes the whole
+/// set unusable. Returning the reason rather than a value lets the caller report
+/// it and fall back to no registrations, which is what the CEP asks for: the
+/// section is ignored, the rest of the repodata is not.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+fn registrations_from(
+    raw: Vec<(MaybeName, MaybeArray)>,
+) -> Result<crate::repo_data::VirtualPackagePlugins, String> {
+    let mut registrations = crate::repo_data::VirtualPackagePlugins::default();
+    let mut registered_plugins = std::collections::HashSet::new();
+    let mut claimed = std::collections::HashSet::new();
+
+    for (plugin, provides) in raw {
+        let MaybeName::Name(plugin) = plugin else {
+            return Err("a plugin key is not a string".to_string());
+        };
+        let plugin = validated_plugin_name(plugin)?;
+        if !registered_plugins.insert(plugin.clone()) {
+            return Err(format!(
+                "the channel registers the plugin package '{}' more than once",
+                plugin.as_source()
+            ));
+        }
+
+        let MaybeArray::Array(provides) = provides else {
+            return Err(format!(
+                "the registration of plugin '{}' is not an array of virtual package names",
+                plugin.as_source()
+            ));
+        };
+
+        // Counted over what the plugin declares, before invalid names are
+        // dropped, so that ignoring a malformed name cannot turn a plugin that
+        // declared too many into one that looks acceptable.
+        if provides.is_empty() || provides.len() > MAX_VIRTUAL_PACKAGES_PER_PLUGIN {
+            return Err(format!(
+                "plugin '{}' registers {} virtual packages, outside the 1 to {} a plugin may \
+                 register",
+                plugin.as_source(),
+                provides.len(),
+                MAX_VIRTUAL_PACKAGES_PER_PLUGIN
+            ));
+        }
+
+        let provides: Vec<_> = provides
+            .into_iter()
+            .filter_map(|name| match name {
+                MaybeName::Name(name) => validated_virtual_package_name(name),
+                MaybeName::NotAName => {
+                    tracing::warn!(
+                        "ignoring a registered virtual package of plugin '{}': it is not a name \
+                         at all",
+                        plugin.as_source()
+                    );
+                    None
+                }
+            })
+            .collect();
+        for name in &provides {
+            if !claimed.insert(name.clone()) {
+                return Err(format!(
+                    "the virtual package '{}' is registered more than once",
+                    name.as_source()
+                ));
+            }
+        }
+
+        // Every name it declared was invalid and dropped above. The plugin
+        // speaks for nothing, which is ignored rather than fatal: the channel's
+        // mistake is in the names, which are ignored one at a time.
+        if provides.is_empty() {
+            tracing::warn!(
+                "ignoring plugin '{}': it registers no valid virtual package",
+                plugin.as_source()
+            );
+            continue;
+        }
+
+        registrations.insert(plugin, provides);
+    }
+    Ok(registrations)
+}
+
+/// The value of one registration entry. A channel that put something other
+/// than an array there has not written a map of registrations, which the CEP
+/// makes an error: the section is ignored as a whole, but the surrounding
+/// repodata must survive, so any shape is accepted here and rejected later.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+enum MaybeArray {
+    Array(Vec<MaybeName>),
+    NotAnArray,
+}
+
+#[cfg(feature = "experimental-virtual-package-plugins")]
+impl<'de> Deserialize<'de> for MaybeArray {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // A hand-written visitor rather than an untagged enum: untagged
+        // buffers the value through serde's recursive `Content` tree, which a
+        // deeply nested value blows through, failing the surrounding document.
+        // `IgnoredAny` drains junk without buffering it.
+        struct ArrayVisitor;
+        impl<'de> serde::de::Visitor<'de> for ArrayVisitor {
+            type Value = MaybeArray;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("an array of virtual package names")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut names = Vec::new();
+                while let Some(name) = seq.next_element::<MaybeName>()? {
+                    names.push(name);
+                }
+                Ok(MaybeArray::Array(names))
+            }
+
+            fn visit_some<D: Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+                d.deserialize_any(self)
+            }
+            fn visit_newtype_struct<D: Deserializer<'de>>(
+                self,
+                d: D,
+            ) -> Result<Self::Value, D::Error> {
+                serde::de::IgnoredAny::deserialize(d)?;
+                Ok(MaybeArray::NotAnArray)
+            }
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<Self::Value, A::Error> {
+                while map
+                    .next_entry::<serde::de::IgnoredAny, serde::de::IgnoredAny>()?
+                    .is_some()
+                {}
+                Ok(MaybeArray::NotAnArray)
+            }
+            fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(MaybeArray::NotAnArray)
+            }
+            fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(MaybeArray::NotAnArray)
+            }
+            fn visit_bool<E: serde::de::Error>(self, _: bool) -> Result<Self::Value, E> {
+                Ok(MaybeArray::NotAnArray)
+            }
+            fn visit_i64<E: serde::de::Error>(self, _: i64) -> Result<Self::Value, E> {
+                Ok(MaybeArray::NotAnArray)
+            }
+            fn visit_u64<E: serde::de::Error>(self, _: u64) -> Result<Self::Value, E> {
+                Ok(MaybeArray::NotAnArray)
+            }
+            fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<Self::Value, E> {
+                Ok(MaybeArray::NotAnArray)
+            }
+            fn visit_str<E: serde::de::Error>(self, _: &str) -> Result<Self::Value, E> {
+                Ok(MaybeArray::NotAnArray)
+            }
+            fn visit_bytes<E: serde::de::Error>(self, _: &[u8]) -> Result<Self::Value, E> {
+                Ok(MaybeArray::NotAnArray)
+            }
+        }
+        deserializer.deserialize_any(ArrayVisitor)
+    }
+}
+
+/// One element of a registration array. A channel that put something other than
+/// a string there has published a name that cannot be a package name, and the
+/// CEP requires such a value to be discarded rather than to invalidate the
+/// surrounding repodata, so the element is accepted and dropped later.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+enum MaybeName {
+    Name(String),
+    NotAName,
+}
+
+#[cfg(feature = "experimental-virtual-package-plugins")]
+impl<'de> Deserialize<'de> for MaybeName {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // A hand-written visitor for the same reason as `MaybeArray`'s, and
+        // for one more: an untagged enum would accept binary data whose bytes
+        // happen to be UTF-8 as a name, but a name is a string, not bytes.
+        struct NameVisitor;
+        impl<'de> serde::de::Visitor<'de> for NameVisitor {
+            type Value = MaybeName;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a virtual package name")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, name: &str) -> Result<Self::Value, E> {
+                Ok(MaybeName::Name(name.to_string()))
+            }
+            fn visit_string<E: serde::de::Error>(self, name: String) -> Result<Self::Value, E> {
+                Ok(MaybeName::Name(name))
+            }
+
+            fn visit_some<D: Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
+                d.deserialize_any(self)
+            }
+            fn visit_newtype_struct<D: Deserializer<'de>>(
+                self,
+                d: D,
+            ) -> Result<Self::Value, D::Error> {
+                serde::de::IgnoredAny::deserialize(d)?;
+                Ok(MaybeName::NotAName)
+            }
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+                Ok(MaybeName::NotAName)
+            }
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<Self::Value, A::Error> {
+                while map
+                    .next_entry::<serde::de::IgnoredAny, serde::de::IgnoredAny>()?
+                    .is_some()
+                {}
+                Ok(MaybeName::NotAName)
+            }
+            fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(MaybeName::NotAName)
+            }
+            fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(MaybeName::NotAName)
+            }
+            fn visit_bool<E: serde::de::Error>(self, _: bool) -> Result<Self::Value, E> {
+                Ok(MaybeName::NotAName)
+            }
+            fn visit_i64<E: serde::de::Error>(self, _: i64) -> Result<Self::Value, E> {
+                Ok(MaybeName::NotAName)
+            }
+            fn visit_u64<E: serde::de::Error>(self, _: u64) -> Result<Self::Value, E> {
+                Ok(MaybeName::NotAName)
+            }
+            fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<Self::Value, E> {
+                Ok(MaybeName::NotAName)
+            }
+            fn visit_bytes<E: serde::de::Error>(self, _: &[u8]) -> Result<Self::Value, E> {
+                Ok(MaybeName::NotAName)
+            }
+        }
+        deserializer.deserialize_any(NameVisitor)
+    }
+}
+
+/// The longest name CEP 26 allows, for a package or a virtual package.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+const MAX_NAME_LENGTH: usize = 64;
+
+/// The most virtual packages CEP XXXX lets one plugin register, which bounds
+/// how much a single plugin can feed into a solve.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+const MAX_VIRTUAL_PACKAGES_PER_PLUGIN: usize = 16;
+
+/// The distributable package name rule of CEP 26. `fancy_regex` is used
+/// because the pattern needs the negative lookahead that keeps a leading
+/// underscore from being followed by another.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+static PACKAGE_NAME: std::sync::LazyLock<fancy_regex::Regex> = std::sync::LazyLock::new(|| {
+    #[allow(clippy::expect_used, reason = "the pattern is a literal from CEP 26")]
+    fancy_regex::Regex::new(r"(?i)^(([a-z0-9])|([a-z0-9_](?!_)))[._-]?([a-z0-9]+(\.|-|_|$))*$")
+        .expect("the CEP 26 package name pattern is valid")
+});
+
+/// The virtual package name rule of CEP 26.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+static VIRTUAL_PACKAGE_NAME: std::sync::LazyLock<fancy_regex::Regex> =
+    std::sync::LazyLock::new(|| {
+        #[allow(clippy::expect_used, reason = "the pattern is a literal from CEP 26")]
+        fancy_regex::Regex::new(r"^__[a-z0-9][._-]?([a-z0-9]+(\.|-|_|$))*$")
+            .expect("the CEP 26 virtual package name pattern is valid")
+    });
+
+/// Whether a name a channel published satisfies one of the CEP 26 patterns.
+///
+/// Matched against the spelling the channel published, not the normalized form.
+/// Normalizing first would lowercase the name and so accept an uppercase
+/// virtual package name, which CEP 26 does not allow: it states the virtual
+/// pattern in lowercase and, unlike the distributable one, does not call it
+/// case-insensitive. The distributable pattern carries its own `(?i)`, so a
+/// mixed-case plugin key still passes.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+fn matches(pattern: &fancy_regex::Regex, name: &crate::PackageName) -> bool {
+    let name = name.as_source();
+    name.len() <= MAX_NAME_LENGTH && pattern.is_match(name).unwrap_or(false)
+}
+
+/// Validates the name of the package providing a plugin. The key names the
+/// package a client installs and the executable it then runs, so a key that is
+/// not a package name has not said what the channel meant. A virtual package
+/// name is rejected with it: nothing serves a virtual package, and the CEP 26
+/// package name rule already excludes the `__` prefix.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+fn validated_plugin_name(name: String) -> Result<crate::PackageName, String> {
+    let source = name.clone();
+    let name = crate::PackageName::try_from(name)
+        .map_err(|err| format!("'{source}' is not a package name: {err}"))?;
+    if !matches(&PACKAGE_NAME, &name) {
+        return Err(format!("'{}' is not a package name", name.as_source()));
+    }
+    Ok(name)
+}
+
+/// Validates a name a plugin claims to provide, which CEP 26 requires to be a
+/// package name carrying the `__` prefix.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+fn validated_virtual_package_name(name: String) -> Option<crate::PackageName> {
+    let name = crate::PackageName::try_from(name)
+        .inspect_err(|err| tracing::warn!("ignoring registered virtual package name: {err}"))
+        .ok()?;
+    if !matches(&VIRTUAL_PACKAGE_NAME, &name) {
+        tracing::warn!(
+            "ignoring registered virtual package '{}': it is not a virtual package name",
+            name.as_source()
+        );
+        return None;
+    }
+    Some(name)
+}
+
 /// A helper function used to sort map alphabetically when serializing.
 pub(crate) fn sort_map_alphabetically<K: Ord + Serialize, T: Serialize, H, S: serde::Serializer>(
     value: &HashMap<K, T, H>,

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -28,6 +28,9 @@ rustls = [
   "opendal/reqwest-rustls-tls",
 ]
 s3 = ["opendal/services-s3", "dep:rattler_s3"]
+experimental-virtual-package-plugins = [
+  "rattler_conda_types/experimental-virtual-package-plugins",
+]
 
 [[bin]]
 name = "rattler-index"

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -950,6 +950,8 @@ async fn index_subdir_inner(
                 &v3,
             ),
             channel_relations: channel_metadata.channel_relations,
+            #[cfg(feature = "experimental-virtual-package-plugins")]
+            virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
         }),
         packages,
         conda_packages,
@@ -1408,6 +1410,8 @@ pub async fn write_repodata(
                 created_at: Some(jiff::Timestamp::now()),
                 repodata_revisions: sharded_repodata_revisions,
                 channel_relations: sharded_channel_relations,
+                #[cfg(feature = "experimental-virtual-package-plugins")]
+                virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
             },
             shards: shards
                 .iter()
@@ -1891,6 +1895,8 @@ pub async fn ensure_channel_initialized_with_channel_metadata(
             base_url: channel_metadata.base_url,
             repodata_revisions: RepodataRevisions::new(),
             channel_relations: channel_metadata.channel_relations,
+            #[cfg(feature = "experimental-virtual-package-plugins")]
+            virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
         }),
         packages: IndexMap::default(),
         conda_packages: IndexMap::default(),

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -110,6 +110,7 @@ native-tls = ['reqwest/native-tls', 'rattler_networking/native-tls', 'rattler_ca
 rustls = ['reqwest/rustls', 'rattler_networking/rustls', 'rattler_cache/rustls', 'rattler_redaction/rustls']
 sparse = ["rattler_conda_types", "memmap2", "self_cell", "superslice", "itertools", "serde_json/raw_value"]
 gateway = ["sparse", "http", "http-cache-semantics", "parking_lot", "async-trait", "rattler_package_streaming"]
+experimental-virtual-package-plugins = ["rattler_conda_types?/experimental-virtual-package-plugins"]
 
 [package.metadata.docs.rs]
 features = ["sparse", "gateway"]

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -223,6 +223,9 @@ mod tests {
                     created_at: Some(jiff::Timestamp::now()),
                     repodata_revisions: RepodataRevisions::default(),
                     channel_relations: None,
+                    #[cfg(feature = "experimental-virtual-package-plugins")]
+                    virtual_package_plugins:
+                        rattler_conda_types::VirtualPackagePlugins::default(),
                 },
                 shards,
             };


### PR DESCRIPTION
... in the rattler_conda_types layer.

All changes are behind the `experimental-virtual-package-plugins` feature flag.

### How Has This Been Tested?

With unit tests and within the wider set of changes that sits on top of this.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.