### PR TITLE
feat(rattler-repodata-gateway): implement virtual package plugins

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/channel_expander.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_expander.rs
@@ -187,7 +187,7 @@ pub(super) struct ChannelExpander {
 }
 
 impl ChannelExpander {
-    pub fn new(
+    pub(super) fn new(
         mode: ChannelRelationsMode,
         max_depth: usize,
         platforms: Vec<Platform>,
@@ -209,26 +209,26 @@ impl ChannelExpander {
     }
 
     /// `max_depth == 0` is equivalent to [`ChannelRelationsMode::Disabled`].
-    pub fn enabled(&self) -> bool {
+    pub(super) fn enabled(&self) -> bool {
         !matches!(self.mode, ChannelRelationsMode::Disabled) && self.max_depth > 0
     }
 
-    pub fn strict(&self) -> bool {
+    pub(super) fn strict(&self) -> bool {
         matches!(self.mode, ChannelRelationsMode::Strict)
     }
 
-    pub fn platforms(&self) -> &[Platform] {
+    pub(super) fn platforms(&self) -> &[Platform] {
         &self.platforms
     }
 
     /// `true` once any subdir contributed an edge; gates reordering.
-    pub fn has_observed_relations(&self) -> bool {
+    pub(super) fn has_observed_relations(&self) -> bool {
         !self.edges.is_empty()
     }
 
     /// Record a warning unless an identical one exists, notifying the
     /// reporter on acceptance.
-    pub fn push_warning(&mut self, warning: ChannelRelationsWarning) {
+    pub(super) fn push_warning(&mut self, warning: ChannelRelationsWarning) {
         if self.emitted.insert(warning.to_string()) {
             if let Some(reporter) = &self.reporter {
                 reporter.on_gateway_warning(&GatewayWarning::from(warning.clone()));
@@ -250,12 +250,12 @@ impl ChannelExpander {
     }
 
     /// Drain the accumulated warnings.
-    pub fn take_warnings(&mut self) -> Vec<ChannelRelationsWarning> {
+    pub(super) fn take_warnings(&mut self) -> Vec<ChannelRelationsWarning> {
         std::mem::take(&mut self.warnings)
     }
 
     /// Register a user channel at depth 0, deduplicating repeats.
-    pub fn register_user_channel(&mut self, channel: Channel) -> (ChannelUrl, Arc<Channel>) {
+    pub(super) fn register_user_channel(&mut self, channel: Channel) -> (ChannelUrl, Arc<Channel>) {
         let url = channel.base_url.clone();
         if let Some(existing) = self.discovered.get(&url) {
             return (url, existing.clone());
@@ -274,7 +274,7 @@ impl ChannelExpander {
     /// the executor can abort. Depth violations are deferred to
     /// [`finalize`](Self::finalize), where they no longer depend on
     /// fetch completion order.
-    pub fn observe(
+    pub(super) fn observe(
         &mut self,
         channel_url: &ChannelUrl,
         _platform: Platform,
@@ -454,7 +454,7 @@ impl ChannelExpander {
     /// Report deferred depth refusals, resolve the priority order from
     /// canonically sorted inputs (identical run to run), and surface
     /// ignored and broken edges.
-    pub fn finalize(&mut self) -> Result<Resolution<ChannelUrl>, super::GatewayError> {
+    fn finalize(&mut self) -> Result<Resolution<ChannelUrl>, super::GatewayError> {
         self.report_depth_refusals()?;
 
         let mut nodes = self.user_channels.clone();
@@ -565,7 +565,7 @@ impl ChannelExpander {
     /// Map each discovered channel to the first user channel in
     /// `user_priority` that reaches it. Derived from the final edge
     /// set, so independent of fetch completion order.
-    pub fn anchors(&self, user_priority: &[ChannelUrl]) -> HashMap<ChannelUrl, ChannelUrl> {
+    fn anchors(&self, user_priority: &[ChannelUrl]) -> HashMap<ChannelUrl, ChannelUrl> {
         // Discovery arcs run declaring -> target: a Base edge stores
         // (from: target, to: declaring), an Override edge stores
         // (from: declaring, to: target).
@@ -601,6 +601,110 @@ impl ChannelExpander {
         }
         anchors
     }
+
+    /// The rank of every channel this walk reached.
+    ///
+    /// `user_caller_idx` maps every channel the caller named to the slot it
+    /// occupied in the caller's source list. Those indices can skip values,
+    /// because a caller may pass custom sources alongside its channels.
+    fn channel_ranks(
+        &self,
+        resolution_order: &[ChannelUrl],
+        user_caller_idx: &HashMap<ChannelUrl, usize>,
+    ) -> HashMap<ChannelUrl, ChannelRank> {
+        let priority_of: HashMap<&ChannelUrl, usize> = resolution_order
+            .iter()
+            .enumerate()
+            .map(|(index, url)| (url, index))
+            .collect();
+
+        // Anchoring reads the final edge set rather than the order fetches
+        // completed in, and it needs the caller's channels in the caller's own
+        // order to decide which of them claims a discovered channel.
+        let mut by_caller_idx: Vec<(usize, ChannelUrl)> = user_caller_idx
+            .iter()
+            .map(|(url, index)| (*index, url.clone()))
+            .collect();
+        by_caller_idx.sort();
+        let user_priority: Vec<ChannelUrl> =
+            by_caller_idx.into_iter().map(|(_, url)| url).collect();
+        let anchor_of = self.anchors(&user_priority);
+
+        resolution_order
+            .iter()
+            .chain(user_priority.iter())
+            .map(|url| {
+                let anchor = user_caller_idx
+                    .get(url)
+                    .copied()
+                    .or_else(|| {
+                        anchor_of
+                            .get(url)
+                            .and_then(|introducer| user_caller_idx.get(introducer).copied())
+                    })
+                    .unwrap_or(usize::MAX);
+                let priority = priority_of.get(url).copied().unwrap_or(usize::MAX);
+                (url.clone(), ChannelRank { anchor, priority })
+            })
+            .collect()
+    }
+
+    /// Resolve this walk into the channel priority order the gateway applies.
+    ///
+    /// Resolving is also what reports the depth and cycle problems met on the
+    /// way, so this runs whether or not the caller reads the order it returns.
+    pub(super) fn finalize_channel_order(
+        &mut self,
+        user_caller_idx: &HashMap<ChannelUrl, usize>,
+    ) -> Result<ChannelOrder, super::GatewayError> {
+        let resolution = self.finalize()?;
+        let ranks = self.channel_ranks(&resolution.order, user_caller_idx);
+
+        #[cfg(feature = "experimental-virtual-package-plugins")]
+        let channels = {
+            let mut channels = resolution.order;
+            channels.sort_by_key(|url| {
+                ranks.get(url).copied().unwrap_or(ChannelRank {
+                    anchor: usize::MAX,
+                    priority: usize::MAX,
+                })
+            });
+            channels
+        };
+
+        Ok(ChannelOrder {
+            #[cfg(feature = "experimental-virtual-package-plugins")]
+            channels,
+            ranks,
+        })
+    }
+}
+
+/// The channels a walk reached, in the priority order the gateway applies.
+pub(super) struct ChannelOrder {
+    /// Every channel the walk reached, highest priority first.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub(super) channels: Vec<ChannelUrl>,
+
+    /// The rank each channel sits at, for a caller sorting something richer
+    /// than a channel list: the repodata query sorts subdir handles by it.
+    pub(super) ranks: HashMap<ChannelUrl, ChannelRank>,
+}
+
+/// Where one channel sits in the channel priority order the gateway applies.
+///
+/// Ordered so that sorting by it *is* the channel priority order: the caller
+/// slot first, then CEP-42 priority inside that slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct ChannelRank {
+    /// The caller slot this channel belongs to. A channel the caller named
+    /// keeps its own slot; a channel found through a relation inherits the slot
+    /// of the user channel that introduced it.
+    pub(super) anchor: usize,
+
+    /// CEP-42 priority, which orders the channels sharing one slot and places
+    /// a base ahead of the channel declaring it.
+    pub(super) priority: usize,
 }
 
 fn field_name(source: EdgeSource) -> &'static str {

--- a/crates/rattler_repodata_gateway/src/gateway/channel_relations.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_relations.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_CHANNEL_RELATIONS_MAX_DEPTH: usize = 10;
 
 /// Where a [`PriorityEdge`] originated from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum EdgeSource {
+pub(super) enum EdgeSource {
     /// Implied by the user's channel ordering.
     User,
     /// Declared via the `to` channel's `base`.
@@ -34,34 +34,34 @@ pub enum EdgeSource {
 
 /// Directed priority edge: `from` outranks `to`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct PriorityEdge<K> {
-    pub from: K,
-    pub to: K,
-    pub source: EdgeSource,
+pub(super) struct PriorityEdge<K> {
+    pub(super) from: K,
+    pub(super) to: K,
+    pub(super) source: EdgeSource,
 }
 
 /// Outcome of a channel priority resolution. Always succeeds; the
 /// caller surfaces `ignored_edges` / `broken_cycle_edges` as warnings
 /// or errors per its mode.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Resolution<K> {
+pub(super) struct Resolution<K> {
     /// Final priority order, highest first.
-    pub order: Vec<K>,
+    pub(super) order: Vec<K>,
     /// Edges respected by `order`.
-    pub edges: Vec<PriorityEdge<K>>,
+    pub(super) edges: Vec<PriorityEdge<K>>,
     /// Relation edges dropped because they contradicted the user's
     /// explicit ordering. Surfaced by the expander as
     /// `UserOrderConflict` warnings.
-    pub ignored_edges: Vec<PriorityEdge<K>>,
+    pub(super) ignored_edges: Vec<PriorityEdge<K>>,
     /// Relation edges dropped to break a cycle.
-    pub broken_cycle_edges: Vec<PriorityEdge<K>>,
+    pub(super) broken_cycle_edges: Vec<PriorityEdge<K>>,
 }
 
 /// Resolve the priority order over `discovered_channels` from the
 /// user's channel order plus the deduplicated relation edges. The
 /// output is fully determined by the inputs; callers needing
 /// run-to-run determinism must pass canonically ordered slices.
-pub fn resolve_channel_priority<K>(
+pub(super) fn resolve_channel_priority<K>(
     user_channels: &[K],
     discovered_channels: &[K],
     relation_edges: &[PriorityEdge<K>],
@@ -627,11 +627,6 @@ mod tests {
         assert_eq!(dropped.to, "b");
     }
 
-    /// A self-loop on a user-listed channel is no longer routed to
-    /// `ignored_edges` via the user-conflict check; self-relations
-    /// are malformed metadata. The algorithm reports them via
-    /// `broken_cycle_edges`; the caller (the expander) translates
-    /// that into a warning/error per its mode.
     #[test]
     fn self_loop_on_a_user_channel_is_treated_as_a_cycle() {
         let reg = registry([("a", Some("a"), None)]);
@@ -743,9 +738,6 @@ mod tests {
         assert!(sources.contains(&EdgeSource::Override));
     }
 
-    /// Two platforms of the same channel declaring DIFFERENT bases is
-    /// valid per CEP-42. Both edges must be respected in the final
-    /// order, with neither silently dropped.
     #[test]
     fn divergent_per_platform_relations_are_both_respected() {
         // Channel `app` has base `cf-linux` (one platform) and base
@@ -772,9 +764,6 @@ mod tests {
         assert!(r.broken_cycle_edges.is_empty());
     }
 
-    /// Exact duplicate relation edges (same from/to/source) must not
-    /// produce a cycle on their own; they're redundant, not
-    /// contradictory.
     #[test]
     fn exact_duplicate_relation_edges_are_not_cycles() {
         let user = ["app"];

--- a/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
@@ -1,5 +1,7 @@
 use std::{path::Path, sync::Arc};
 
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{Channel, ChannelRelations, PackageName, RepodataRevisions};
 
 use crate::{
@@ -120,5 +122,10 @@ impl SubdirClient for LocalSubdirClient {
 
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.sparse.channel_relations()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        self.sparse.virtual_package_plugins()
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -35,9 +35,13 @@ use coalesced_map::{CoalescedGetError, CoalescedMap};
 pub use error::GatewayError;
 #[cfg(feature = "indicatif")]
 pub use indicatif::{IndicatifReporter, IndicatifReporterBuilder};
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub use query::SubdirVirtualPackagePlugins;
 pub use query::{NamesQuery, NamesQueryOutput, RepoDataQuery, RepoDataQueryOutput};
 #[cfg(not(target_arch = "wasm32"))]
 use rattler_cache::package_cache::PackageCache;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{Channel, ChannelRelations, MatchSpec, Platform, RepoDataRecord};
 use rattler_networking::LazyClient;
 pub use repo_data::RepoData;
@@ -91,6 +95,19 @@ impl SubdirSelection {
             SubdirSelection::Some(subdirs) => subdirs.contains(&subdir.to_string()),
         }
     }
+}
+
+/// The channels a set of user-specified channels resolves to, in
+/// [CEP-42] priority order.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedChannels {
+    /// The channels the user named together with the ones their relations
+    /// brought in, highest priority first.
+    pub channels: Vec<Channel>,
+
+    /// Non-fatal problems met while following the relations.
+    pub warnings: Vec<GatewayWarning>,
 }
 
 /// Specifies what caches to clear.
@@ -227,6 +244,67 @@ impl Gateway {
             // for every platform except noarch; catch the noarch
             // error so `None` holds for all platforms.
             Err(GatewayError::SubdirNotFoundError(_)) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Resolves `channels` into the [CEP-42] channel priority order,
+    /// following the relations the channels declare and discovering the
+    /// channels they name.
+    ///
+    /// Relation problems degrade the result rather than failing it, as in
+    /// [`ChannelRelationsMode::Warn`]
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub async fn resolved_channels(
+        &self,
+        channels: impl IntoIterator<Item = Channel>,
+        platforms: impl IntoIterator<Item = Platform>,
+    ) -> Result<ResolvedChannels, GatewayError> {
+        let walk = query::walk_channels(
+            query::ChannelWalkOptions {
+                gateway: self.inner.clone(),
+                channels: channels.into_iter().collect(),
+                platforms: platforms.into_iter().collect(),
+                mode: ChannelRelationsMode::default(),
+                max_depth: DEFAULT_CHANNEL_RELATIONS_MAX_DEPTH,
+                reporter: None,
+                collect_notices: false,
+            },
+            |_url, _platform, _subdir| {},
+        )
+        .await?;
+
+        Ok(ResolvedChannels {
+            channels: walk
+                .order
+                .iter()
+                .filter_map(|url| walk.channels.get(url).map(|channel| (**channel).clone()))
+                .collect(),
+            warnings: walk
+                .warnings
+                .into_iter()
+                .map(GatewayWarning::from)
+                .collect(),
+        })
+    }
+
+    /// Returns the virtual package detection plugins registered by the
+    /// given `(channel, platform)` subdirectory, keyed by the name of the
+    /// package providing the plugin. Empty if the subdirectory registers
+    /// none or doesn't exist.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub async fn virtual_package_plugins(
+        &self,
+        channel: &Channel,
+        platform: Platform,
+    ) -> Result<VirtualPackagePlugins, GatewayError> {
+        match self
+            .inner
+            .get_or_create_subdir(channel, platform, None)
+            .await
+        {
+            Ok(subdir) => Ok(subdir.virtual_package_plugins().clone()),
+            Err(GatewayError::SubdirNotFoundError(_)) => Ok(VirtualPackagePlugins::default()),
             Err(err) => Err(err),
         }
     }
@@ -3083,6 +3161,383 @@ mod test {
         );
     }
 
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn write_test_subdir_with_plugins(root: &std::path::Path, pkg: &str, plugins: &str) {
+        let subdir = root.join("linux-64");
+        std::fs::create_dir_all(&subdir).unwrap();
+        let json = format!(
+            r#"{{
+    "info": {{
+        "subdir": "linux-64",
+        "virtual_package_plugins": {{{plugins}}}
+    }},
+    "packages.conda": {{
+        "{pkg}-1.0.0-0.conda": {{
+            "build": "0",
+            "build_number": 0,
+            "depends": [],
+            "md5": "00000000000000000000000000000000",
+            "name": "{pkg}",
+            "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+            "size": 1000,
+            "subdir": "linux-64",
+            "timestamp": 1700000000000,
+            "version": "1.0.0"
+        }}
+    }}
+}}"#
+        );
+        std::fs::write(subdir.join("repodata.json"), json).unwrap();
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    type FlatPlugins = Vec<(String, Platform, Vec<(String, Vec<String>)>)>;
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn flatten_plugins(output: &crate::RepoDataQueryOutput) -> FlatPlugins {
+        output
+            .virtual_package_plugins
+            .iter()
+            .map(|entry| {
+                (
+                    entry.channel.url().path().trim_matches('/').to_string(),
+                    entry.platform,
+                    entry
+                        .plugins
+                        .iter()
+                        .map(|(plugin, provided)| {
+                            (
+                                plugin.as_source().to_string(),
+                                provided.iter().map(|v| v.as_source().to_string()).collect(),
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_reported_per_subdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        write_test_subdir_with_plugins(&a, "shared", r#""cuda-detect": ["__cuda", "__cuda_arch"]"#);
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let output = Gateway::new()
+            .query(
+                vec![Channel::from_url(server.url().join("a/").unwrap())],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("shared", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            flatten_plugins(&output),
+            vec![(
+                "a".to_string(),
+                Platform::Linux64,
+                vec![(
+                    "cuda-detect".to_string(),
+                    vec!["__cuda".to_string(), "__cuda_arch".to_string()],
+                )],
+            )]
+        );
+        assert!(output.warnings.is_empty(), "{:?}", output.warnings);
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_conflicting_channels_both_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            &dir.path().join("a"),
+            "shared",
+            r#""a-detect": ["__rocm"]"#,
+        );
+        write_test_subdir_with_plugins(
+            &dir.path().join("b"),
+            "shared",
+            r#""b-detect": ["__rocm"]"#,
+        );
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let a = Channel::from_url(server.url().join("a/").unwrap());
+        let b = Channel::from_url(server.url().join("b/").unwrap());
+
+        let output = Gateway::new()
+            .query(
+                vec![a, b],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("shared", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        let reported: Vec<String> = flatten_plugins(&output)
+            .into_iter()
+            .map(|(channel, _, plugins)| format!("{channel}:{}", plugins[0].0))
+            .collect();
+        assert_eq!(reported, vec!["a:a-detect", "b:b-detect"]);
+        assert!(output.warnings.is_empty(), "{:?}", output.warnings);
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_duplicate_claim_within_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            &dir.path().join("a"),
+            "shared",
+            r#""first-detect": ["__rocm"], "second-detect": ["__rocm"]"#,
+        );
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let output = Gateway::new()
+            .query(
+                vec![Channel::from_url(server.url().join("a/").unwrap())],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("shared", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        let plugins = flatten_plugins(&output);
+        assert_eq!(
+            plugins[0].2,
+            vec![
+                ("first-detect".to_string(), vec!["__rocm".to_string()]),
+                ("second-detect".to_string(), vec!["__rocm".to_string()]),
+            ]
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_resolved_order_agrees_with_a_query_over_two_user_channels() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir(&dir.path().join("alpha"), "pkg-alpha", "1.0.0", None, None);
+        write_test_subdir(
+            &dir.path().join("beta"),
+            "pkg-beta",
+            "1.0.0",
+            Some("../shared"),
+            None,
+        );
+        write_test_subdir(
+            &dir.path().join("shared"),
+            "pkg-shared",
+            "1.0.0",
+            None,
+            None,
+        );
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let alpha = Channel::from_url(server.url().join("alpha/").unwrap());
+        let beta = Channel::from_url(server.url().join("beta/").unwrap());
+
+        let gateway = Gateway::new();
+        let resolved = gateway
+            .resolved_channels(vec![alpha.clone(), beta.clone()], vec![Platform::Linux64])
+            .await
+            .unwrap();
+
+        // Each channel holds one uniquely named package, so a bucket's records
+        // name the channel it came from.
+        let buckets = gateway
+            .query(
+                vec![alpha, beta],
+                vec![Platform::Linux64],
+                vec![
+                    MatchSpec::from_str("pkg-alpha", Strict).unwrap(),
+                    MatchSpec::from_str("pkg-beta", Strict).unwrap(),
+                    MatchSpec::from_str("pkg-shared", Strict).unwrap(),
+                ],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+        let queried: Vec<String> = buckets
+            .repodata
+            .iter()
+            .filter_map(|repodata| {
+                repodata.iter().next().map(|record| {
+                    record
+                        .package_record
+                        .name
+                        .as_normalized()
+                        .trim_start_matches("pkg-")
+                        .to_string()
+                })
+            })
+            .collect();
+
+        assert_eq!(
+            resolved_names(&resolved),
+            queried,
+            "resolved_channels and query disagree on channel priority"
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn resolved_names(resolved: &crate::ResolvedChannels) -> Vec<String> {
+        resolved
+            .channels
+            .iter()
+            .map(|channel| {
+                channel
+                    .base_url
+                    .url()
+                    .path_segments()
+                    .and_then(|mut segments| segments.rfind(|segment| !segment.is_empty()))
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_resolved_channels_follows_relations() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir(
+            &dir.path().join("conda-forge"),
+            "shared",
+            "1.0.0",
+            None,
+            None,
+        );
+        write_test_subdir(
+            &dir.path().join("bioconda"),
+            "shared",
+            "2.0.0",
+            Some("../conda-forge"),
+            None,
+        );
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let resolved = Gateway::new()
+            .resolved_channels(
+                vec![Channel::from_url(server.url().join("bioconda/").unwrap())],
+                vec![Platform::Linux64],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resolved_names(&resolved), ["conda-forge", "bioconda"]);
+        assert!(resolved.warnings.is_empty(), "{:?}", resolved.warnings);
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_resolved_channels_keep_the_user_order() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir(
+            &dir.path().join("conda-forge"),
+            "shared",
+            "1.0.0",
+            None,
+            None,
+        );
+        write_test_subdir(
+            &dir.path().join("bioconda"),
+            "shared",
+            "2.0.0",
+            Some("../conda-forge"),
+            None,
+        );
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let resolved = Gateway::new()
+            .resolved_channels(
+                vec![
+                    Channel::from_url(server.url().join("bioconda/").unwrap()),
+                    Channel::from_url(server.url().join("conda-forge/").unwrap()),
+                ],
+                vec![Platform::Linux64],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resolved_names(&resolved), ["bioconda", "conda-forge"]);
+        assert!(
+            resolved.warnings.iter().any(|warning| matches!(
+                warning,
+                crate::GatewayWarning::ChannelRelations(
+                    crate::ChannelRelationsWarning::UserOrderConflict { .. }
+                )
+            )),
+            "expected the dropped relation to be reported; got {:?}",
+            resolved.warnings,
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_reported_for_unmatched_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            &dir.path().join("a"),
+            "shared",
+            r#""cuda-detect": ["__cuda"]"#,
+        );
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let output = Gateway::new()
+            .query(
+                vec![Channel::from_url(server.url().join("a/").unwrap())],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("no-such-package", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        assert!(
+            output.iter().all(RepoData::is_empty),
+            "the spec must not match any record"
+        );
+        assert_eq!(
+            flatten_plugins(&output),
+            vec![(
+                "a".to_string(),
+                Platform::Linux64,
+                vec![("cuda-detect".to_string(), vec!["__cuda".to_string()])],
+            )]
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_virtual_package_plugins_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        write_test_subdir(&dir.path().join("a"), "shared", "1.0.0", None, None);
+
+        let server = SimpleChannelServer::new(dir.path()).await;
+        let output = Gateway::new()
+            .query(
+                vec![Channel::from_url(server.url().join("a/").unwrap())],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("shared", Strict).unwrap()],
+            )
+            .recursive(false)
+            .execute()
+            .await
+            .unwrap();
+
+        assert!(output.virtual_package_plugins.is_empty());
+    }
+
     /// Repodata with CEP-42 `channel_relations` in `info`.
     fn make_repodata_with_relations(
         name: &str,
@@ -3203,6 +3658,81 @@ mod test {
                 .await
                 .unwrap_or_else(|e| panic!("{platform} must return None, not error: {e}"));
             assert!(relations.is_none());
+        }
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_gateway_virtual_package_plugins_roundtrip() {
+        let channel_dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            channel_dir.path(),
+            "testpkg",
+            r#""cuda-detect": ["__cuda", "__cuda_arch"], "rocm-detect": ["__rocm"]"#,
+        );
+
+        let server = SimpleChannelServer::new(channel_dir.path()).await;
+        let plugins = Gateway::new()
+            .virtual_package_plugins(&server.channel(), Platform::Linux64)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plugins
+                .iter()
+                .map(|(plugin, provided)| (
+                    plugin.as_source(),
+                    provided
+                        .iter()
+                        .map(PackageName::as_source)
+                        .collect::<Vec<_>>()
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("cuda-detect", vec!["__cuda", "__cuda_arch"]),
+                ("rocm-detect", vec!["__rocm"]),
+            ]
+        );
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_gateway_virtual_package_plugins_absent() {
+        let channel_dir = tempfile::tempdir().unwrap();
+        let subdir_path = channel_dir.path().join("linux-64");
+        std::fs::create_dir_all(&subdir_path).unwrap();
+        std::fs::write(
+            subdir_path.join("repodata.json"),
+            make_repodata("testpkg", "1.0.0"),
+        )
+        .unwrap();
+
+        let server = SimpleChannelServer::new(channel_dir.path()).await;
+        let plugins = Gateway::new()
+            .virtual_package_plugins(&server.channel(), Platform::Linux64)
+            .await
+            .unwrap();
+        assert!(plugins.is_empty());
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_gateway_virtual_package_plugins_missing_subdir() {
+        let channel_dir = tempfile::tempdir().unwrap();
+        write_test_subdir_with_plugins(
+            channel_dir.path(),
+            "testpkg",
+            r#""cuda-detect": ["__cuda"]"#,
+        );
+
+        let server = SimpleChannelServer::new(channel_dir.path()).await;
+        let gateway = Gateway::new();
+        for platform in [Platform::Osx64, Platform::NoArch] {
+            let plugins = gateway
+                .virtual_package_plugins(&server.channel(), platform)
+                .await
+                .unwrap_or_else(|e| panic!("{platform} must return empty, not error: {e}"));
+            assert!(plugins.is_empty(), "{platform} declared none");
         }
     }
 

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -1,10 +1,12 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     future::{Future, IntoFuture},
     sync::Arc,
 };
 
 use futures::{FutureExt, StreamExt, select_biased, stream::FuturesUnordered};
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{
     Channel, ChannelUrl, MatchSpec, Matches, PackageName, PackageNameMatcher, Platform,
     RepoDataRecord,
@@ -40,6 +42,29 @@ pub struct RepoDataQueryOutput {
     /// Non-fatal warnings encountered during the query. Also streamed
     /// to [`Reporter::on_gateway_warning`] as they are recorded.
     pub warnings: Vec<GatewayWarning>,
+    /// Virtual package detection plugins declared by the queried channel
+    /// subdirs, in resolved channel-priority order.
+    ///
+    /// Reported exactly as declared: duplicate claims on the same virtual
+    /// package are not resolved, and no plugin is fetched or executed.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub virtual_package_plugins: Vec<SubdirVirtualPackagePlugins>,
+}
+
+/// Plugin registrations declared by a single channel subdir.
+///
+/// Kept per subdir rather than per channel because different subdirs of one
+/// channel may declare different metadata; collapsing them would silently drop
+/// registrations.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+#[derive(Debug, Clone)]
+pub struct SubdirVirtualPackagePlugins {
+    /// The channel that declared these plugins.
+    pub channel: ChannelUrl,
+    /// The subdir the declaration was read from.
+    pub platform: Platform,
+    /// Plugin package name mapped to the virtual packages it provides.
+    pub plugins: VirtualPackagePlugins,
 }
 
 impl std::ops::Deref for RepoDataQueryOutput {
@@ -378,9 +403,13 @@ struct QueryExecutor {
 
     /// CEP-42 expansion state.
     expander: ChannelExpander,
-
     /// CEP-6 notice collection state.
     notices: NoticeCollector,
+
+    /// Plugin registrations collected from each resolved channel subdir.
+    /// Emitted in channel-priority order once the final order is known.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    virtual_package_plugins: ahash::HashMap<(ChannelUrl, Platform), VirtualPackagePlugins>,
 }
 
 /// Collects CEP-6 notices while a query runs. Fetches are queued as channels
@@ -629,6 +658,8 @@ impl QueryExecutor {
             pending_records: FuturesUnordered::new(),
             expander,
             notices,
+            #[cfg(feature = "experimental-virtual-package-plugins")]
+            virtual_package_plugins: ahash::HashMap::default(),
         })
     }
 
@@ -990,6 +1021,14 @@ impl QueryExecutor {
                     }
                     self.expand_pattern_specs_for_subdir(subdir.as_ref());
                     if let Some((url, platform)) = kind_url_and_platform {
+                        #[cfg(feature = "experimental-virtual-package-plugins")]
+                        {
+                            let plugins = subdir.virtual_package_plugins();
+                            if !plugins.is_empty() {
+                                self.virtual_package_plugins
+                                    .insert((url.clone(), platform), plugins.clone());
+                            }
+                        }
                         self.expand_relations_for_subdir(&url, platform, subdir.as_ref())?;
                     }
                     if self.pending_subdirs.is_empty() {
@@ -1065,11 +1104,7 @@ impl QueryExecutor {
             .queue(&self.gateway, &url, channel.clone(), self.reporter.clone());
         let barrier = Arc::new(BarrierCell::new());
 
-        let policy = if self.expander.strict() {
-            FetchErrorPolicy::WrapAsChannelRelationsError
-        } else {
-            FetchErrorPolicy::SwallowAsWarning
-        };
+        let policy = discovery_policy(&self.expander);
         let fut = build_channel_subdir_future(
             self.gateway.clone(),
             channel,
@@ -1103,14 +1138,6 @@ impl QueryExecutor {
         let mut handles = self.subdir_handles;
 
         if self.expander.enabled() && self.expander.has_observed_relations() {
-            let resolution = self.expander.finalize()?;
-
-            let priority_of: std::collections::HashMap<&ChannelUrl, usize> = resolution
-                .order
-                .iter()
-                .enumerate()
-                .map(|(i, u)| (u, i))
-                .collect();
             let platform_idx_of: std::collections::HashMap<Platform, usize> = self
                 .expander
                 .platforms()
@@ -1129,18 +1156,10 @@ impl QueryExecutor {
                 })
                 .collect();
 
-            // Anchors derive from the final edge set, independent of
-            // fetch completion order.
-            let mut users_by_caller_idx: Vec<(usize, ChannelUrl)> = user_channel_caller_idx
-                .iter()
-                .map(|(url, idx)| (*idx, url.clone()))
-                .collect();
-            users_by_caller_idx.sort();
-            let user_priority: Vec<ChannelUrl> = users_by_caller_idx
-                .into_iter()
-                .map(|(_, url)| url)
-                .collect();
-            let anchor_of = self.expander.anchors(&user_priority);
+            let ranks = self
+                .expander
+                .finalize_channel_order(&user_channel_caller_idx)?
+                .ranks;
 
             let mut tagged: Vec<((usize, usize, usize, usize), SubdirHandle)> = handles
                 .into_iter()
@@ -1148,19 +1167,22 @@ impl QueryExecutor {
                 .map(|(orig_idx, h)| {
                     let (anchor, prio, plat) = match (&h.kind, h.caller_source_idx) {
                         (SubdirKind::Custom, Some(i)) => (i, 0_usize, 0_usize),
+                        // A handle the caller supplied keeps the slot the
+                        // caller put it in, so one channel named twice stays in
+                        // both places rather than collapsing into one.
                         (SubdirKind::Channel { url, platform }, Some(i)) => {
-                            let r = priority_of.get(url).copied().unwrap_or(usize::MAX);
+                            let r = ranks.get(url).map_or(usize::MAX, |rank| rank.priority);
                             let p = platform_idx_of.get(platform).copied().unwrap_or(usize::MAX);
                             (i, r, p)
                         }
                         (SubdirKind::Channel { url, platform }, None) => {
-                            let anchor = anchor_of
-                                .get(url)
-                                .and_then(|u| user_channel_caller_idx.get(u).copied())
-                                .unwrap_or(usize::MAX);
-                            let r = priority_of.get(url).copied().unwrap_or(usize::MAX);
+                            let rank = ranks.get(url);
                             let p = platform_idx_of.get(platform).copied().unwrap_or(usize::MAX);
-                            (anchor, r, p)
+                            (
+                                rank.map_or(usize::MAX, |rank| rank.anchor),
+                                rank.map_or(usize::MAX, |rank| rank.priority),
+                                p,
+                            )
                         }
                         (SubdirKind::Custom, None) => {
                             unreachable!("custom sources are always caller-supplied")
@@ -1172,6 +1194,27 @@ impl QueryExecutor {
             tagged.sort_by_key(|(key, _)| *key);
             handles = tagged.into_iter().map(|(_, h)| h).collect();
         }
+
+        // `handles` is already in channel-priority order, so walking it yields
+        // the registrations in that order too. Custom sources have no channel.
+        #[cfg(feature = "experimental-virtual-package-plugins")]
+        let virtual_package_plugins = handles
+            .iter()
+            .filter_map(|h| match &h.kind {
+                SubdirKind::Channel { url, platform } => {
+                    let key = (url.clone(), *platform);
+                    self.virtual_package_plugins.remove(&key).map(|plugins| {
+                        let (channel, platform) = key;
+                        SubdirVirtualPackagePlugins {
+                            channel,
+                            platform,
+                            plugins,
+                        }
+                    })
+                }
+                SubdirKind::Custom => None,
+            })
+            .collect();
 
         let mut repodata: Vec<RepoData> =
             Vec::with_capacity(handles.len() + usize::from(direct.is_some()));
@@ -1188,6 +1231,8 @@ impl QueryExecutor {
                 .into_iter()
                 .map(GatewayWarning::from)
                 .collect(),
+            #[cfg(feature = "experimental-virtual-package-plugins")]
+            virtual_package_plugins,
         })
     }
 }
@@ -1326,13 +1371,13 @@ fn spawn_one_package_fetch(
 #[cfg(target_arch = "wasm32")]
 type BoxFuture<T> = futures::future::LocalBoxFuture<'static, T>;
 
+#[cfg(not(target_arch = "wasm32"))]
+type BoxFuture<T> = futures::future::BoxFuture<'static, T>;
+
 #[cfg(target_arch = "wasm32")]
 fn box_future<T, F: Future<Output = T> + 'static>(future: F) -> BoxFuture<T> {
     future.boxed_local()
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-type BoxFuture<T> = futures::future::BoxFuture<'static, T>;
 
 #[cfg(not(target_arch = "wasm32"))]
 fn box_future<T, F: Future<Output = T> + Send + 'static>(future: F) -> BoxFuture<T> {
@@ -1445,81 +1490,24 @@ impl NamesQuery {
     /// Execute the query and return the package names along with any
     /// non-fatal CEP-42 warnings.
     pub async fn execute(self) -> Result<NamesQueryOutput, GatewayError> {
-        let mut expander = ChannelExpander::new(
-            self.channel_relations_mode,
-            self.channel_relations_max_depth,
-            self.platforms.clone(),
-            self.reporter.clone(),
-        );
-        let mut notices = NoticeCollector::new(self.channel_notices);
-
-        let mut pending: FuturesUnordered<BoxFuture<NamesFetchResult>> = FuturesUnordered::new();
-        for channel in self.channels {
-            let (url, channel_arc) = expander.register_user_channel(channel);
-            notices.queue(
-                &self.gateway,
-                &url,
-                channel_arc.clone(),
-                self.reporter.clone(),
-            );
-            for &platform in &self.platforms {
-                pending.push(spawn_names_fetch(
-                    self.gateway.clone(),
-                    channel_arc.clone(),
-                    platform,
-                    url.clone(),
-                    self.reporter.clone(),
-                    FetchErrorPolicy::Propagate,
-                ));
-            }
-        }
-
         let mut names: std::collections::HashSet<String> = std::collections::HashSet::default();
-        let strict = expander.strict();
-        let policy = if strict {
-            FetchErrorPolicy::WrapAsChannelRelationsError
-        } else {
-            FetchErrorPolicy::SwallowAsWarning
-        };
-
-        loop {
-            select_biased! {
-                result = pending.select_next_some() => {
-                    let (url, platform, subdir, warning) = result?;
-                    if let Some(w) = warning {
-                        expander.push_warning(w);
-                    }
-                    if let Some(subdir_names) = subdir.package_names() {
-                        names.extend(subdir_names);
-                    }
-                    for (new_url, new_channel, new_plat) in expander.observe(&url, platform, &subdir)? {
-                        notices.queue(&self.gateway, &new_url, new_channel.clone(), self.reporter.clone());
-                        pending.push(spawn_names_fetch(
-                            self.gateway.clone(),
-                            new_channel,
-                            new_plat,
-                            new_url,
-                            self.reporter.clone(),
-                            policy,
-                        ));
-                    }
+        let walk = walk_channels(
+            ChannelWalkOptions {
+                gateway: self.gateway,
+                channels: self.channels,
+                platforms: self.platforms,
+                mode: self.channel_relations_mode,
+                max_depth: self.channel_relations_max_depth,
+                reporter: self.reporter,
+                collect_notices: self.channel_notices,
+            },
+            |_url, _platform, subdir| {
+                if let Some(subdir_names) = subdir.package_names() {
+                    names.extend(subdir_names);
                 }
-
-                batch = notices.pending.select_next_some() => {
-                    notices.collect(self.reporter.as_deref(), batch);
-                }
-
-                complete => {
-                    break;
-                }
-            }
-        }
-
-        if expander.enabled() && expander.has_observed_relations() {
-            // Names are an unordered set; finalize only for its
-            // depth/cycle diagnostics and strict-mode errors.
-            expander.finalize()?;
-        }
+            },
+        )
+        .await?;
 
         let names = names
             .into_iter()
@@ -1527,14 +1515,169 @@ impl NamesQuery {
             .collect::<Result<Vec<PackageName>, _>>()?;
         Ok(NamesQueryOutput {
             names,
-            notices: notices.collected,
-            warnings: expander
-                .take_warnings()
+            notices: walk.notices,
+            warnings: walk
+                .warnings
                 .into_iter()
                 .map(GatewayWarning::from)
                 .collect(),
         })
     }
+}
+
+/// Everything a walk over a set of channels and the channels their CEP-42
+/// relations reach produced.
+pub(super) struct ChannelWalk {
+    /// Every channel walked, in CEP-42 priority order.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub order: Vec<ChannelUrl>,
+
+    /// The [`Channel`] behind each url, since a walk discovers channels the
+    /// caller never named and a caller may want to query them.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub channels: HashMap<ChannelUrl, Arc<Channel>>,
+
+    /// CEP-6 notices, empty unless the walk was asked for them.
+    pub notices: Vec<ChannelNoticeResult>,
+
+    /// Non-fatal relation problems met on the way.
+    pub warnings: Vec<ChannelRelationsWarning>,
+}
+
+/// What a [`walk_channels`] needs: where to fetch from, what to start from, and
+/// how much of CEP-42 to honour on the way.
+pub(super) struct ChannelWalkOptions {
+    /// Where to fetch subdirs from.
+    pub gateway: Arc<GatewayInner>,
+
+    /// The channels to start from, in the order the caller gave them, which
+    /// CEP-42 treats as priority edges of its own.
+    pub channels: Vec<Channel>,
+
+    /// The subdirs to fetch of every channel walked.
+    pub platforms: Vec<Platform>,
+
+    /// How to treat the relations the channels declare.
+    pub mode: ChannelRelationsMode,
+
+    /// How far a chain of relations may be followed.
+    pub max_depth: usize,
+
+    /// Told about warnings as they are recorded.
+    pub reporter: Option<Arc<dyn Reporter>>,
+
+    /// Whether to fetch the CEP-6 notices of every channel walked.
+    pub collect_notices: bool,
+}
+
+/// Which error policy a channel a relation discovered is fetched under.
+fn discovery_policy(expander: &ChannelExpander) -> FetchErrorPolicy {
+    if expander.strict() {
+        FetchErrorPolicy::WrapAsChannelRelationsError
+    } else {
+        FetchErrorPolicy::SwallowAsWarning
+    }
+}
+
+/// Fetches every subdir of `channels` and of the channels their CEP-42
+/// relations reach, hands each one to `visit`, and resolves the priority order
+/// they end up in.
+pub(super) async fn walk_channels<Visit>(
+    options: ChannelWalkOptions,
+    mut visit: Visit,
+) -> Result<ChannelWalk, GatewayError>
+where
+    Visit: FnMut(&ChannelUrl, Platform, &Subdir),
+{
+    let ChannelWalkOptions {
+        gateway,
+        channels,
+        platforms,
+        mode,
+        max_depth,
+        reporter,
+        collect_notices,
+    } = options;
+
+    let mut expander = ChannelExpander::new(mode, max_depth, platforms.clone(), reporter.clone());
+    let mut notices = NoticeCollector::new(collect_notices);
+    let mut walked: HashMap<ChannelUrl, Arc<Channel>> = HashMap::new();
+
+    let mut pending: FuturesUnordered<BoxFuture<NamesFetchResult>> = FuturesUnordered::new();
+    let mut user_order: Vec<ChannelUrl> = Vec::new();
+    for channel in channels {
+        let (url, channel) = expander.register_user_channel(channel);
+        if !user_order.contains(&url) {
+            user_order.push(url.clone());
+        }
+        walked.insert(url.clone(), channel.clone());
+        notices.queue(&gateway, &url, channel.clone(), reporter.clone());
+        for &platform in &platforms {
+            pending.push(spawn_names_fetch(
+                gateway.clone(),
+                channel.clone(),
+                platform,
+                url.clone(),
+                reporter.clone(),
+                FetchErrorPolicy::Propagate,
+            ));
+        }
+    }
+
+    let policy = discovery_policy(&expander);
+    loop {
+        select_biased! {
+            result = pending.select_next_some() => {
+                let (url, platform, subdir, warning) = result?;
+                if let Some(warning) = warning {
+                    expander.push_warning(warning);
+                }
+                visit(&url, platform, subdir.as_ref());
+                for (url, channel, platform) in expander.observe(&url, platform, &subdir)? {
+                    walked.insert(url.clone(), channel.clone());
+                    notices.queue(&gateway, &url, channel.clone(), reporter.clone());
+                    pending.push(spawn_names_fetch(
+                        gateway.clone(),
+                        channel,
+                        platform,
+                        url,
+                        reporter.clone(),
+                        policy,
+                    ));
+                }
+            }
+
+            batch = notices.pending.select_next_some() => {
+                notices.collect(reporter.as_deref(), batch);
+            }
+
+            complete => {
+                break;
+            }
+        }
+    }
+
+    // Resolved even where no relation was declared: the order is then the one
+    // the caller gave. Finalizing also reports the depth and cycle problems met
+    // on the way, so it runs whether or not anything reads the order it produces.
+    let user_caller_idx: HashMap<ChannelUrl, usize> = user_order
+        .into_iter()
+        .enumerate()
+        .map(|(index, url)| (url, index))
+        .collect();
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    let order = expander.finalize_channel_order(&user_caller_idx)?.channels;
+    #[cfg(not(feature = "experimental-virtual-package-plugins"))]
+    expander.finalize_channel_order(&user_caller_idx)?;
+
+    Ok(ChannelWalk {
+        #[cfg(feature = "experimental-virtual-package-plugins")]
+        order,
+        #[cfg(feature = "experimental-virtual-package-plugins")]
+        channels: walked,
+        notices: notices.collected,
+        warnings: expander.take_warnings(),
+    })
 }
 
 type NamesFetchResult = Result<

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/mod.rs
@@ -1,5 +1,7 @@
 use crate::gateway::subdir::{PackageRecords, SubdirClient};
 use crate::{GatewayError, Reporter};
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{ChannelRelations, PackageName, RepodataRevisions};
 
 cfg_if::cfg_if! {
@@ -33,5 +35,10 @@ impl SubdirClient for RemoteSubdirClient {
 
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.sparse.channel_relations()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        self.sparse.virtual_package_plugins()
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -183,6 +183,8 @@ mod tests {
         routing::get,
     };
     use rattler_conda_types::{Channel, RepodataRevisions, ShardedRepodata, ShardedSubdirInfo};
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    use rattler_conda_types::{PackageName, VirtualPackagePlugins};
     use rattler_digest::{Sha256, parse_digest_from_hex};
     use std::future::IntoFuture;
     use std::net::SocketAddr;
@@ -224,7 +226,7 @@ mod tests {
                     repodata_revisions: RepodataRevisions::default(),
                     channel_relations: None,
                     #[cfg(feature = "experimental-virtual-package-plugins")]
-                    virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
+                    virtual_package_plugins: mock_virtual_package_plugins(),
                 },
                 shards,
             };
@@ -310,6 +312,47 @@ mod tests {
     enum MockShardResponse {
         Empty,
         Truncated,
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn mock_virtual_package_plugins() -> VirtualPackagePlugins {
+        [(
+            PackageName::new_unchecked("cuda-detect"),
+            vec![
+                PackageName::new_unchecked("__cuda"),
+                PackageName::new_unchecked("__cuda_arch"),
+            ],
+        )]
+        .into_iter()
+        .collect()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    #[tokio::test]
+    async fn test_sharded_index_reports_virtual_package_plugins() {
+        let server = MockShardedServer::new(MockShardResponse::Empty).await;
+        let cache_dir = tempfile::tempdir().unwrap();
+
+        let subdir = ShardedSubdir::new(
+            server.channel(),
+            "linux-64".to_string(),
+            rattler_networking::LazyClient::default(),
+            cache_dir.path().to_path_buf(),
+            ShardCachePolicy {
+                action: CacheAction::NoCache,
+                missing_shards_are_empty: false,
+            },
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            subdir.virtual_package_plugins(),
+            &mock_virtual_package_plugins()
+        );
     }
 
     #[tokio::test]
@@ -511,10 +554,6 @@ mod tests {
     const CACHE_ONLY_ACTIONS: [CacheAction; 2] =
         [CacheAction::UseCacheOnly, CacheAction::ForceCacheOnly];
 
-    /// A cache-only build with no index cached must report
-    /// [`GatewayError::ShardedIndexNotCached`] and nothing else: that is the
-    /// variant `SubdirBuilder` matches on to fall back to `repodata.json`,
-    /// which may well be cached even when the sharded index is not.
     #[tokio::test]
     async fn uncached_index_is_reported_as_such_in_cache_only_mode() {
         let server = MockShardedServer::new(MockShardResponse::Empty).await;
@@ -543,10 +582,6 @@ mod tests {
         );
     }
 
-    /// Without the opt-in, a cold shard fails a cache-only query with a
-    /// distinct error: nothing is known about the package, which is not the
-    /// same as the package having no records. Neither mode may touch the
-    /// network to find out.
     #[tokio::test]
     async fn cold_shard_is_an_error_by_default() {
         for action in CACHE_ONLY_ACTIONS {
@@ -573,10 +608,6 @@ mod tests {
         }
     }
 
-    /// With `missing_shards_are_empty` the same query reports the package as
-    /// having no records, which lets a caller that restricts a solve to
-    /// locally available packages fail on the restriction instead of on the
-    /// cache. Neither mode may touch the network to find out.
     #[tokio::test]
     async fn cold_shard_is_empty_when_opted_in() {
         for action in CACHE_ONLY_ACTIONS {

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
@@ -7,6 +7,8 @@ use std::{
 };
 
 use rattler_conda_types::Platform;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 
 use super::{
     add_trailing_slash, decode_zst_bytes_async, is_missing_sharded_repodata_status, parse_records,
@@ -320,6 +322,11 @@ impl SubdirClient for ShardedSubdir {
 
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.sharded_repodata.info.channel_relations.as_ref()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        &self.sharded_repodata.info.virtual_package_plugins
     }
 }
 

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
 use futures::future::OptionFuture;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{
     Channel, ChannelRelations, PackageName, RepodataRevisions, ShardedRepodata,
 };
@@ -196,5 +198,10 @@ impl SubdirClient for ShardedSubdir {
 
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.sharded_repodata.info.channel_relations.as_ref()
+    }
+
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        &self.sharded_repodata.info.virtual_package_plugins
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir.rs
@@ -1,11 +1,15 @@
 use std::sync::Arc;
 
 use ahash::HashMap;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{ChannelRelations, PackageName, RepoDataRecord, RepodataRevisions};
 
 use super::GatewayError;
 use crate::Reporter;
 use crate::sparse::empty_repodata_revisions;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use crate::sparse::empty_virtual_package_plugins;
 use coalesced_map::{CoalescedGetError, CoalescedMap};
 
 /// Records for a single package, with precomputed unique dependency strings
@@ -114,6 +118,16 @@ impl Subdir {
             Subdir::NotFound => None,
         }
     }
+
+    /// Virtual package detection plugins registered by this subdir, or empty
+    /// if none are registered / the subdir was not found.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        match self {
+            Subdir::Found(subdir) => subdir.virtual_package_plugins(),
+            Subdir::NotFound => empty_virtual_package_plugins(),
+        }
+    }
 }
 
 /// Fetches and caches repodata records by package name for a specific
@@ -172,6 +186,12 @@ impl SubdirData {
     pub fn channel_relations(&self) -> Option<&ChannelRelations> {
         self.client.channel_relations()
     }
+
+    /// Virtual package detection plugins registered by this subdir.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        self.client.virtual_package_plugins()
+    }
 }
 
 /// A client that can be used to fetch repodata for a specific subdirectory.
@@ -200,6 +220,13 @@ pub trait SubdirClient: Send + Sync {
     /// [CEP-42]: https://github.com/conda/ceps/blob/main/cep-0042.md
     fn channel_relations(&self) -> Option<&ChannelRelations> {
         None
+    }
+
+    /// Virtual package detection plugins registered by this subdir. Sources
+    /// that cannot carry the metadata (e.g. custom) keep the empty default.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        empty_virtual_package_plugins()
     }
 }
 
@@ -311,8 +338,6 @@ mod tests {
         assert_eq!(&*per_extra["d"], &["aiosignal".to_string()]);
     }
 
-    /// A dep that appears in the base set of one record and in an extra of
-    /// another must not be repeated in the extra (base wins).
     #[test]
     fn extract_unique_deps_split_base_wins_across_records() {
         let rec_a = make_record("black", &["aiohttp"], &[]);
@@ -322,9 +347,6 @@ mod tests {
         assert_eq!(&*per_extra["d"], &["aiosignal".to_string()]);
     }
 
-    /// Same as `extract_unique_deps_split_base_wins_across_records` but with
-    /// the records visited in the opposite order. The base-wins invariant
-    /// must hold regardless of iteration order.
     #[test]
     fn extract_unique_deps_split_base_wins_reversed_order() {
         let rec_extra_first = make_record("black", &[], &[("d", &["aiohttp", "aiosignal"])]);
@@ -334,8 +356,6 @@ mod tests {
         assert_eq!(&*per_extra["d"], &["aiosignal".to_string()]);
     }
 
-    /// An extra whose only dep also appears in some record's base list must
-    /// not produce an empty entry in the per-extra map.
     #[test]
     fn extract_unique_deps_split_extra_fully_subsumed_is_dropped() {
         let rec_extra_first = make_record("black", &[], &[("d", &["aiohttp"])]);

--- a/crates/rattler_repodata_gateway/src/lib.rs
+++ b/crates/rattler_repodata_gateway/src/lib.rs
@@ -84,5 +84,7 @@ pub use gateway::{
 };
 #[cfg(feature = "indicatif")]
 pub use gateway::{IndicatifReporter, IndicatifReporterBuilder};
+#[cfg(all(feature = "gateway", feature = "experimental-virtual-package-plugins"))]
+pub use gateway::{ResolvedChannels, SubdirVirtualPackagePlugins};
 #[cfg(all(not(target_arch = "wasm32"), feature = "gateway"))]
 pub use gateway::{RunExportExtractorError, RunExportsReporter};

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -14,6 +14,8 @@ use std::{
 
 use bytes::Bytes;
 use itertools::Itertools;
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{
     Channel, ChannelInfo, ChannelRelations, MatchSpec, Matches, PackageName, PackageRecord,
     RepoDataRecord, RepodataRevisions, UrlOrPath, WhlPackageRecord, compute_package_url,
@@ -34,6 +36,14 @@ use thiserror::Error;
 /// Shared empty revisions, returned by accessors when none are advertised.
 pub(crate) fn empty_repodata_revisions() -> &'static RepodataRevisions {
     static EMPTY: LazyLock<RepodataRevisions> = LazyLock::new(RepodataRevisions::new);
+    &EMPTY
+}
+
+/// Shared empty plugin registrations, returned by accessors when a subdir
+/// registers none.
+#[cfg(feature = "experimental-virtual-package-plugins")]
+pub(crate) fn empty_virtual_package_plugins() -> &'static VirtualPackagePlugins {
+    static EMPTY: LazyLock<VirtualPackagePlugins> = LazyLock::new(VirtualPackagePlugins::new);
     &EMPTY
 }
 
@@ -537,6 +547,16 @@ impl SparseRepoData {
             .as_ref()?
             .channel_relations
             .as_ref()
+    }
+
+    /// Virtual package detection plugins registered in
+    /// `info.virtual_package_plugins`.
+    #[cfg(feature = "experimental-virtual-package-plugins")]
+    pub fn virtual_package_plugins(&self) -> &VirtualPackagePlugins {
+        match &self.inner.borrow_repo_data().info {
+            Some(info) => &info.virtual_package_plugins,
+            None => empty_virtual_package_plugins(),
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Implements virtual package plugin support in the rattler-repodata-gateway layer.

Stack base: `virtual-package-plugins-cache`.

Stack:
1. `virtual-package-plugins-conda-types`
2. `virtual-package-plugins-cache`
3. `virtual-package-plugins-repodata-gateway` (this PR)
4. `virtual-package-plugins-index`
5. `virtual-package-plugins-runtime`
6. `virtual-package-plugins-bin`

### How Has This Been Tested?

- `pixi run cargo-fmt`
- `pixi run -- cargo nextest run -p rattler_cache --features experimental-virtual-package-plugins virtual_package_plugin_cache`
- `pixi run -- cargo nextest run -p rattler_virtual_package_plugins --features experimental-virtual-package-plugins`
- `pixi run -- cargo clippy -p rattler_cache --features experimental-virtual-package-plugins --all-targets -- -D warnings`
- `pixi run -- cargo clippy -p rattler_virtual_package_plugins --features experimental-virtual-package-plugins --all-targets -- -D warnings`
- `pixi run -- cargo clippy -p rattler-bin --features experimental-virtual-package-plugins --all-targets -- -D warnings`

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
