### PR TITLE
ci(py-rattler): build aarch64 windows and riscv64 wheels

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -155,13 +155,14 @@ jobs:
             arch: armv7
             manylinux: "2_28"
             distro: ubuntu22.04
-          # riscv64 has no manylinux_2_28 image, and run-on-arch only ships a
-          # riscv64 rootfs for ubuntu20.04, so it carries its own pair.
+          # riscv64 has no manylinux_2_28 image, so it builds against 2_31.
+          # The distro still has to carry python 3.10 or newer for our abi3
+          # wheel, which rules out the ubuntu20.04 rootfs.
           - target: riscv64gc-unknown-linux-gnu
             runner: ubuntu-latest
             arch: riscv64
             manylinux: "2_31"
-            distro: ubuntu20.04
+            distro: ubuntu22.04
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -235,11 +236,9 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
           args: --release --out dist --no-default-features --features native-tls,vendored-openssl,pty
-      # Skipped for both PowerPC targets: the emulated container hangs in
-      # apt-get while installing Python. uv dropped the same step for the
-      # same reason in astral-sh/uv#11229 and has never restored it.
+      # Only ppc64le: run-on-arch ships no rootfs for big endian ppc64.
       - uses: uraimo/run-on-arch-action@460cb8e6d9f726a588fc9b5e681c8a6cab09ae41 # v3.2.0
-        if: ${{ !startsWith(matrix.platform.arch, 'ppc64') }}
+        if: matrix.platform.arch != 'ppc64'
         name: Test wheel
         with:
           arch: ${{ matrix.platform.arch }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: "Build sdist"
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: py-rattler
           command: sdist
@@ -58,20 +58,23 @@ jobs:
           path: py-rattler/dist
 
   windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.platform.runner }}
     name: Build ${{ matrix.platform.target }}
     strategy:
       fail-fast: false
       matrix:
         platform:
           - target: x86_64-pc-windows-msvc
+            runner: windows-latest
             arch: x64
           - target: i686-pc-windows-msvc
+            runner: windows-latest
             arch: x86
-    #     There are a number of issues with cross compiling ring to windows on aarch64.
-    #     For now, we just won't build a wheel, we will revisit this in the future.
-    #      - target: aarch64-pc-windows-msvc
-    #        arch: x64
+          # Cross compiling ring to aarch64-windows is what kept this target
+          # off the list, so build it on a native arm64 runner instead.
+          - target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
+            arch: arm64
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -81,13 +84,12 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.platform.arch }}
       - name: "Build wheels"
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           args: --release --out dist --no-default-features --features rustls
       - name: "Test wheel"
-        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
         run: |
           python -m pip install py-rattler/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
@@ -116,7 +118,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - name: "Build wheels"
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: py-rattler
           target: ${{ matrix.target }}
@@ -145,8 +147,18 @@ jobs:
         platform:
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
+            manylinux: "2_28"
+            distro: ubuntu22.04
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7
+            manylinux: "2_28"
+            distro: ubuntu22.04
+          # riscv64 has no manylinux_2_28 image, and run-on-arch only ships a
+          # riscv64 rootfs for ubuntu20.04, so it carries its own pair.
+          - target: riscv64gc-unknown-linux-gnu
+            arch: riscv64
+            manylinux: "2_31"
+            distro: ubuntu20.04
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -156,18 +168,17 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: "Build wheels"
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
-          manylinux: "2_28"
+          manylinux: ${{ matrix.platform.manylinux }}
           args: --release --out dist  --no-default-features --features rustls,pty
       - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
-        if: matrix.platform.arch != 'ppc64'
         name: Test wheel
         with:
           arch: ${{ matrix.platform.arch }}
-          distro: ubuntu22.04
+          distro: ${{ matrix.platform.distro }}
           githubToken: ${{ github.token }}
           install: |
             apt-get update
@@ -209,7 +220,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: "Build wheels"
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
@@ -257,7 +268,7 @@ jobs:
           architecture: x64
       - name: "Build wheels (rustls)"
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: py-rattler
           target: ${{ matrix.target }}
@@ -265,7 +276,7 @@ jobs:
           args: --release --out dist --no-default-features --features rustls,pty
       - name: "Build wheels (native-tls)"
         if: matrix.target != 'x86_64-unknown-linux-musl'
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: py-rattler
           target: ${{ matrix.target }}
@@ -299,6 +310,8 @@ jobs:
             arch: aarch64
           - target: armv7-unknown-linux-musleabihf
             arch: armv7
+          - target: riscv64gc-unknown-linux-musl
+            arch: riscv64
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -308,7 +321,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: "Build wheels"
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
@@ -343,7 +356,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - name: "Build wheels - x86_64"
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           working-directory: py-rattler
           target: x86_64
@@ -370,7 +383,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
       - name: "Build wheels - universal2"
-        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           args: --release --target universal2-apple-darwin --out dist --no-default-features --features rustls,pty
           working-directory: py-rattler

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -183,6 +183,17 @@ jobs:
         run: |
           pip install py-rattler/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
           python3 -c "import rattler; print(rattler.__version__)"
+      # run-on-arch runs `apt update` on the runner before it configures QEMU,
+      # and apt retries a failing mirror instead of moving on to the next one.
+      - name: "Bound apt on the runner"
+        if: ${{ matrix.platform.distro }}
+        run: |
+          cat /etc/apt/apt-mirrors.txt || true
+          printf '%s\n' \
+            'Acquire::Retries "0";' \
+            'Acquire::http::Timeout "10";' \
+            'Acquire::https::Timeout "10";' \
+            | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
       - uses: uraimo/run-on-arch-action@460cb8e6d9f726a588fc9b5e681c8a6cab09ae41 # v3.2.0
         if: ${{ matrix.platform.distro }}
         name: Test wheel (emulated)
@@ -236,6 +247,17 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
           args: --release --out dist --no-default-features --features native-tls,vendored-openssl,pty
+      # run-on-arch runs `apt update` on the runner before it configures QEMU,
+      # and apt retries a failing mirror instead of moving on to the next one.
+      - name: "Bound apt on the runner"
+        if: matrix.platform.arch != 'ppc64'
+        run: |
+          cat /etc/apt/apt-mirrors.txt || true
+          printf '%s\n' \
+            'Acquire::Retries "0";' \
+            'Acquire::http::Timeout "10";' \
+            'Acquire::https::Timeout "10";' \
+            | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
       # Only ppc64le: run-on-arch ships no rootfs for big endian ppc64.
       - uses: uraimo/run-on-arch-action@460cb8e6d9f726a588fc9b5e681c8a6cab09ae41 # v3.2.0
         if: matrix.platform.arch != 'ppc64'
@@ -351,6 +373,17 @@ jobs:
             apk add py3-pip
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/py-rattler/dist/ --force-reinstall --break-system-packages
             python3 -c "import rattler; print(rattler.__version__)"
+      # run-on-arch runs `apt update` on the runner before it configures QEMU,
+      # and apt retries a failing mirror instead of moving on to the next one.
+      - name: "Bound apt on the runner"
+        if: ${{ matrix.platform.distro }}
+        run: |
+          cat /etc/apt/apt-mirrors.txt || true
+          printf '%s\n' \
+            'Acquire::Retries "0";' \
+            'Acquire::http::Timeout "10";' \
+            'Acquire::https::Timeout "10";' \
+            | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
       - uses: uraimo/run-on-arch-action@460cb8e6d9f726a588fc9b5e681c8a6cab09ae41 # v3.2.0
         if: ${{ matrix.platform.distro }}
         name: Test wheel (emulated)

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -174,7 +174,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
           args: --release --out dist  --no-default-features --features rustls,pty
-      - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
+      - uses: uraimo/run-on-arch-action@460cb8e6d9f726a588fc9b5e681c8a6cab09ae41 # v3.2.0
         name: Test wheel
         with:
           arch: ${{ matrix.platform.arch }}
@@ -229,7 +229,7 @@ jobs:
       # Skipped for both PowerPC targets: the emulated container hangs in
       # apt-get while installing Python. uv dropped the same step for the
       # same reason in astral-sh/uv#11229 and has never restored it.
-      - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
+      - uses: uraimo/run-on-arch-action@460cb8e6d9f726a588fc9b5e681c8a6cab09ae41 # v3.2.0
         if: ${{ !startsWith(matrix.platform.arch, 'ppc64') }}
         name: Test wheel
         with:
@@ -327,7 +327,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
           args: --release --out dist --no-default-features --features rustls,pty
-      - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
+      - uses: uraimo/run-on-arch-action@460cb8e6d9f726a588fc9b5e681c8a6cab09ae41 # v3.2.0
         name: Test wheel
         with:
           arch: ${{ matrix.platform.arch }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -136,26 +136,29 @@ jobs:
           path: py-rattler/dist
 
   linux-cross:
-    runs-on: ubuntu-latest
-    # The QEMU test step normally runs in a couple of minutes; anything much
-    # longer is a hang, not slow progress.
+    runs-on: ${{ matrix.platform.runner }}
+    # Entries with a distro test under QEMU, which normally takes a couple of
+    # minutes; anything much longer is a hang, not slow progress.
     timeout-minutes: 30
     name: Build ${{ matrix.platform.target }}
     strategy:
       fail-fast: false
       matrix:
         platform:
+          # Native arm64 runner, so no distro: this one builds in the aarch64
+          # manylinux image and tests on the host, no emulation anywhere.
           - target: aarch64-unknown-linux-gnu
-            arch: aarch64
+            runner: ubuntu-24.04-arm
             manylinux: "2_28"
-            distro: ubuntu22.04
           - target: armv7-unknown-linux-gnueabihf
+            runner: ubuntu-latest
             arch: armv7
             manylinux: "2_28"
             distro: ubuntu22.04
           # riscv64 has no manylinux_2_28 image, and run-on-arch only ships a
           # riscv64 rootfs for ubuntu20.04, so it carries its own pair.
           - target: riscv64gc-unknown-linux-gnu
+            runner: ubuntu-latest
             arch: riscv64
             manylinux: "2_31"
             distro: ubuntu20.04
@@ -174,8 +177,14 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
           args: --release --out dist  --no-default-features --features rustls,pty
+      - name: "Test wheel"
+        if: ${{ !matrix.platform.distro }}
+        run: |
+          pip install py-rattler/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          python3 -c "import rattler; print(rattler.__version__)"
       - uses: uraimo/run-on-arch-action@460cb8e6d9f726a588fc9b5e681c8a6cab09ae41 # v3.2.0
-        name: Test wheel
+        if: ${{ matrix.platform.distro }}
+        name: Test wheel (emulated)
         with:
           arch: ${{ matrix.platform.arch }}
           distro: ${{ matrix.platform.distro }}
@@ -299,19 +308,25 @@ jobs:
           path: py-rattler/dist
 
   musllinux-cross:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 30
     name: Build ${{ matrix.platform.target }}
     strategy:
       fail-fast: false
       matrix:
         platform:
+          # Native arm64 runner, so no distro: this one tests in a plain alpine
+          # container on the host, the same way the x86_64 musllinux job does.
           - target: aarch64-unknown-linux-musl
-            arch: aarch64
+            runner: ubuntu-24.04-arm
           - target: armv7-unknown-linux-musleabihf
+            runner: ubuntu-latest
             arch: armv7
+            distro: alpine_latest
           - target: riscv64gc-unknown-linux-musl
+            runner: ubuntu-latest
             arch: riscv64
+            distro: alpine_latest
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -327,11 +342,22 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
           args: --release --out dist --no-default-features --features rustls,pty
+      - name: "Test wheel"
+        if: ${{ !matrix.platform.distro }}
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
+        with:
+          image: alpine:latest
+          options: -v ${{ github.workspace }}:/io -w /io
+          run: |
+            apk add py3-pip
+            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/py-rattler/dist/ --force-reinstall --break-system-packages
+            python3 -c "import rattler; print(rattler.__version__)"
       - uses: uraimo/run-on-arch-action@460cb8e6d9f726a588fc9b5e681c8a6cab09ae41 # v3.2.0
-        name: Test wheel
+        if: ${{ matrix.platform.distro }}
+        name: Test wheel (emulated)
         with:
           arch: ${{ matrix.platform.arch }}
-          distro: alpine_latest
+          distro: ${{ matrix.platform.distro }}
           githubToken: ${{ github.token }}
           install: |
             apk add py3-pip


### PR DESCRIPTION
### Description

Three targets we do not ship wheels for today, where nothing is actually stopping us.

`aarch64-pc-windows-msvc` was commented out because cross compiling ring to it did not work. `windows-11-arm` is a GitHub-hosted arm64 runner, free for public repos, so that reason is gone: it builds natively and the wheel gets tested on the machine that built it.

`riscv64gc`, gnu and musl. It needs manylinux_2_31 rather than 2_28, so `linux-cross` reads `manylinux` and `distro` off the matrix now instead of hardcoding one pair.

maturin-action goes to v1.51.0. v1.49.4 has no container mapping for `riscv64gc-unknown-linux-musl`, so it fell back to building on the host and died on a missing `riscv64-linux-musl-gcc`. v1.51.0 maps it to `rust-musl-cross:riscv64gc-musl`.

Both aarch64 targets move to `ubuntu-24.04-arm`, also free for public repos, which takes two of the six emulated jobs off QEMU entirely. The build goes native too: maturin-action keys its container table on the host arch, so on arm64 it picks `manylinux_2_28_aarch64` rather than the x86_64 cross image. Whether an entry emulates is now a matter of whether it sets a `distro`.

run-on-arch-action goes to v3.2.0. v3.0.1 is from April 2025 and still on node20, which GitHub is retiring. The emulated test steps were running long on an earlier push, so this is partly a shot at that, but nothing in the v3.1.0 or v3.2.0 notes mentions it.

ppc64le gets its wheel test back, and the hang that #2696 worked around turns out not to be about PowerPC at all. `run-on-arch.sh` runs `sudo apt update` on the runner before it configures QEMU, and when `azure.archive.ubuntu.com` goes bad apt retries it, falls through to `archive.ubuntu.com`, then stalls mid download with nothing bounding the wait. The emulated container never starts. So the emulated jobs now set `Acquire::Retries "0"` and a 10 second timeout first, which is what uv landed for the same stall in astral-sh/uv#21198.

The guard goes back to skipping only big endian ppc64, which run-on-arch has no rootfs for.

Also drops the `arch != 'ppc64'` guard on the `linux-cross` test step. No PowerPC target is in that job's matrix, so it never did anything.

### How Has This Been Tested?

`actionlint` and `pixi run dprint-check` pass. Beyond that it is CI's job, `release-python.yml` triggers on changes to itself so this PR builds all 17 targets. The maturin-action bump touches every build job, so the run also covers the existing 14.

Where the previous run got to, 16 of 18 green:

| target | result |
| --- | --- |
| `aarch64-pc-windows-msvc` | 12m22s, native runner |
| `aarch64-unknown-linux-gnu` | 6m14s, was 11m45s under QEMU |
| `aarch64-unknown-linux-musl` | 6m21s, was 7m32s under QEMU |
| `armv7-unknown-linux-gnueabihf` | 10m59s |
| `armv7-unknown-linux-musleabihf` | 9m52s |
| `riscv64gc-unknown-linux-musl` | 9m41s |
| `powerpc64le-unknown-linux-gnu` | built, apt stalled, cut at 30m |
| `riscv64gc-unknown-linux-gnu` | built, apt stalled, cut at 30m |

Both of the two that failed died in the runner's apt, before their container started, so the ubuntu22.04 change for riscv64 is still unproven. The 30 minute cap is doing its job in the meantime.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
