### PR TITLE
feat: support provider-neutral rustls

### DIFF
--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -15,6 +15,7 @@ readme.workspace = true
 default = ['rustls']
 native-tls =['reqwest/native-tls', 'rattler_package_streaming/native-tls', 'rattler_cache/native-tls', 'rattler_networking/native-tls']
 rustls = ['reqwest/rustls', 'rattler_package_streaming/rustls', 'rattler_cache/rustls', 'rattler_networking/rustls']
+rustls-no-provider = ['reqwest/rustls-no-provider', 'rattler_package_streaming/rustls-no-provider', 'rattler_cache/rustls-no-provider', 'rattler_networking/rustls-no-provider']
 oauth = ["dep:openidconnect", "dep:oauth2-reqwest", "dep:open"]
 cli-tools = ['dep:clap', 'oauth', 'dep:console']
 # Adds an interactive MultiSelect picker to `auth logout` when run without

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -12,6 +12,7 @@ readme.workspace = true
 [features]
 default = ["rustls"]
 rustls = ["reqwest/rustls", "reqwest-middleware/rustls", "rattler_networking/rustls", "rattler_package_streaming/rustls"]
+rustls-no-provider = ["reqwest/rustls-no-provider", "rattler_networking/rustls-no-provider", "rattler_package_streaming/rustls-no-provider"]
 native-tls = ["reqwest/native-tls", "rattler_networking/native-tls", "rattler_package_streaming/native-tls"]
 
 [dependencies]

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -15,6 +15,7 @@ readme.workspace = true
 default = ["rustls", "system-integration"]
 native-tls = ["reqwest/native-tls", "ambient-id/native-tls"]
 rustls = ["reqwest/rustls", "ambient-id/rustls"]
+rustls-no-provider = ["reqwest/rustls-no-provider"]
 gcs = ["google-cloud-auth", "tokio/sync"]
 s3 = ["aws-config", "aws-sdk-s3", "aws-smithy-http-client"]
 system-integration = ["keyring", "netrc-rs", "dirs"]

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -68,6 +68,7 @@ getrandom_v02 = { package = "getrandom", version = "0.2", features = ["js"] }
 default = ["rustls"]
 native-tls = ["rattler_networking/native-tls", "rattler_redaction/native-tls"]
 rustls = ["rattler_networking/rustls", "rattler_redaction/rustls"]
+rustls-no-provider = ["reqwest/rustls-no-provider", "rattler_networking/rustls-no-provider", "rattler_redaction/rustls-no-provider"]
 reqwest = [
   "dep:reqwest-middleware",
   "dep:reqwest",

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -14,6 +14,7 @@ readme.workspace = true
 default = ["rustls"]
 native-tls = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls"]
+rustls-no-provider = ["reqwest/rustls-no-provider"]
 
 [dependencies]
 url = { workspace = true }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -113,6 +113,7 @@ url = { workspace = true }
 default = ['rustls']
 native-tls = ['reqwest/native-tls', 'rattler_networking/native-tls', 'rattler_cache/native-tls', 'rattler_redaction/native-tls']
 rustls = ['reqwest/rustls', 'rattler_networking/rustls', 'rattler_cache/rustls', 'rattler_redaction/rustls']
+rustls-no-provider = ['reqwest/rustls-no-provider', 'rattler_networking/rustls-no-provider', 'rattler_cache/rustls-no-provider', 'rattler_redaction/rustls-no-provider', 'rattler_package_streaming?/rustls-no-provider']
 sparse = ["rattler_conda_types", "memmap2", "self_cell", "superslice", "itertools", "serde_json/raw_value"]
 gateway = ["sparse", "http", "http-cache-semantics", "parking_lot", "async-trait", "rattler_package_streaming"]
 


### PR DESCRIPTION
Reqwest's `rustls` feature selects AWS-LC. That is a good default, but it means downstream binaries cannot choose a smaller Rustls provider without replacing Rattler's feature wiring.

This adds a `rustls-no-provider` feature to the Rattler crates used by the installer, package cache, package streaming, networking, redaction, and repodata gateway. It forwards Reqwest's matching feature through the complete dependency chain. Existing defaults stay unchanged.

A downstream application can now enable `rustls-no-provider`, select a provider through its own `rustls` dependency, and install that provider before constructing a Reqwest client. In microrattler, selecting Ring this way reduced the optimized Windows binary from 8,820,736 to 8,473,600 bytes: 347,136 bytes, or 3.9%.

## Testing

- Checked every added feature independently with `cargo check --no-default-features`.
- Verified the normal dependency graph for `rattler` with `rustls-no-provider` does not contain `aws-lc-rs`.
- Built a temporary integration binary that installed Ring and fetched conda-forge repodata over HTTPS.
- Built microrattler with the provider-neutral feature chain, ran its workspace tests, and manually searched conda-forge over HTTPS. One unrelated shell activation assertion failed consistently on Windows; all networking and package-management tests passed.