### PR TITLE
feat(rattler-index): implement virtual package plugins

### DIFF
--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -30,6 +30,7 @@ rustls = [
 s3 = ["opendal/services-s3", "dep:rattler_s3"]
 experimental-virtual-package-plugins = [
   "rattler_conda_types/experimental-virtual-package-plugins",
+  "rattler_repodata_gateway/experimental-virtual-package-plugins",
 ]
 
 [[bin]]

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -28,6 +28,8 @@ use opendal::layers::RetryLayer;
 #[cfg(feature = "s3")]
 use opendal::services::S3Config;
 use opendal::{Configurator, Operator, services::FsConfig};
+#[cfg(feature = "experimental-virtual-package-plugins")]
+use rattler_conda_types::VirtualPackagePlugins;
 use rattler_conda_types::{
     ChannelInfo, ChannelNotice, ChannelNotices, ChannelRelations, MatchSpec, PackageRecord,
     ParseMatchSpecOptions, PatchInstructions, Platform, RepoData, Shard, ShardedRepodata,
@@ -956,7 +958,7 @@ async fn index_subdir_inner(
             ),
             channel_relations: channel_metadata.channel_relations,
             #[cfg(feature = "experimental-virtual-package-plugins")]
-            virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
+            virtual_package_plugins: VirtualPackagePlugins::default(),
         }),
         packages,
         conda_packages,
@@ -1540,7 +1542,7 @@ pub async fn write_repodata(
                 repodata_revisions: sharded_repodata_revisions,
                 channel_relations: sharded_channel_relations,
                 #[cfg(feature = "experimental-virtual-package-plugins")]
-                virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
+                virtual_package_plugins: VirtualPackagePlugins::default(),
             },
             shards: shards
                 .iter()
@@ -2025,7 +2027,7 @@ pub async fn ensure_channel_initialized_with_channel_metadata(
             repodata_revisions: RepodataRevisions::new(),
             channel_relations: channel_metadata.channel_relations,
             #[cfg(feature = "experimental-virtual-package-plugins")]
-            virtual_package_plugins: rattler_conda_types::VirtualPackagePlugins::default(),
+            virtual_package_plugins: VirtualPackagePlugins::default(),
         }),
         packages: IndexMap::default(),
         conda_packages: IndexMap::default(),


### PR DESCRIPTION
### Description

Implements virtual package plugin support in the rattler-index layer.

Stack base: `virtual-package-plugins-repodata-gateway`.

Stack:
1. `virtual-package-plugins-conda-types`
2. `virtual-package-plugins-cache`
3. `virtual-package-plugins-repodata-gateway`
4. `virtual-package-plugins-index` (this PR)
5. `virtual-package-plugins-runtime`
6. `virtual-package-plugins-bin`

### How Has This Been Tested?

- `pixi run cargo-fmt`
- `pixi run -- cargo nextest run -p rattler_cache --features experimental-virtual-package-plugins virtual_package_plugin_cache`
- `pixi run -- cargo nextest run -p rattler_virtual_package_plugins --features experimental-virtual-package-plugins`
- `pixi run -- cargo clippy -p rattler_cache --features experimental-virtual-package-plugins --all-targets -- -D warnings`
- `pixi run -- cargo clippy -p rattler_virtual_package_plugins --features experimental-virtual-package-plugins --all-targets -- -D warnings`
- `pixi run -- cargo clippy -p rattler-bin --features experimental-virtual-package-plugins --all-targets -- -D warnings`

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
