### PR TITLE
ci(js): use npm trusted publishing for js-rattler

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -93,7 +93,7 @@ jobs:
   upload-release:
     name: Upload to NPM
     runs-on: ubuntu-latest
-    environment: npm
+    environment: release
     if: ${{ inputs.tag }}
     needs:
       - validate-tag

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -104,15 +104,14 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
           path: tarball
-      - run: npm publish --provenance --access public ./tarball/conda-org-rattler-*.tgz
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public ./tarball/conda-org-rattler-*.tgz
 
   tag-release:
     name: Tag release

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -93,6 +93,7 @@ jobs:
   upload-release:
     name: Upload to NPM
     runs-on: ubuntu-latest
+    environment: npm
     if: ${{ inputs.tag }}
     needs:
       - validate-tag


### PR DESCRIPTION
### Description

Switch the js-rattler npm release to Trusted Publishing.

The current workflow still authenticates with `NPM_TOKEN`, even though it already has `id-token: write`. This removes the long-lived token and lets npm authenticate through GitHub OIDC instead.

Changes:
- use Node 24 for the publish job
- remove `NODE_AUTH_TOKEN`
- remove the explicit `--provenance` flag
- use the existing `release` GitHub environment

npm still needs a Trusted Publisher configured for `conda/rattler`, workflow `release-js.yml`, environment `release`.

### How Has This Been Tested?

This can only be fully tested by publishing a release after the npm Trusted Publisher is configured.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: ChatGPT

### Checklist:
- [x] I have performed a self-review of my own code
