### PR TITLE
docs: rename CEP 146 to CEP 48

### DIFF
--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add the CEP 146 repodata wire model ([#2669](https://github.com/conda/rattler/pull/2669))
+- add the CEP 48 repodata wire model ([#2669](https://github.com/conda/rattler/pull/2669))
 
 ### Fixed
 
-- recover merged CEP 146 PRs (#2674, #2673, #2670)
+- recover merged CEP 48 PRs (#2674, #2673, #2670)
 
 ## [0.50.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.49.1...rattler_conda_types-v0.50.0) - 2026-08-15
 

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -183,7 +183,7 @@ pub struct RepodataRevisionSelection {
 /// A repodata revision.
 ///
 /// Legacy repodata predates numbered layouts and uses the `packages` and
-/// `packages.conda` maps. CEP 146 adds the v3 layout. Other numeric values are
+/// `packages.conda` maps. CEP 48 adds the v3 layout. Other numeric values are
 /// preserved so readers can report future revisions without interpreting them.
 #[derive(Debug, Default, Eq, PartialEq, Clone, Copy, Hash, Ord, PartialOrd)]
 pub enum RepodataRevision {

--- a/crates/rattler_config/CHANGELOG.md
+++ b/crates/rattler_config/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add the CEP 146 repodata wire model ([#2669](https://github.com/conda/rattler/pull/2669))
+- add the CEP 48 repodata wire model ([#2669](https://github.com/conda/rattler/pull/2669))
 
 ## [0.7.1](https://github.com/conda/rattler/compare/rattler_config-v0.7.0...rattler_config-v0.7.1) - 2026-08-15
 

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add the CEP 146 repodata wire model ([#2669](https://github.com/conda/rattler/pull/2669))
+- add the CEP 48 repodata wire model ([#2669](https://github.com/conda/rattler/pull/2669))
 
 ### Fixed
 

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- recover merged CEP 146 PRs (#2674, #2673, #2670)
+- recover merged CEP 48 PRs (#2674, #2673, #2670)
 
 ## [0.27.1](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.27.0...rattler_package_streaming-v0.27.1) - 2026-08-15
 

--- a/crates/rattler_redaction/CHANGELOG.md
+++ b/crates/rattler_redaction/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- recover merged CEP 146 PRs (#2674, #2673, #2670)
+- recover merged CEP 48 PRs (#2674, #2673, #2670)
 
 ## [0.2.2](https://github.com/conda/rattler/compare/rattler_redaction-v0.2.1...rattler_redaction-v0.2.2) - 2026-07-14
 

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(js)* support custom fetch and record queries in the gateway ([#2687](https://github.com/conda/rattler/pull/2687))
 - Accept sparse repodata in solve ([#2627](https://github.com/conda/rattler/pull/2627))
 - *(py)* expose pip injection for solve APIs ([#2677](https://github.com/conda/rattler/pull/2677))
-- add the CEP 146 repodata wire model ([#2669](https://github.com/conda/rattler/pull/2669))
+- add the CEP 48 repodata wire model ([#2669](https://github.com/conda/rattler/pull/2669))
 
 ## [0.32.1](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.32.0...rattler_repodata_gateway-v0.32.1) - 2026-08-15
 


### PR DESCRIPTION
### Description

[CEP 48](https://github.com/conda/ceps/pull/146) has now been minted. Rattler previously referred to it as CEP 146, which was the proposal's PR number rather than its final CEP number.

This updates the repodata revision documentation and changelog entries to use CEP 48.

### How Has This Been Tested?

Checked that no CEP 146 references remain in tracked files and ran `git diff --check`. No runtime tests were needed because this only changes documentation and changelog text.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Pi

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
