### PR TITLE
chore: prepare py-rattler v0.26.0 release

### DIFF
--- a/.agents/skills/prepare-py-rattler-release/SKILL.md
+++ b/.agents/skills/prepare-py-rattler-release/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: prepare-py-rattler-release
+description: Prepare a py-rattler (Python bindings) release PR against conda/rattler — assess what landed since the last tag, pick the version bump, write the CHANGELOG entry with tested example snippets, and open a draft PR from the fork. Use when asked to prepare, cut, or draft a py-rattler release, or to bump the Python bindings version.
+---
+
+# Prepare a py-rattler release
+
+Opens one draft PR against `conda/rattler:main` from the maintainer's fork: bumps the version, writes the changelog section, lists whatever still has to land first.
+
+Python bindings only. The crates in `crates/` release themselves through release-plz (the `chore: release (#NNNN)` commits). Publishing is separate: once this merges, someone dispatches `.github/workflows/release-python.yml` with the version as `tag`, which builds the wheels, pushes to PyPI and tags `py-rattler-v<version>`.
+
+## 1. Isolated checkout
+
+`jj root` tells you which VCS you are in. Colocated repos take either.
+
+Don't work in the checkout you already have open. It usually carries churn you don't want in a release commit.
+
+```powershell
+# jj
+jj git fetch --remote upstream
+jj workspace add --name release-py ..\rattler-release-py
+jj new 'main@upstream'   # inside the new workspace
+
+# git
+git fetch upstream
+git worktree add -b prepare-py-rattler-v<version> ..\rattler-release-py upstream/main
+```
+
+jj wants `main@upstream`, git wants `upstream/main`. `jj workspace add --revision 'upstream/main'` fails *after* creating the directory, so just `jj new` inside it.
+
+A jj workspace has no `.git`, so run `git log`/`git show`/`gh` from the colocated checkout and use `jj diff`/`jj st` inside the workspace. A git worktree has one and everything runs in place.
+
+Afterwards: `jj workspace forget release-py` or `git worktree remove ..\rattler-release-py`, then delete the directory.
+
+`origin` is the fork, `upstream` is `conda/rattler`. Check `git remote -v` instead of guessing the owner.
+
+## 2. Range
+
+```powershell
+git tag --list 'py-rattler-v*' --sort=-v:refname | Select-Object -First 1
+git log --oneline <last-tag>..upstream/main
+```
+
+Read `## [Unreleased]` in `py-rattler/CHANGELOG.md` too. Earlier PRs may have filed entries there; fold them in rather than duplicating them.
+
+## 3. Triage
+
+py-rattler is a thin PyO3 wrapper and the wheel vendors the crates, so a crate change ships to Python users even when nothing under `py-rattler/` was touched. Ask "would a Python user notice this?", not "which directory did it touch?".
+
+Drop `chore(ci)`, renovate and dependabot bumps, `chore: release`, js-rattler-only changes, test-only changes, docs-only changes. Keep new or changed Python API, bugs users actually hit, security fixes, real performance work, new platforms, and dependency bumps that change behavior.
+
+Listing what each commit touched under `py-rattler/` separates API work from dependency noise quickly:
+
+```powershell
+$commits = git log --format='%h %s' <last-tag>..upstream/main -- py-rattler/
+foreach ($c in $commits) {
+  $h = $c.Split(' ')[0]
+  $files = git show --pretty=format: --name-only $h -- py-rattler/ | Where-Object { $_ -and $_ -notmatch 'Cargo.lock|pixi.lock' }
+  if ($files) { Write-Output "=== $c"; $files | ForEach-Object { Write-Output "    $_" } }
+}
+```
+
+`py-rattler/rattler/**.py` or `py-rattler/src/**.rs` means the Python surface moved. Only `py-rattler/Cargo.toml` is usually a dependency bump.
+
+Don't read dependency versions off commit subjects. Bumps ride along inside unrelated feature PRs, and a PR titled after its own feature can quietly move the solver two minor versions. Diff the lock across the range instead, and pay attention to anything the bindings actually run (`resolvo` above all, since every `solve()` is it):
+
+```powershell
+git show <last-tag>:py-rattler/Cargo.lock | Select-String -Pattern 'name = "resolvo"' -Context 0,1
+git show upstream/main:py-rattler/Cargo.lock | Select-String -Pattern 'name = "resolvo"' -Context 0,1
+```
+
+The wheel ships whatever the lock says: `MATURIN_PEP517_ARGS` in `py-rattler/pixi.toml` includes `--locked`.
+
+## 4. Breaking changes
+
+Rust API breakage and py-rattler breakage are mostly unrelated. A renamed Rust type is invisible from Python unless the bindings expose it, and most of those shouldn't be in the changelog at all. The other direction matters more: a Rust change with no API break can still break Python users, because the surface stayed identical while the behavior under it moved. That is the case that gets missed.
+
+Breaking means any of:
+
+- removed or renamed symbol, changed signature, changed return type, changed default
+- same call, different result. A different solve, a parser that now accepts or rejects, a changed `__str__`, a changed sort or cache key
+- format changes: lockfile version, on-disk cache, repodata wire model
+
+`feat!:` subjects and leftover `cargo-semver-checks` bot comments say where to look. They are not evidence.
+
+**Ask about one PR at a time.** One candidate, one question, then wait. Don't batch them into a multi-select or a list to tick off. The maintainer usually wants to ask something back ("does that path even run without a gateway?") and a checkbox gives them nowhere to do it. Expect several turns.
+
+Argue four things per candidate:
+
+1. **The call.** `solve(...)`, `str(MatchSpec)`, `Gateway.query(...)`, `index_fs(...)`. Not "the solver changed". If you can't name one it isn't a candidate. Carry the name into the changelog entry too.
+2. **The code path.** Python entry point → PyO3 binding → the crate item the PR changed, with file references so it can be checked. Say what makes a conditional path run. If you can't trace it end to end you don't understand it well enough to ask yet.
+3. **Before → after**, with a real value. `foo py39h123_0` → `foo * py39h123_0`.
+4. **Who it hits**, including when you think that's nobody.
+
+Include the ones you're unsure about and say you're unsure. The verdict is the maintainer's: rejected means the entry loses its `**BREAKING:**` prefix, moves back to Added or Fixed, drops out of the highlights and stops counting toward the bump. Settle this before steps 5 and 6.
+
+## 5. Version
+
+py-rattler is pre-1.0, so breaking goes in the minor slot. Anything breaking gives `0.X+1.0`, otherwise `0.X.Y+1`. Say why before editing.
+
+Three places have to agree, and `pixi run -e test lint` fails on the first two drifting (`scripts/ensure-version-synced.nu`):
+
+- `py-rattler/Cargo.toml`, `[package] version`
+- `py-rattler/pyproject.toml`, `[project] version`
+- `py-rattler/Cargo.lock`, through `pixi run -- cargo update --manifest-path py-rattler/Cargo.toml --workspace --offline`. `cargo` is not on `PATH` outside pixi.
+
+The lock diff should be that one version line; a wider refresh is fine but mention it. `rattler.__version__` comes from the crate version at runtime, so there's nothing to bump in the Python sources. `py-rattler/pixi.lock` should not change at all, and any `pixi run` inside `py-rattler/` rewrites it, so put it back with `jj restore --from '@-' py-rattler/pixi.lock` or `git checkout -- py-rattler/pixi.lock`.
+
+## 6. Changelog
+
+```markdown
+## [Unreleased]
+
+## [0.26.0] - 2026-08-19
+
+### Highlights
+### Added
+### Changed
+### Fixed
+### Performance
+```
+
+- One line per entry, imperative, ending in `` in [#NNNN](https://github.com/conda/rattler/pull/NNNN) ``. Full links here, not bare `#NNNN`: this file renders on PyPI and the docs site.
+- Breaking entries take `**BREAKING:** ` and come first under `### Changed`, whatever the commit type was. Name the old behavior and the new one so a reader can tell whether their code is affected.
+- Every breaking change also gets a `**Breaking: ...**` paragraph in the highlights with the migration. Never let one show up only as a bullet.
+- Highlights cover the few things a user would actually want to know: a new capability, a changed way of doing something, or a speedup big enough to feel. Add a short snippet where that beats prose, and drop the imports unless the import path is the surprising part. A measured performance win belongs here with its numbers, not buried at the bottom under `### Performance`.
+- **Never hard-wrap.** One line per paragraph and per entry, however long. Nothing reflows markdown in this repo (dprint only does YAML), and re-wrapping one sentence rewrites the whole paragraph in the next diff. If you unwrap mechanically, watch the link-reference definitions at the bottom of the file and any YAML frontmatter; joining those silently breaks them. Reflow only your own section and check the diff shows nothing outside it.
+- Omit empty sections. Security fixes link the advisory. Date with `Get-Date -Format 'yyyy-MM-dd'`.
+
+## 7. Test the snippets
+
+```powershell
+pixi run -e test python -c "<snippet>"
+```
+
+from `py-rattler/`. The first run compiles the extension and takes 10+ minutes, so start it in the background right after step 2 and triage while it builds.
+
+On Windows it will probably die in `aws-lc-sys` (rustls is the default feature): no NASM, and then `error C1083: Cannot open include file` from aws-lc's own C sources even with `cmake`, `ninja`, `nasm` and `AWS_LC_SYS_CMAKE_BUILDER = "1"` added to `py-rattler/pixi.toml`. That's the machine, not the release. Don't sink more than an attempt or two into it: use WSL or Linux, or check the snippets against `py-rattler/rattler/**` and say in the PR they weren't run. Revert any pixi.toml workaround. (`pixi exec nasm` doesn't help, rattler-build rebuilds `PATH`.)
+
+Wrap async snippets in `asyncio.run(...)` to test them. Prefer constructions that work offline. Never present an untested snippet as tested.
+
+## 8. Pending work
+
+Open PRs labelled `python-bindings` are usually it:
+
+```powershell
+$prs = gh pr list --repo conda/rattler --label python-bindings --state open --limit 50 --json number,title,isDraft | ConvertFrom-Json
+foreach ($p in $prs) { "#$($p.number) [$(if($p.isDraft){'draft'}else{'ready'})] $($p.title)" }
+```
+
+```bash
+gh pr list --repo conda/rattler --label python-bindings --state open --limit 50 --json number,title,isDraft --jq '.[] | "#\(.number) [\(if .isDraft then "draft" else "ready" end)] \(.title)"'
+```
+
+The PowerShell variant builds the strings in a loop because a `-q` jq expression with spaces gets mangled there.
+
+Show that list, ask whether any should land first and whether anything else is pending, then look up whatever gets named with `gh pr view`, `gh issue view` or `gh search prs`. Say so if you can't find something instead of guessing a number.
+
+## 9. Open the PR
+
+```powershell
+# jj (no --allow-new; create the bookmark locally first)
+jj describe -m 'chore: prepare py-rattler v<version> release'
+jj commit
+jj bookmark create prepare-py-rattler-v<version> --revision '@-'
+jj git push --remote origin --bookmark prepare-py-rattler-v<version>
+
+# git (the branch already exists from `worktree add -b`)
+git add -A
+git commit -m 'chore: prepare py-rattler v<version> release'
+git push -u origin prepare-py-rattler-v<version>
+```
+
+```powershell
+gh pr create --repo conda/rattler --base main --head <fork-owner>:prepare-py-rattler-v<version> --draft --title "chore: prepare py-rattler v<version> release" --body-file <file>
+```
+
+Amending later is `jj squash` then a plain `jj git push` (the bookmark follows the rewrite), or `git commit --amend` and `git push --force-with-lease`.
+
+**Keep the body short.** Link the rendered changelog near the top, then write only what it doesn't say. Half a screen, and if a sentence is already true in the changelog, cut it rather than reword it.
+
+```markdown
+**[changelog](https://github.com/<fork-owner>/rattler/blob/<branch>/py-rattler/CHANGELOG.md)**
+```
+
+Include the version and the one or two changes that forced the bump level, the judgment calls from step 4 with an invitation to push back (that part exists nowhere else, and it's the only bit a reviewer can really check you on), the pending checklist under `### Pending before release`, whether the snippets ran, and the template's AI disclosure with `Tools:`. Don't paste the user's prompt. `AGENTS.md` suggests it, but on a release PR it's long and buries everything that matters. Leave the disclosure boxes for the maintainer to tick.
+
+Reference PRs bare (`#2700`), never with a copied title. GitHub attaches the live title, a copied one goes stale the moment someone retitles. Where the reader needs to know what a PR does to them, describe the effect instead ("`solve()` follows CEP-42 relations by default"); that's content, not a title.
+
+Reread the body before posting and rewrite whatever sounds like AI wrote it: spaced em dashes as an all-purpose connector, bolded lead-ins, every paragraph the same length, sentences built in neat parallel. Break it up until it reads like a person wrote it. Short sentences are fine, and saying a caveat bothers you beats dressing it up as a limitation.
+
+Draft as long as anything is pending, and `gh pr ready <n> --repo conda/rattler` only once the maintainer confirms. If nothing is pending, still open as draft and ask.
+
+When a pending PR lands the notes are stale. Rebase onto `main@upstream`, re-run steps 2 to 4 over the new commits, add entries for whatever API arrived, and say in the PR which items are already folded in.
+
+## Checklist
+
+- [ ] fresh worktree or workspace on `upstream/main`, not the checkout you had open
+- [ ] whole range triaged, drops deliberate
+- [ ] each breaking candidate argued with its call and traced code path, asked one at a time, confirmed
+- [ ] bump level justified
+- [ ] `Cargo.toml`, `pyproject.toml` and `Cargo.lock` agree, `pixi.lock` untouched
+- [ ] changelog dated, grouped, linked, breaking marked and called out in the highlights
+- [ ] snippets run, or reported as unverified
+- [ ] `python-bindings` PRs checked and pending work listed
+- [ ] PR body links the changelog, repeats none of it, humanized
+- [ ] opened as a draft from the fork against `conda/rattler:main`

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/py-rattler/CHANGELOG.md
+++ b/py-rattler/CHANGELOG.md
@@ -7,6 +7,134 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-09-10
+
+### Highlights
+
+**Solving got about twice as fast.** Median solve times of `py-rattler-v0.25.0` (resolvo 0.10.3) against this release (0.12.1):
+
+| Environment | 0.25.0 / 0.10.3 | 0.26.0 / 0.12.1 | Reduction |
+|---|---:|---:|---:|
+| Python 3.9 | 2.948 ms | 1.588 ms | 46.1% |
+| xtensor/xsimd | 1.903 ms | 1.163 ms | 38.9% |
+| TensorFlow | 152.068 ms | 65.047 ms | 57.2% |
+| Quetz | 203.054 ms | 97.023 ms | 52.2% |
+| TensorBoard/grpc | 74.354 ms | 30.696 ms | 58.7% |
+
+**Read a single file out of a package without downloading it.** `PackageArchive` opens a `.conda` archive over HTTP range requests and reads only the entries you ask for, so inspecting metadata no longer costs a full download. Local paths work too, and `RepoDataRecord.from_package_archive()` turns a local `.conda` or `.tar.bz2` into a record that `install()` accepts.
+
+```python
+from rattler.package_streaming import PackageArchive
+
+pkg = await PackageArchive.from_url(client, url)
+index = await pkg.index_json()
+recipe = await pkg.read_file("info/recipe/meta.yaml")
+```
+
+**Solve from repodata you already have.** `solve` accepts `SparseRepoData` next to channels and `RepoDataSource`, so cached or locally produced repodata can go into a solve without routing it through the gateway. Both solve entry points also gained `add_pip_as_python_dependency`.
+
+```python
+sparse = SparseRepoData(Channel("conda-forge"), "noarch", "noarch/repodata.json")
+records = await solve([sparse], ["python 3.12.*"], add_pip_as_python_dependency=True)
+```
+
+**Read a config file from Python.** `Config` parses the same TOML the rest of the rattler tooling reads, and `install()`, `index_fs()`, `index_s3()`, `Client.from_config()` and `Gateway.from_config()` accept one. Nothing reads a config file unless you pass it in.
+
+```python
+config = Config.load_from_default_locations("rattler-build")
+gateway = Gateway.from_config(config)
+await install(records, target_prefix, config=config)
+```
+
+**Ask what depends on a package.** `Gateway.who_needs()` scans a subdir's repodata in reverse and returns the records that declare a dependency on your target, direct dependents only.
+
+```python
+dependents = await Gateway().who_needs([Channel("conda-forge")], ["linux-64"], "openssl")
+{d.record.name.normalized for d in dependents}
+```
+
+**CEP-6 channel notices.** Pass `channel_notices=True` to `query`/`names` and read them off the result, or fetch them with `Gateway.channel_notices(...)`.
+
+**Breaking: `repodata_revisions` is a list now.** The `vN`-keyed mapping introduced in 0.25.0 let callers hand-write revision statistics that the indexer already derives. Revisions are selected by name now, optionally with a publisher message, and the old mapping raises a `TypeError` that spells out the new shape.
+
+```python
+# before
+await index_fs(channel_dir, repodata_revisions={"v3": {"n_packages": 1}})
+# now
+await index_fs(channel_dir, repodata_revisions=["v3"])
+await index_fs(channel_dir, repodata_revisions=[{"revision": "v3", "message": "v3 packages"}])
+```
+
+**Breaking: CEP-42 relations are followed by default.** `Gateway.query()`, `Gateway.names()` and `solve()` follow a channel's declared `channel_relations` now, pulling the related channels into the query and into the priority order; previously they were ignored. Only channels that publish CEP-42 metadata are affected. Cycles and failed fetches surface as `rattler.exceptions.GatewayWarning`, and `channel_relations="disabled"` restores the old behavior ([#2462](https://github.com/conda/rattler/pull/2462)).
+
+### Added
+
+- Read rattler configuration files from Python with `Config`, including `from_toml`, `load_from_files`, `load_from_default_locations`, `set`/`unset`, `to_toml` and `save` in [#2772](https://github.com/conda/rattler/pull/2772)
+- Accept a `config` argument on `install`, `index_fs` and `index_s3`, add `Client.from_config()` and `Gateway.from_config()`, and raise `ConfigError` for a config that cannot be loaded in [#2772](https://github.com/conda/rattler/pull/2772)
+- Look up reverse dependencies with `Gateway.who_needs(sources, platforms, target)`, returning `Dependent` edges with `record`, `dependency`, `kind`, `run_export_kind` and `extra` in [#2738](https://github.com/conda/rattler/pull/2738)
+- Inspect the packages a channel marks as removed through `GatewayQueryResult.removed`, `SparseRepoData.load_removed()` and the new `RemovedPackage` in [#2751](https://github.com/conda/rattler/pull/2751)
+- Expose `noarch`, `extra_depends`, `flags`, `purls`, `python_site_packages_path` and `repodata_revision` on `IndexJson` in [#2771](https://github.com/conda/rattler/pull/2771)
+- Build a `RepoDataRecord` from a local `.conda` or `.tar.bz2` archive with `await RepoDataRecord.from_package_archive(path)`, ready to pass to `install()`, in [#2698](https://github.com/conda/rattler/pull/2698)
+- Add stable `MatchSpec.to_canonical_string()` output and `CanonicalMatchSpecError` for values the grammar cannot represent in [#2670](https://github.com/conda/rattler/pull/2670)
+- Expose repodata revision metadata on `RepoData`, `ChannelInfo` and `SparseRepoData`, plus `PackageRecord.flags`, in [#2674](https://github.com/conda/rattler/pull/2674)
+- Add the `networkx` install extra for `PackageRecord.to_graph()` in [#2725](https://github.com/conda/rattler/pull/2725)
+- Publish wheels for Windows ARM64 and Linux RISC-V GNU and musl in [#2700](https://github.com/conda/rattler/pull/2700)
+- `PackageArchive` for sparse reads from remote and local packages, with `read_file`, `read_files`, `list_files`, `index_json` and `paths_json` in [#2632](https://github.com/conda/rattler/pull/2632)
+- Accept `SparseRepoData` directly as a `solve` source in [#2627](https://github.com/conda/rattler/pull/2627)
+- `add_pip_as_python_dependency` on `solve` and `solve_with_sparse_repodata` in [#2677](https://github.com/conda/rattler/pull/2677)
+- CEP-6 channel notices: `Gateway.channel_notices()` plus a `channel_notices` flag on `query` and `names` in [#2639](https://github.com/conda/rattler/pull/2639)
+- `ChannelPriority.Flexible` in [#2617](https://github.com/conda/rattler/pull/2617)
+- `alternative_target_prefix` on `Installer`, to patch a different prefix into hardcoded paths in [#2484](https://github.com/conda/rattler/pull/2484)
+- iOS and Android subdirs with matching `__ios` and `__android` virtual packages and overrides in [#2613](https://github.com/conda/rattler/pull/2613)
+- `emscripten-wasm64` platform in [#2680](https://github.com/conda/rattler/pull/2680)
+- `cache_dir` on `VirtualPackage.detect()` in [#2568](https://github.com/conda/rattler/pull/2568)
+- Signed entry-point launchers for Windows x86, x64 and arm64 in [#2493](https://github.com/conda/rattler/pull/2493)
+
+### Changed
+
+- **BREAKING:** `index_fs`/`index_s3` take `repodata_revisions` as a sequence of selections (`["v3"]` or `[{"revision": "v3", "message": ...}]`); the `vN`-keyed mapping and `RepodataRevisionMetadata` are gone in [#2669](https://github.com/conda/rattler/pull/2669)
+- **BREAKING:** `Gateway.query()`, `Gateway.names()` and `solve()` follow CEP-42 `channel_relations` by default, so channels declaring relations contribute extra channels to the query and the priority order; the new `channel_relations` and `channel_relations_max_depth` arguments control it, and `"disabled"` restores the old behavior in [#2462](https://github.com/conda/rattler/pull/2462)
+- Run `Gateway.who_needs()` against full repodata instead of fetching one shard per package name, and take `SourceConfig.sharded_enabled` literally: `file://` channels are never sharded, and `fast.prefix.dev` no longer forces sharding on in [#2776](https://github.com/conda/rattler/pull/2776)
+- Upgrade PyO3 to 0.29 in [#2545](https://github.com/conda/rattler/pull/2545) and [#2546](https://github.com/conda/rattler/pull/2546)
+- Bound concurrent downloads with a semaphore in [#2475](https://github.com/conda/rattler/pull/2475)
+- Record git `lfs` on source locations in the lock file in [#2633](https://github.com/conda/rattler/pull/2633)
+
+### Fixed
+
+- Make `MatchSpec` parsing and `str(MatchSpec)` round-trip safely in awkward cases; build-only specs now render as `foo[build="py39h123_0"]` instead of inventing a `*` version in [#2670](https://github.com/conda/rattler/pull/2670)
+- Canonicalize `depends`, `constrains` and `extra_depends` when `index_fs`/`index_s3` write v3 repodata in [#2718](https://github.com/conda/rattler/pull/2718)
+- Keep packages with legacy-compatible `extra_depends` in legacy repodata so older clients can see them in [#2721](https://github.com/conda/rattler/pull/2721)
+- Leave archives listed under the `removed` key of a `repodata.json` out of `Gateway.query()`, `Gateway.names()` and `SparseRepoData.load_records()` results, matching sharded channels; they are not installable and were never valid solve candidates in [#2751](https://github.com/conda/rattler/pull/2751)
+- Deduplicate archives present in both legacy and v3 repodata and prefer the v3 record in [#2720](https://github.com/conda/rattler/pull/2720)
+- Rate a solvable's repeated requirements on the same package by the most restrictive one, so `solve()` picks the same build for tied candidates across platforms in [#2649](https://github.com/conda/rattler/pull/2649)
+- Fix a panic in the solver's conflict detection that could abort a `solve()` ([resolvo#231](https://github.com/prefix-dev/resolvo/pull/231))
+- Accept quoted extras lists in `MatchSpec` (`foobar[extras=["science"]]`) and enforce CEP 44's group-name grammar in [#2552](https://github.com/conda/rattler/pull/2552)
+- Keep a trailing underscore in a `MatchSpec` version instead of splitting it into the build string, per CEP 33: `tmux=3.7b_` is version `3.7b_` with no build in [#2606](https://github.com/conda/rattler/pull/2606)
+- Follow the OCI registry's `WWW-Authenticate` challenge in [#2628](https://github.com/conda/rattler/pull/2628)
+- Report a missing OCI manifest as a 404 in [#2651](https://github.com/conda/rattler/pull/2651) and retry a digest-addressed blob 404 through the manifest in [#2653](https://github.com/conda/rattler/pull/2653)
+- Honor `max-age` without a `public` cache directive in [#2664](https://github.com/conda/rattler/pull/2664)
+- Limit concurrent shard cache reads in the gateway in [#2163](https://github.com/conda/rattler/pull/2163)
+- Detect read-only filesystems in the package cache instead of failing in [#2594](https://github.com/conda/rattler/pull/2594)
+- Reject a truncated package archive in `extract()` and `download_and_extract()` instead of leaving an empty directory behind, and skip tar symlink entries on Windows rather than failing the whole extraction in [#2748](https://github.com/conda/rattler/pull/2748)
+- Make the Windows package-cache rename retry actually fire in [#2555](https://github.com/conda/rattler/pull/2555)
+- Include the sha256 in the cache key for `file://` packages in [#2507](https://github.com/conda/rattler/pull/2507)
+- Use a valid regex when searching Windows keyring credentials in [#2564](https://github.com/conda/rattler/pull/2564)
+- Write `repodata.json` atomically when indexing in [#2511](https://github.com/conda/rattler/pull/2511)
+- Make shard creation deterministic in [#2553](https://github.com/conda/rattler/pull/2553)
+- Preserve a leading `..` when normalizing `UrlOrPath`, so distinct relative paths no longer collapse in [#2548](https://github.com/conda/rattler/pull/2548)
+- Escape environment variable values in activation scripts in [#2621](https://github.com/conda/rattler/pull/2621) and preserve newlines in them in [#2591](https://github.com/conda/rattler/pull/2591)
+- Build the pty support on Android, OpenBSD and illumos in [#2533](https://github.com/conda/rattler/pull/2533), [#2524](https://github.com/conda/rattler/pull/2524) and [#2635](https://github.com/conda/rattler/pull/2635)
+- Build the sdist with pax tar headers by requiring maturin 1.14 in [#2696](https://github.com/conda/rattler/pull/2696)
+
+### Performance
+
+- Cut solve times by 38.9% to 58.7% (51.2% geometric mean) from py-rattler 0.25.0 / resolvo 0.10.3 to 0.26.0 / 0.12.1, combining Resolvo's clause and hot-path work with Rattler's candidate-ordering changes in [#2520](https://github.com/conda/rattler/pull/2520), [#2609](https://github.com/conda/rattler/pull/2609), [#2711](https://github.com/conda/rattler/pull/2711) and [#2730](https://github.com/conda/rattler/pull/2730)
+- Extract packages on a blocking worker, which speeds up `install()`, `extract()` and `download_and_extract()`, most noticeably on Windows in [#2748](https://github.com/conda/rattler/pull/2748)
+- Speed up version, version spec and match spec parsing in [#2515](https://github.com/conda/rattler/pull/2515)
+- Speed up CUDA virtual package detection in [#2568](https://github.com/conda/rattler/pull/2568)
+- Probe reflink support once per filesystem instead of per file in [#2508](https://github.com/conda/rattler/pull/2508)
+- Avoid parsing match specs when checking dependency overrides in [#2506](https://github.com/conda/rattler/pull/2506)
+
 ## [0.25.0] - 2026-06-09
 
 ### Changed

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "py-rattler"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 license = "BSD-3-Clause"
 publish = false

--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "py-rattler"
-version = "0.25.0"
+version = "0.26.0"
 requires-python = ">=3.10"
 description = "A blazing fast library to work with the conda ecosystem"
 readme = "README.md"


### PR DESCRIPTION
Time for a py-rattler release. This bumps to 0.26.0 and turns `## [Unreleased]` into a real section for the 175 commits since `py-rattler-v0.25.0`.

**[changelog](https://github.com/baszalmstra/rattler/blob/prepare-py-rattler-v0.26.0/py-rattler/CHANGELOG.md)**

Minor bump, because two things break. #2669 reshapes `repodata_revisions` on `index_fs`/`index_s3`. #2462 makes `Gateway.query()`, `Gateway.names()` and `solve()` follow CEP-42 `channel_relations` by default.

#2751 is the one I got wrong in the previous revision: I had it under breaking. It sits in Fixed now, since a removed archive is not installable and sharded channels already left those records out, so `Gateway.query()` returning them was the bug. The reporting side of it is a new feature and stays in Added: `GatewayQueryResult.removed`, `SparseRepoData.load_removed()` and `RemovedPackage`.

I still don't think #2649, #2552, #2610 and #2606 are breaking: the behavior changes, but there was nothing dependable to break in the first place. The same goes for #2670, #2718, #2720 and #2721, which fix MatchSpec round-tripping or repodata that was generated or loaded incorrectly, and for #2748, where the sync extraction path caught up with the async one (a truncated archive now raises instead of leaving an empty directory, and tar symlinks on Windows are skipped instead of failing the extraction).

Four commits from this range are in neither list because Python can't reach them. #2782 sorts `PrefixData::new`, and `PrefixData` has one consumer, `rattler list`; `install()` scans a prefix through `PrefixRecord::collect_from_prefix`, which is unchanged. #2731 moves the `__glibc` baseline used by `detect_for_platform`, and we only bind `VirtualPackage.detect()`, which detects the host libc. #2758 fixes `rattler_menuinst`, which `install()` never invokes. #2754 only touches `py-rattler/pixi.toml`; the Windows wheels never enabled `pty` to begin with. Push back on any of these calls.

Rebased onto current main. #2738, #2751, #2771, #2772 and #2776 are folded in, so both changelog requests are handled.

## Pending before release

- [x] #2700
- [x] #2698
- [x] #2730
- [x] #2738
- [ ] ~~#2699~~

## Testing

The version is synced across `Cargo.toml`, `pyproject.toml` and `Cargo.lock`; the lock diff is one version line.

The benchmark numbers in the highlights still hold: `resolvo` is unchanged at 0.12.1 in the lock across the rebase, and nothing else the bindings run moved either (only the workspace `rattler_*` crates plus `astral_async_zip` 0.0.20 to 0.0.21). Those numbers came from the five `rattler_solve` Criterion benchmarks at `py-rattler-v0.25.0` (resolvo 0.10.3) against main (0.12.1), same harness, conda-forge fixture and Rust 1.95.0. The median of three balanced alternating rounds shows 38.9% to 58.7% lower solve times, 51.2% by geometric mean; the paired-round geometric mean stayed between 50.8% and 51.9%. A fourth round was discarded when the process guard caught another Cargo build starting.

The changelog snippets are still not executed, which bugs me. py-rattler doesn't build on the machine I prepared this on: `aws-lc-sys` falls over under the conda MSVC activation on Windows. I checked every symbol in the new snippets against `py-rattler/rattler/**` and `py-rattler/src/**` instead, but someone on Linux should really run them before this merges.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code, Pi

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
