### PR TITLE
feat(conda-types): implement virtual package plugins

### DIFF
--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -13,6 +13,9 @@ readme.workspace = true
 default = ["rustls"]
 rustls = ["reqwest/rustls", "reqwest-middleware/rustls", "rattler_networking/rustls", "rattler_package_streaming/rustls"]
 native-tls = ["reqwest/native-tls", "rattler_networking/native-tls", "rattler_package_streaming/native-tls"]
+experimental-virtual-package-plugins = [
+  "rattler_conda_types/experimental-virtual-package-plugins",
+]
 
 [dependencies]
 

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -14,6 +14,7 @@ readme.workspace = true
 [features]
 default = ["rayon"]
 semver = ["rattler_conda_version/semver"]
+experimental-virtual-package-plugins = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/rattler_conda_types/src/lib.rs
+++ b/crates/rattler_conda_types/src/lib.rs
@@ -33,6 +33,8 @@ pub mod prefix;
 pub mod prefix_data;
 pub mod prefix_record;
 mod record_traits;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+mod sourced_virtual_package;
 
 #[cfg(test)]
 use std::path::{Path, PathBuf};
@@ -78,6 +80,8 @@ pub use rattler_conda_version::version_spec::{
 };
 pub use rattler_conda_version::{ParseStrictness, Version, VersionSpec};
 pub use record_traits::HasArtifactIdentificationRefs;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub use repo_data::VirtualPackagePlugins;
 pub use repo_data::{
     ChannelInfo, ChannelRelations, ConvertSubdirError, PackageRecord, RecordFromPath, RepoData,
     RepodataRevision, RepodataRevisionInfo, RepodataRevisionMetadata, RepodataRevisionSelection,
@@ -88,6 +92,8 @@ pub use repo_data::{
 };
 pub use repo_data_record::{RepoDataRecord, SolverResult};
 pub use run_export::RunExportKind;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub use sourced_virtual_package::{SourcedVirtualPackage, VirtualPackageSource};
 
 /// An package identifier that can be used to identify packages across package
 /// ecosystems.

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -24,6 +24,8 @@ use serde_with::{
 use thiserror::Error;
 use url::Url;
 
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use crate::utils::serde::DeserializeVirtualPackagePlugins;
 use crate::{
     Arch, Channel, Flag, MatchSpec, Matches, NoArchType, PackageName, PackageUrl,
     ParseMatchSpecError, ParseStrictness, Platform, RepoDataRecord, VersionWithSource,
@@ -107,7 +109,18 @@ pub struct ChannelInfo {
     /// [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
     #[serde(default, skip_serializing_if = "ChannelRelations::is_none_or_empty")]
     pub channel_relations: Option<ChannelRelations>,
+
+    /// Virtual package detection plugins registered by the channel.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[serde_as(deserialize_as = "DeserializeVirtualPackagePlugins")]
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub virtual_package_plugins: VirtualPackagePlugins,
 }
+
+/// Virtual package detection plugins registered by a channel: the name of the
+/// package providing the plugin, mapped to the virtual packages it provides.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub type VirtualPackagePlugins = IndexMap<PackageName, Vec<PackageName>>;
 
 /// Repodata revisions keyed by revision, mirroring the `vN` dictionary of the
 /// CEP draft <https://github.com/conda/ceps/pull/146>. Keying encodes
@@ -1226,6 +1239,8 @@ mod test {
         package::DistArchiveIdentifier,
         repo_data::{compute_package_url, determine_subdir},
     };
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    use crate::{PackageName, repo_data::VirtualPackagePlugins};
 
     // isl-0.12.2-1.tar.bz2
     // gmp-5.1.2-6.tar.bz2
@@ -1308,6 +1323,8 @@ mod test {
                     base: Some("../conda-forge".to_string()),
                     overrides: None,
                 }),
+                #[cfg(feature = "experimental-virtual-package-plugins")]
+                virtual_package_plugins: VirtualPackagePlugins::default(),
             }),
             packages: IndexMap::default(),
             conda_packages: IndexMap::default(),
@@ -1330,6 +1347,8 @@ mod test {
                     base_url: None,
                     repodata_revisions: IndexMap::default(),
                     channel_relations,
+                    #[cfg(feature = "experimental-virtual-package-plugins")]
+                    virtual_package_plugins: VirtualPackagePlugins::default(),
                 }),
                 packages: IndexMap::default(),
                 conda_packages: IndexMap::default(),
@@ -1339,6 +1358,411 @@ mod test {
             let json = serde_json::to_string(&repodata).unwrap();
             assert!(!json.contains("channel_relations"));
         }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins() {
+        // A single plugin may provide several virtual packages; the order of
+        // both the plugins and their virtual packages is preserved.
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "foobar-detect": ["__foobar", "__something_else"],
+                    "rocm-detect": ["__rocm"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        let plugins = &repodata.info.as_ref().unwrap().virtual_package_plugins;
+
+        assert_eq!(
+            plugins
+                .keys()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["foobar-detect", "rocm-detect"]
+        );
+        assert_eq!(
+            plugins[&PackageName::new_unchecked("foobar-detect")]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__foobar", "__something_else"]
+        );
+        assert_eq!(
+            plugins[&PackageName::new_unchecked("rocm-detect")]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__rocm"]
+        );
+
+        let json = serde_json::to_string(&repodata).unwrap();
+        assert!(json.contains("\"virtual_package_plugins\""));
+        assert_eq!(serde_json::from_str::<RepoData>(&json).unwrap(), repodata);
+
+        let without = RepoData {
+            version: Some(2),
+            info: Some(ChannelInfo {
+                subdir: Some("linux-64".to_string()),
+                base_url: None,
+                repodata_revisions: IndexMap::default(),
+                channel_relations: None,
+                virtual_package_plugins: VirtualPackagePlugins::default(),
+            }),
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            v3: V3Packages::default(),
+            removed: ahash::HashSet::default(),
+        };
+        assert!(
+            !serde_json::to_string(&without)
+                .unwrap()
+                .contains("virtual_package_plugins")
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_contradictions_drop_the_whole_section() {
+        let seventeen: Vec<String> = (0..17).map(|index| format!("\"__v{index}\"")).collect();
+        for (label, body) in [
+            ("not a map", "null".to_string()),
+            ("not a map either", r#"["cuda-detect"]"#.to_string()),
+            (
+                "key is not a package name",
+                r#"{"invalid$plugin": ["__cuda"]}"#.to_string(),
+            ),
+            (
+                "key is a virtual package name",
+                r#"{"__leading": ["__cuda"]}"#.to_string(),
+            ),
+            (
+                "one package under two keys",
+                r#"{"A-Detect": ["__x"], "a-detect": ["__y"]}"#.to_string(),
+            ),
+            (
+                "the same key twice",
+                r#"{"a-detect": ["__x"], "a-detect": ["__y"]}"#.to_string(),
+            ),
+            (
+                "one virtual package from two plugins",
+                r#"{"cuda-detect": ["__cuda"], "other-detect": ["__cuda"]}"#.to_string(),
+            ),
+            (
+                "one virtual package twice in one plugin",
+                r#"{"cuda-detect": ["__cuda", "__cuda"]}"#.to_string(),
+            ),
+            (
+                "no virtual packages declared",
+                r#"{"empty-detect": []}"#.to_string(),
+            ),
+            (
+                "a registration value that is a string",
+                r#"{"cuda-detect": "__cuda"}"#.to_string(),
+            ),
+            (
+                "a registration value that is null",
+                r#"{"cuda-detect": null}"#.to_string(),
+            ),
+            (
+                "a registration value that is a number",
+                r#"{"cuda-detect": 5}"#.to_string(),
+            ),
+            (
+                "a registration value that is a map",
+                r#"{"cuda-detect": {"__cuda": true}}"#.to_string(),
+            ),
+            (
+                "a valid registration next to a malformed one",
+                r#"{"good-detect": ["__good"], "bad-detect": 5}"#.to_string(),
+            ),
+            (
+                "more than sixteen declared",
+                format!(r#"{{"big-detect": [{}]}}"#, seventeen.join(", ")),
+            ),
+        ] {
+            let raw = format!(
+                r#"{{
+                    "info": {{ "subdir": "linux-64", "virtual_package_plugins": {body} }},
+                    "packages": {{}},
+                    "packages.conda": {{}},
+                    "repodata_version": 2
+                }}"#
+            );
+            let repodata: RepoData = serde_json::from_str(&raw)
+                .unwrap_or_else(|err| panic!("{label} invalidated the repodata: {err}"));
+            assert!(
+                repodata
+                    .info
+                    .as_ref()
+                    .unwrap()
+                    .virtual_package_plugins
+                    .is_empty(),
+                "{label} left registrations behind"
+            );
+            assert_eq!(
+                repodata.info.as_ref().unwrap().subdir.as_deref(),
+                Some("linux-64"),
+                "{label} lost the rest of the info dictionary"
+            );
+        }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_virtual_names_are_lowercase_only() {
+        // CEP 26 states the virtual package pattern in lowercase and, unlike
+        // the distributable one, does not call it case-insensitive.
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "CUDA-Detect": ["__cuda", "__Foo_Bar"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        let plugins = &repodata.info.as_ref().unwrap().virtual_package_plugins;
+
+        assert_eq!(
+            plugins[&PackageName::try_from("cuda-detect").unwrap()]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda"],
+            "an uppercase virtual package name was kept"
+        );
+        assert_eq!(
+            plugins
+                .keys()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["CUDA-Detect"],
+            "a mixed-case plugin key was rejected, though CEP 26 calls that pattern \
+             case-insensitive"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_non_string_value_is_ignored() {
+        // Not a package name in any sense, so it is discarded like any other
+        // invalid name rather than invalidating the surrounding repodata.
+        for entry in ["5", "null", "[\"__x\"]", "{\"a\": 1}", "true"] {
+            let raw = format!(
+                r#"{{
+                    "info": {{
+                        "subdir": "linux-64",
+                        "virtual_package_plugins": {{ "cuda-detect": ["__cuda", {entry}] }}
+                    }},
+                    "packages": {{}},
+                    "packages.conda": {{}}
+                }}"#
+            );
+            let repodata: RepoData = serde_json::from_str(&raw)
+                .unwrap_or_else(|err| panic!("{entry} invalidated the repodata: {err}"));
+            assert_eq!(
+                repodata.info.as_ref().unwrap().virtual_package_plugins
+                    [&PackageName::try_from("cuda-detect").unwrap()]
+                    .iter()
+                    .map(PackageName::as_source)
+                    .collect::<Vec<_>>(),
+                ["__cuda"],
+                "{entry} did not leave the plugin's other names intact"
+            );
+        }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_invalid_value_is_ignored() {
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "cuda-detect": ["__cuda", "__", "cuda", "_cuda", "__a--b"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            repodata.info.as_ref().unwrap().virtual_package_plugins
+                [&PackageName::try_from("cuda-detect").unwrap()]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda"],
+            "a value CEP 26 does not allow as a virtual package name was kept"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_reject_non_virtual_names() {
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "cuda-detect": ["__cuda", "cuda", "_cuda"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        let plugins = &repodata.info.as_ref().unwrap().virtual_package_plugins;
+        assert_eq!(
+            plugins[&PackageName::try_from("cuda-detect").unwrap()]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda"],
+            "a name without the '__' prefix was registered as a virtual package"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_drop_plugins_providing_nothing() {
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": {
+                    "bogus-detect": ["cuda", "invalid$virtual"],
+                    "cuda-detect": ["__cuda"]
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            repodata
+                .info
+                .as_ref()
+                .unwrap()
+                .virtual_package_plugins
+                .keys()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["cuda-detect"],
+            "a plugin whose every declared name was invalid was kept"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_names_are_normalized() {
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "virtual_package_plugins": { "CUDA-Detect": ["__cuda"] }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        let plugins = &repodata.info.as_ref().unwrap().virtual_package_plugins;
+
+        let plugin = PackageName::try_from("cuda-detect").unwrap();
+        assert!(
+            plugins.contains_key(&plugin),
+            "a registration is unreachable by the plugin's normalized name"
+        );
+        assert!(
+            plugins[&plugin].contains(&PackageName::try_from("__cuda").unwrap()),
+            "a provided virtual package never matches the detected name"
+        );
+        assert_eq!(
+            plugins.keys().next().unwrap().as_source(),
+            "CUDA-Detect",
+            "the spelling the channel published was not preserved"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_deep_nesting_does_not_reject_the_document() {
+        let deep = format!("{}{}", "[".repeat(150), "]".repeat(150));
+
+        // Nested junk where a name belongs is dropped alone.
+        let raw = format!(
+            r#"{{
+                "info": {{
+                    "subdir": "linux-64",
+                    "virtual_package_plugins": {{ "cuda-detect": ["__cuda", {deep}] }}
+                }},
+                "packages": {{}},
+                "packages.conda": {{}}
+            }}"#
+        );
+        let repodata: RepoData = serde_json::from_str(&raw)
+            .unwrap_or_else(|err| panic!("a nested element invalidated the repodata: {err}"));
+        assert_eq!(
+            repodata.info.as_ref().unwrap().virtual_package_plugins
+                [&PackageName::try_from("cuda-detect").unwrap()]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda"],
+            "a deeply nested element was not dropped alone"
+        );
+
+        // Nested junk where the registration array belongs drops the section.
+        let deep_maps = format!("{}0{}", r#"{"a":"#.repeat(150), "}".repeat(150));
+        let raw = format!(
+            r#"{{
+                "info": {{
+                    "subdir": "linux-64",
+                    "virtual_package_plugins": {{ "cuda-detect": {deep_maps} }}
+                }},
+                "packages": {{}},
+                "packages.conda": {{}}
+            }}"#
+        );
+        let repodata: RepoData = serde_json::from_str(&raw)
+            .unwrap_or_else(|err| panic!("a nested value invalidated the repodata: {err}"));
+        assert!(
+            repodata
+                .info
+                .as_ref()
+                .unwrap()
+                .virtual_package_plugins
+                .is_empty(),
+            "a registration value that is not an array was kept"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_virtual_package_plugins_roundtrip_keeps_identity() {
+        let mut plugins = VirtualPackagePlugins::default();
+        plugins.insert(
+            PackageName::try_from("CUDA-Detect").unwrap(),
+            vec![PackageName::try_from("__cuda").unwrap()],
+        );
+        let info = ChannelInfo {
+            subdir: Some("linux-64".to_string()),
+            base_url: None,
+            repodata_revisions: IndexMap::default(),
+            channel_relations: None,
+            virtual_package_plugins: plugins.clone(),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        let back: ChannelInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.virtual_package_plugins, plugins,
+            "a validated registration changed identity through a round trip ({json})"
+        );
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/repo_data/sharded.rs
+++ b/crates/rattler_conda_types/src/repo_data/sharded.rs
@@ -2,7 +2,11 @@
 
 use crate::PackageRecord;
 use crate::package::DistArchiveIdentifier;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use crate::repo_data::VirtualPackagePlugins;
 use crate::repo_data::{ChannelRelations, RepodataRevisions, V3Packages};
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use crate::utils::serde::DeserializeVirtualPackagePlugins;
 use crate::utils::serde::{sort_index_map_alphabetically, sort_set_alphabetically};
 use indexmap::IndexMap;
 use jiff::Timestamp;
@@ -60,6 +64,12 @@ pub struct ShardedSubdirInfo {
     /// [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
     #[serde(default, skip_serializing_if = "ChannelRelations::is_none_or_empty")]
     pub channel_relations: Option<ChannelRelations>,
+
+    /// Virtual package detection plugins registered by the channel.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[serde_as(deserialize_as = "DeserializeVirtualPackagePlugins")]
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub virtual_package_plugins: VirtualPackagePlugins,
 }
 
 #[cfg(test)]
@@ -74,10 +84,6 @@ mod tests {
         shards: serde::de::IgnoredAny,
     }
 
-    /// Shards are content-addressed (stored under the hash of their bytes), so
-    /// serialization must not depend on the insertion order of the underlying
-    /// maps and sets — otherwise every producer run writes a fresh shard file
-    /// and orphans the previous one.
     #[test]
     fn test_shard_serialization_is_insertion_order_independent() {
         let entry = |n: u64| {
@@ -121,6 +127,8 @@ mod tests {
                 created_at: None,
                 repodata_revisions: IndexMap::default(),
                 channel_relations: None,
+                #[cfg(feature = "experimental-virtual-package-plugins")]
+                virtual_package_plugins: VirtualPackagePlugins::default(),
             },
             shards: ahash::HashMap::default(),
         };
@@ -133,7 +141,6 @@ mod tests {
         assert_eq!(decoded.info.subdir, "linux-64");
     }
 
-    // See https://github.com/conda/ceps/blob/main/cep-0042.md
     #[test]
     fn test_sharded_subdir_info_channel_relations() {
         // Deserialize a sharded index with channel_relations.
@@ -160,10 +167,87 @@ mod tests {
                 created_at: None,
                 repodata_revisions: IndexMap::default(),
                 channel_relations,
+                #[cfg(feature = "experimental-virtual-package-plugins")]
+                virtual_package_plugins: VirtualPackagePlugins::default(),
             };
             let json = serde_json::to_string(&info).unwrap();
             assert!(!json.contains("channel_relations"));
         }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_sharded_subdir_info_normalizes_plugin_names() {
+        let raw = r#"{
+            "subdir": "linux-64",
+            "base_url": "./",
+            "shards_base_url": "./shards/",
+            "virtual_package_plugins": { "CUDA-Detect": ["__cuda"] }
+        }"#;
+        let info: ShardedSubdirInfo = serde_json::from_str(raw).unwrap();
+        let plugin = PackageName::try_from("cuda-detect").unwrap();
+        assert!(
+            info.virtual_package_plugins.contains_key(&plugin),
+            "a sharded registration is unreachable by its normalized name"
+        );
+        assert!(
+            info.virtual_package_plugins[&plugin]
+                .contains(&PackageName::try_from("__cuda").unwrap()),
+            "a provided virtual package never matches the detected name"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_sharded_subdir_info_virtual_package_plugins() {
+        let raw = r#"{
+            "subdir": "linux-64",
+            "base_url": "./",
+            "shards_base_url": "./shards/",
+            "virtual_package_plugins": {
+                "cuda-detect": ["__cuda", "__cuda_arch"]
+            }
+        }"#;
+        let info: ShardedSubdirInfo = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            info.virtual_package_plugins[&PackageName::new_unchecked("cuda-detect")]
+                .iter()
+                .map(PackageName::as_source)
+                .collect::<Vec<_>>(),
+            ["__cuda", "__cuda_arch"]
+        );
+
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("\"virtual_package_plugins\""));
+
+        // Omitted entirely when no plugins are registered.
+        let info = ShardedSubdirInfo {
+            virtual_package_plugins: VirtualPackagePlugins::default(),
+            ..info
+        };
+        assert!(
+            !serde_json::to_string(&info)
+                .unwrap()
+                .contains("virtual_package_plugins")
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[test]
+    fn test_sharded_subdir_info_plugins_survive_msgpack() {
+        let raw = r#"{
+            "subdir": "linux-64",
+            "base_url": "./",
+            "shards_base_url": "./shards/",
+            "virtual_package_plugins": { "cuda-detect": ["__cuda", "__cuda_arch"] }
+        }"#;
+        let info: ShardedSubdirInfo = serde_json::from_str(raw).unwrap();
+        let bytes = rmp_serde::to_vec_named(&info).unwrap();
+        let back: ShardedSubdirInfo = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(
+            back.virtual_package_plugins, info.virtual_package_plugins,
+            "the registrations changed through a msgpack round trip"
+        );
     }
 }
 

--- a/crates/rattler_conda_types/src/sourced_virtual_package.rs
+++ b/crates/rattler_conda_types/src/sourced_virtual_package.rs
@@ -1,0 +1,59 @@
+//! A virtual package together with what produced it.
+
+use rattler_digest::{Sha256Hash, serde::SerializableHash};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use crate::{ChannelUrl, GenericVirtualPackage, PackageName};
+
+/// A virtual package and the source that produced it.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SourcedVirtualPackage {
+    /// What produced this.
+    pub source: VirtualPackageSource,
+
+    /// The virtual package itself, as handed to the solver.
+    pub package: GenericVirtualPackage,
+}
+
+/// Where a virtual package came from.
+#[serde_as]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VirtualPackageSource {
+    /// Detected by this client itself, according to CEP 30.
+    BuiltIn,
+
+    /// Detected by a plugin a channel registered.
+    Plugin {
+        /// The channel that registered the plugin.
+        channel: ChannelUrl,
+
+        /// The package providing the plugin.
+        plugin: PackageName,
+
+        /// A hash over the plugin package *and* every package installed
+        /// alongside it, so it changes when any dependency of the plugin does.
+        #[serde_as(as = "SerializableHash::<rattler_digest::Sha256>")]
+        environment: Sha256Hash,
+    },
+
+    /// Taken from a `CONDA_OVERRIDE_*` variable instead of being detected.
+    Overridden {
+        /// The channel whose plugin would have answered.
+        channel: ChannelUrl,
+
+        /// The plugin that would have been run.
+        plugin: PackageName,
+    },
+}
+
+impl VirtualPackageSource {
+    /// Whether this came from the client rather than from a channel.
+    pub fn is_built_in(&self) -> bool {
+        match self {
+            Self::BuiltIn => true,
+            Self::Plugin { .. } | Self::Overridden { .. } => false,
+        }
+    }
+}

--- a/crates/rattler_conda_types/src/utils/serde.rs
+++ b/crates/rattler_conda_types/src/utils/serde.rs
@@ -229,6 +229,222 @@ impl Serialize for TimestampMs {
 /// string.
 pub struct DeserializeFromStrUnchecked;
 
+/// A helper struct to deserialize virtual package plugin registrations,
+/// validating every name and skipping the ones a channel got wrong.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub struct DeserializeVirtualPackagePlugins;
+
+#[cfg(feature = "experimental-virtual-package-plugins")]
+impl<'de> DeserializeAs<'de, crate::repo_data::VirtualPackagePlugins>
+    for DeserializeVirtualPackagePlugins
+{
+    fn deserialize_as<D>(
+        deserializer: D,
+    ) -> Result<crate::repo_data::VirtualPackagePlugins, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Read the entries as pairs rather than a map: a map resolves a
+        // repeated key last-wins, which would hide a collision the CEP makes an
+        // error.
+        struct Entries;
+        impl<'de> serde::de::Visitor<'de> for Entries {
+            type Value = Option<Vec<(String, Vec<MaybeName>)>>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a map of plugin names to virtual package names")
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut entries = Vec::new();
+                while let Some(entry) = map.next_entry::<String, Vec<MaybeName>>()? {
+                    entries.push(entry);
+                }
+                Ok(Some(entries))
+            }
+
+            fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+
+            fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(None)
+            }
+        }
+
+        let raw = match deserializer.deserialize_any(Entries) {
+            Ok(Some(raw)) => raw,
+            Ok(None) => {
+                tracing::warn!(
+                    "ignoring info.virtual_package_plugins: it is not a map of plugin registrations"
+                );
+                return Ok(crate::repo_data::VirtualPackagePlugins::default());
+            }
+            Err(reason) => {
+                tracing::warn!("ignoring info.virtual_package_plugins: {reason}");
+                return Ok(crate::repo_data::VirtualPackagePlugins::default());
+            }
+        };
+
+        // A channel that contradicted itself has not established what it meant,
+        // so the whole set goes rather than the offending entry.
+        match registrations_from(raw) {
+            Ok(registrations) => Ok(registrations),
+            Err(reason) => {
+                tracing::warn!("ignoring info.virtual_package_plugins entirely: {reason}");
+                Ok(crate::repo_data::VirtualPackagePlugins::default())
+            }
+        }
+    }
+}
+
+/// Builds the registrations, or names the contradiction that makes the whole
+/// set unusable. Returning the reason rather than a value lets the caller report
+/// it and fall back to no registrations.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+fn registrations_from(
+    raw: Vec<(String, Vec<MaybeName>)>,
+) -> Result<crate::repo_data::VirtualPackagePlugins, String> {
+    let mut registrations = crate::repo_data::VirtualPackagePlugins::default();
+    let mut registered_plugins = std::collections::HashSet::new();
+    let mut claimed = std::collections::HashSet::new();
+
+    for (plugin, provides) in raw {
+        let plugin = validated_plugin_name(plugin)?;
+        if !registered_plugins.insert(plugin.clone()) {
+            return Err(format!(
+                "the channel registers the plugin package '{}' more than once",
+                plugin.as_source()
+            ));
+        }
+
+        // Counted over what the plugin declares, before invalid names are dropped.
+        if provides.is_empty() || provides.len() > MAX_VIRTUAL_PACKAGES_PER_PLUGIN {
+            return Err(format!(
+                "plugin '{}' registers {} virtual packages, outside the 1 to {} a plugin may \
+                 register",
+                plugin.as_source(),
+                provides.len(),
+                MAX_VIRTUAL_PACKAGES_PER_PLUGIN
+            ));
+        }
+
+        let provides: Vec<_> = provides
+            .into_iter()
+            .filter_map(|name| match name {
+                MaybeName::Name(name) => validated_virtual_package_name(name),
+                MaybeName::NotAName(_) => {
+                    tracing::warn!(
+                        "ignoring a registered virtual package of plugin '{}': it is not a name \
+                         at all",
+                        plugin.as_source()
+                    );
+                    None
+                }
+            })
+            .collect();
+        for name in &provides {
+            if !claimed.insert(name.clone()) {
+                return Err(format!(
+                    "the virtual package '{}' is registered more than once",
+                    name.as_source()
+                ));
+            }
+        }
+
+        // Every name it declared was invalid and dropped above. The plugin
+        // speaks for nothing, which is ignored rather than fatal.
+        if provides.is_empty() {
+            tracing::warn!(
+                "ignoring plugin '{}': it registers no valid virtual package",
+                plugin.as_source()
+            );
+            continue;
+        }
+
+        registrations.insert(plugin, provides);
+    }
+    Ok(registrations)
+}
+
+/// One element of a registration array. A channel that put something other than
+/// a string there has published a name that cannot be a package name, and the
+/// CEP requires such a value to be discarded
+#[cfg(feature = "experimental-virtual-package-plugins")]
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum MaybeName {
+    Name(String),
+    NotAName(serde::de::IgnoredAny),
+}
+
+/// The longest name CEP 26 allows, for a package or a virtual package.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+const MAX_NAME_LENGTH: usize = 64;
+
+/// The most virtual packages CEP lets one plugin register, which bounds how much
+/// a single plugin can feed into a solve.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+const MAX_VIRTUAL_PACKAGES_PER_PLUGIN: usize = 16;
+
+/// The distributable package name rule of CEP 26. `fancy_regex` is used
+/// because the pattern needs the negative lookahead that keeps a leading
+/// underscore from being followed by another.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+static PACKAGE_NAME: std::sync::LazyLock<fancy_regex::Regex> = std::sync::LazyLock::new(|| {
+    #[allow(clippy::expect_used, reason = "the pattern is a literal from CEP 26")]
+    fancy_regex::Regex::new(r"(?i)^(([a-z0-9])|([a-z0-9_](?!_)))[._-]?([a-z0-9]+(\.|-|_|$))*$")
+        .expect("the CEP 26 package name pattern is valid")
+});
+
+/// The virtual package name rule of CEP 26.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+static VIRTUAL_PACKAGE_NAME: std::sync::LazyLock<fancy_regex::Regex> =
+    std::sync::LazyLock::new(|| {
+        #[allow(clippy::expect_used, reason = "the pattern is a literal from CEP 26")]
+        fancy_regex::Regex::new(r"^__[a-z0-9][._-]?([a-z0-9]+(\.|-|_|$))*$")
+            .expect("the CEP 26 virtual package name pattern is valid")
+    });
+
+/// Whether a name a channel published satisfies one of the CEP 26 patterns.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+fn matches(pattern: &fancy_regex::Regex, name: &crate::PackageName) -> bool {
+    let name = name.as_source();
+    name.len() <= MAX_NAME_LENGTH && pattern.is_match(name).unwrap_or(false)
+}
+
+/// Validates the name of the package providing a plugin.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+fn validated_plugin_name(name: String) -> Result<crate::PackageName, String> {
+    let source = name.clone();
+    let name = crate::PackageName::try_from(name)
+        .map_err(|err| format!("'{source}' is not a package name: {err}"))?;
+    if !matches(&PACKAGE_NAME, &name) {
+        return Err(format!("'{}' is not a package name", name.as_source()));
+    }
+    Ok(name)
+}
+
+/// Validates a name a plugin claims to provide, which CEP 26 requires to be a
+/// package name carrying the `__` prefix.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+fn validated_virtual_package_name(name: String) -> Option<crate::PackageName> {
+    let name = crate::PackageName::try_from(name)
+        .inspect_err(|err| tracing::warn!("ignoring registered virtual package name: {err}"))
+        .ok()?;
+    if !matches(&VIRTUAL_PACKAGE_NAME, &name) {
+        tracing::warn!(
+            "ignoring registered virtual package '{}': it is not a virtual package name",
+            name.as_source()
+        );
+        return None;
+    }
+    Some(name)
+}
+
 /// A helper function used to sort map alphabetically when serializing.
 pub(crate) fn sort_map_alphabetically<K: Ord + Serialize, T: Serialize, H, S: serde::Serializer>(
     value: &HashMap<K, T, H>,

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -28,6 +28,9 @@ rustls = [
   "opendal/reqwest-rustls-tls",
 ]
 s3 = ["opendal/services-s3", "dep:rattler_s3"]
+experimental-virtual-package-plugins = [
+  "rattler_conda_types/experimental-virtual-package-plugins",
+]
 
 [[bin]]
 name = "rattler-index"

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -955,6 +955,8 @@ async fn index_subdir_inner(
                 &v3,
             ),
             channel_relations: channel_metadata.channel_relations,
+            #[cfg(feature = "experimental-virtual-package-plugins")]
+            virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
         }),
         packages,
         conda_packages,
@@ -1537,6 +1539,8 @@ pub async fn write_repodata(
                 created_at: Some(jiff::Timestamp::now()),
                 repodata_revisions: sharded_repodata_revisions,
                 channel_relations: sharded_channel_relations,
+                #[cfg(feature = "experimental-virtual-package-plugins")]
+                virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
             },
             shards: shards
                 .iter()
@@ -2020,6 +2024,8 @@ pub async fn ensure_channel_initialized_with_channel_metadata(
             base_url: channel_metadata.base_url,
             repodata_revisions: RepodataRevisions::new(),
             channel_relations: channel_metadata.channel_relations,
+            #[cfg(feature = "experimental-virtual-package-plugins")]
+            virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
         }),
         packages: IndexMap::default(),
         conda_packages: IndexMap::default(),

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -115,6 +115,7 @@ native-tls = ['reqwest/native-tls', 'rattler_networking/native-tls', 'rattler_ca
 rustls = ['reqwest/rustls', 'rattler_networking/rustls', 'rattler_cache/rustls', 'rattler_redaction/rustls']
 sparse = ["rattler_conda_types", "memmap2", "self_cell", "superslice", "itertools", "serde_json/raw_value"]
 gateway = ["sparse", "http", "http-cache-semantics", "parking_lot", "async-trait", "rattler_package_streaming"]
+experimental-virtual-package-plugins = ["rattler_conda_types?/experimental-virtual-package-plugins"]
 
 [package.metadata.docs.rs]
 features = ["sparse", "gateway"]

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -223,6 +223,8 @@ mod tests {
                     created_at: Some(jiff::Timestamp::now()),
                     repodata_revisions: RepodataRevisions::default(),
                     channel_relations: None,
+                    #[cfg(feature = "experimental-virtual-package-plugins")]
+                    virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
                 },
                 shards,
             };


### PR DESCRIPTION
### Description

Implements virtual package plugin support in the conda-types layer.

Stack base: `main`.

Stack:
1. `virtual-package-plugins-conda-types` (this PR)
2. `virtual-package-plugins-cache`
3. `virtual-package-plugins-repodata-gateway`
4. `virtual-package-plugins-index`
5. `virtual-package-plugins-runtime`
6. `virtual-package-plugins-bin`

### How Has This Been Tested?

- `pixi run cargo-fmt`
- `pixi run -- cargo nextest run -p rattler_cache --features experimental-virtual-package-plugins virtual_package_plugin_cache`
- `pixi run -- cargo nextest run -p rattler_virtual_package_plugins --features experimental-virtual-package-plugins`
- `pixi run -- cargo clippy -p rattler_cache --features experimental-virtual-package-plugins --all-targets -- -D warnings`
- `pixi run -- cargo clippy -p rattler_virtual_package_plugins --features experimental-virtual-package-plugins --all-targets -- -D warnings`
- `pixi run -- cargo clippy -p rattler-bin --features experimental-virtual-package-plugins --all-targets -- -D warnings`

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
