### PR TITLE
fix: canonicalize MatchSpecs in v3 repodata

### DIFF
--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -155,13 +155,13 @@ impl IndexJson {
     /// Validates that the fields in this `index.json` are representable by its
     /// required repodata revision.
     ///
-    /// Prefer [`Self::into_validated`] when the parsed MatchSpecs are needed
+    /// Prefer [`Self::into_validated`] when the parsed `MatchSpecs` are needed
     /// afterwards, such as while indexing a package.
     pub fn validate(&self) -> Result<(), ValidateIndexJsonError> {
         self.clone().into_validated().map(|_| ())
     }
 
-    /// Validates this `index.json` and retains its parsed MatchSpecs.
+    /// Validates this `index.json` and retains its parsed `MatchSpecs`.
     ///
     /// This avoids parsing dependency specifications again when an indexer must
     /// render them for the effective repodata revision.
@@ -234,7 +234,7 @@ impl IndexJson {
     }
 }
 
-/// An `index.json` whose dependency MatchSpecs have been parsed and validated.
+/// An `index.json` whose dependency `MatchSpecs` have been parsed and validated.
 #[derive(Debug, Clone)]
 pub struct ValidatedIndexJson {
     index: IndexJson,
@@ -255,7 +255,7 @@ impl ValidatedIndexJson {
     }
 }
 
-/// Parsed dependency MatchSpecs retained after validating an `index.json`.
+/// Parsed dependency `MatchSpecs` retained after validating an `index.json`.
 #[derive(Debug, Clone)]
 pub struct ValidatedMatchSpecs {
     depends: Vec<MatchSpec>,
@@ -264,7 +264,7 @@ pub struct ValidatedMatchSpecs {
 }
 
 impl ValidatedMatchSpecs {
-    /// Renders the validated MatchSpecs for a repodata revision.
+    /// Renders the validated `MatchSpecs` for a repodata revision.
     pub fn render_for_revision(
         self,
         revision: RepodataRevision,
@@ -303,7 +303,7 @@ impl ValidatedMatchSpecs {
     }
 }
 
-/// Dependency MatchSpecs rendered for a repodata record.
+/// Dependency `MatchSpecs` rendered for a repodata record.
 #[derive(Debug, Clone)]
 pub struct RenderedMatchSpecs {
     /// Rendered package dependencies.

--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -10,8 +10,8 @@ use thiserror::Error;
 
 use super::PackageFile;
 use crate::{
-    Flag, MatchSpec, NoArchType, PackageName, PackageUrl, ParseMatchSpecError,
-    ParseMatchSpecOptions, RepodataRevision, VersionWithSource,
+    CanonicalMatchSpecError, Flag, MatchSpec, NoArchType, PackageName, PackageUrl,
+    ParseMatchSpecError, ParseMatchSpecOptions, RepodataRevision, VersionWithSource,
 };
 
 /// A representation of the `index.json` file found in package archives.
@@ -154,16 +154,51 @@ impl IndexJson {
 
     /// Validates that the fields in this `index.json` are representable by its
     /// required repodata revision.
+    ///
+    /// Prefer [`Self::into_validated`] when the parsed MatchSpecs are needed
+    /// afterwards, such as while indexing a package.
     pub fn validate(&self) -> Result<(), ValidateIndexJsonError> {
-        let required_revision = self.required_repodata_revision();
+        self.clone().into_validated().map(|_| ())
+    }
+
+    /// Validates this `index.json` and retains its parsed MatchSpecs.
+    ///
+    /// This avoids parsing dependency specifications again when an indexer must
+    /// render them for the effective repodata revision.
+    pub fn into_validated(self) -> Result<ValidatedIndexJson, ValidateIndexJsonError> {
+        let parse_options =
+            ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3);
+        let depends = parse_matchspecs("depends", &self.depends, parse_options)?;
+        let constrains = parse_matchspecs("constrains", &self.constrains, parse_options)?;
+        let extra_depends = self
+            .extra_depends
+            .iter()
+            .map(|(group, specs)| {
+                parse_matchspecs(format!("extra_depends.{group}"), specs, parse_options)
+                    .map(|parsed| (group.clone(), parsed))
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+
+        let required_revision = self.repodata_revision.unwrap_or_else(|| {
+            if !self.extra_depends.is_empty()
+                || !self.flags.is_empty()
+                || depends
+                    .iter()
+                    .chain(constrains.iter())
+                    .any(|spec| spec.required_repodata_revision() == RepodataRevision::V3)
+            {
+                RepodataRevision::V3
+            } else {
+                RepodataRevision::Legacy
+            }
+        });
+
         if required_revision.uses_legacy_package_layout() && !self.extra_depends.is_empty() {
             return Err(ValidateIndexJsonError::LegacyExtraDepends);
         }
-
         if required_revision.uses_legacy_package_layout() && !self.flags.is_empty() {
             return Err(ValidateIndexJsonError::LegacyFlags);
         }
-
         for flag in &self.flags {
             if flag.validate().is_err() {
                 return Err(ValidateIndexJsonError::InvalidFlag {
@@ -172,71 +207,156 @@ impl IndexJson {
             }
         }
 
-        let parse_options =
-            ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3);
-
-        for spec in &self.depends {
-            Self::validate_matchspec(required_revision, "depends", spec, parse_options)?;
-        }
-
-        for spec in &self.constrains {
-            Self::validate_matchspec(required_revision, "constrains", spec, parse_options)?;
-        }
-
-        for (group, specs) in &self.extra_depends {
-            for spec in specs {
-                Self::validate_matchspec(
-                    required_revision,
-                    format!("extra_depends.{group}"),
-                    spec,
-                    parse_options,
-                )?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn validate_matchspec(
-        required_revision: RepodataRevision,
-        field: impl Into<String>,
-        spec: &str,
-        parse_options: ParseMatchSpecOptions,
-    ) -> Result<(), ValidateIndexJsonError> {
-        let field = field.into();
-        let matchspec = MatchSpec::from_str(spec, parse_options).map_err(|source| {
-            ValidateIndexJsonError::InvalidMatchSpec {
-                field: field.clone(),
-                spec: spec.to_string(),
-                source,
-            }
-        })?;
-
         if required_revision.uses_legacy_package_layout() {
-            if matchspec.extras.is_some() {
-                return Err(ValidateIndexJsonError::LegacyMatchSpecExtras {
-                    field,
-                    spec: spec.to_string(),
-                });
-            }
-
-            if matchspec.condition.is_some() {
-                return Err(ValidateIndexJsonError::LegacyMatchSpecCondition {
-                    field,
-                    spec: spec.to_string(),
-                });
-            }
-
-            if matchspec.flags.is_some() {
-                return Err(ValidateIndexJsonError::LegacyMatchSpecFlags {
-                    field,
-                    spec: spec.to_string(),
-                });
+            for (field, specs) in std::iter::once(("depends".to_string(), &depends))
+                .chain(std::iter::once(("constrains".to_string(), &constrains)))
+                .chain(
+                    extra_depends
+                        .iter()
+                        .map(|(group, specs)| (format!("extra_depends.{group}"), specs)),
+                )
+            {
+                for spec in specs {
+                    validate_legacy_matchspec(&field, spec)?;
+                }
             }
         }
 
-        Ok(())
+        Ok(ValidatedIndexJson {
+            index: self,
+            required_revision,
+            matchspecs: ValidatedMatchSpecs {
+                depends,
+                constrains,
+                extra_depends,
+            },
+        })
     }
+}
+
+/// An `index.json` whose dependency MatchSpecs have been parsed and validated.
+#[derive(Debug, Clone)]
+pub struct ValidatedIndexJson {
+    index: IndexJson,
+    required_revision: RepodataRevision,
+    matchspecs: ValidatedMatchSpecs,
+}
+
+impl ValidatedIndexJson {
+    /// Returns the repodata revision required by this package.
+    pub fn required_repodata_revision(&self) -> RepodataRevision {
+        self.required_revision
+    }
+
+    /// Splits the validated metadata into the original index record and its
+    /// parsed dependency specifications.
+    pub fn into_parts(self) -> (IndexJson, ValidatedMatchSpecs) {
+        (self.index, self.matchspecs)
+    }
+}
+
+/// Parsed dependency MatchSpecs retained after validating an `index.json`.
+#[derive(Debug, Clone)]
+pub struct ValidatedMatchSpecs {
+    depends: Vec<MatchSpec>,
+    constrains: Vec<MatchSpec>,
+    extra_depends: BTreeMap<String, Vec<MatchSpec>>,
+}
+
+impl ValidatedMatchSpecs {
+    /// Renders the validated MatchSpecs for a repodata revision.
+    pub fn render_for_revision(
+        self,
+        revision: RepodataRevision,
+    ) -> Result<RenderedMatchSpecs, CanonicalMatchSpecError> {
+        let render = |spec: MatchSpec| {
+            if revision.as_u64() >= RepodataRevision::V3.as_u64() {
+                spec.to_canonical_string()
+            } else {
+                Ok(spec.to_string())
+            }
+        };
+
+        Ok(RenderedMatchSpecs {
+            depends: self
+                .depends
+                .into_iter()
+                .map(&render)
+                .collect::<Result<_, _>>()?,
+            constrains: self
+                .constrains
+                .into_iter()
+                .map(&render)
+                .collect::<Result<_, _>>()?,
+            extra_depends: self
+                .extra_depends
+                .into_iter()
+                .map(|(group, specs)| {
+                    specs
+                        .into_iter()
+                        .map(&render)
+                        .collect::<Result<_, _>>()
+                        .map(|rendered| (group, rendered))
+                })
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+/// Dependency MatchSpecs rendered for a repodata record.
+#[derive(Debug, Clone)]
+pub struct RenderedMatchSpecs {
+    /// Rendered package dependencies.
+    pub depends: Vec<String>,
+    /// Rendered package constraints.
+    pub constrains: Vec<String>,
+    /// Rendered optional dependency groups.
+    pub extra_depends: BTreeMap<String, Vec<String>>,
+}
+
+fn parse_matchspecs(
+    field: impl Into<String>,
+    specs: &[String],
+    parse_options: ParseMatchSpecOptions,
+) -> Result<Vec<MatchSpec>, ValidateIndexJsonError> {
+    let field = field.into();
+    specs
+        .iter()
+        .map(|spec| {
+            MatchSpec::from_str(spec, parse_options).map_err(|source| {
+                ValidateIndexJsonError::InvalidMatchSpec {
+                    field: field.clone(),
+                    spec: spec.clone(),
+                    source,
+                }
+            })
+        })
+        .collect()
+}
+
+fn validate_legacy_matchspec(
+    field: &str,
+    matchspec: &MatchSpec,
+) -> Result<(), ValidateIndexJsonError> {
+    if matchspec.extras.is_some() {
+        return Err(ValidateIndexJsonError::LegacyMatchSpecExtras {
+            field: field.to_string(),
+            spec: matchspec.to_string(),
+        });
+    }
+    if matchspec.condition.is_some() {
+        return Err(ValidateIndexJsonError::LegacyMatchSpecCondition {
+            field: field.to_string(),
+            spec: matchspec.to_string(),
+        });
+    }
+    if matchspec.flags.is_some() {
+        return Err(ValidateIndexJsonError::LegacyMatchSpecFlags {
+            field: field.to_string(),
+            spec: matchspec.to_string(),
+        });
+    }
+    Ok(())
 }
 
 fn matchspec_requires_v3(spec: &str, parse_options: ParseMatchSpecOptions) -> bool {
@@ -385,6 +505,54 @@ mod test {
             inferred_revision.required_repodata_revision(),
             RepodataRevision::V3
         );
+    }
+
+    #[test]
+    pub fn test_validated_matchspecs_render_for_revision() {
+        let index: IndexJson = serde_json::from_str(
+            r#"{
+                "build": "0",
+                "build_number": 0,
+                "constrains": ["python >=3.10"],
+                "depends": ["python >=3.10"],
+                "extra_depends": { "test": ["pytest >=8"] },
+                "name": "demo",
+                "version": "1.0"
+            }"#,
+        )
+        .unwrap();
+        let (_, matchspecs) = index.into_validated().unwrap().into_parts();
+
+        let v3 = matchspecs
+            .clone()
+            .render_for_revision(RepodataRevision::V3)
+            .unwrap();
+        assert_eq!(v3.depends, ["python[version=\">=3.10\"]"]);
+        assert_eq!(v3.constrains, ["python[version=\">=3.10\"]"]);
+        assert_eq!(v3.extra_depends["test"], ["pytest[version=\">=8\"]"]);
+
+        let revision_4 = matchspecs
+            .clone()
+            .render_for_revision(RepodataRevision::Unknown(4))
+            .unwrap();
+        assert_eq!(revision_4.depends, v3.depends);
+        assert_eq!(revision_4.constrains, v3.constrains);
+        assert_eq!(revision_4.extra_depends, v3.extra_depends);
+
+        let legacy = matchspecs
+            .clone()
+            .render_for_revision(RepodataRevision::Legacy)
+            .unwrap();
+        assert_eq!(legacy.depends, ["python >=3.10"]);
+        assert_eq!(legacy.constrains, ["python >=3.10"]);
+        assert_eq!(legacy.extra_depends["test"], ["pytest >=8"]);
+
+        let revision_2 = matchspecs
+            .render_for_revision(RepodataRevision::Unknown(2))
+            .unwrap();
+        assert_eq!(revision_2.depends, legacy.depends);
+        assert_eq!(revision_2.constrains, legacy.constrains);
+        assert_eq!(revision_2.extra_depends, legacy.extra_depends);
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/package/mod.rs
+++ b/crates/rattler_conda_types/src/package/mod.rs
@@ -24,7 +24,7 @@ pub use {
     files::Files,
     has_prefix::HasPrefix,
     has_prefix::HasPrefixEntry,
-    index::IndexJson,
+    index::{IndexJson, RenderedMatchSpecs, ValidatedIndexJson, ValidatedMatchSpecs},
     link::{LinkJson, NoArchLinks, PythonEntryPoints},
     no_link::NoLink,
     no_softlink::NoSoftlink,

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -29,12 +29,12 @@ use opendal::layers::RetryLayer;
 use opendal::services::S3Config;
 use opendal::{Configurator, Operator, services::FsConfig};
 use rattler_conda_types::{
-    ChannelInfo, ChannelNotice, ChannelNotices, ChannelRelations, PackageRecord, PatchInstructions,
-    Platform, RepoData, Shard, ShardedRepodata, ShardedSubdirInfo, UrlOrPath, V3Extensions,
-    V3Packages, WhlPackageRecord,
+    ChannelInfo, ChannelNotice, ChannelNotices, ChannelRelations, MatchSpec, PackageRecord,
+    ParseMatchSpecOptions, PatchInstructions, Platform, RepoData, Shard, ShardedRepodata,
+    ShardedSubdirInfo, UrlOrPath, V3Extensions, V3Packages, WhlPackageRecord,
     package::{
         CondaArchiveType, DistArchiveIdentifier, DistArchiveType, IndexJson, PackageFile,
-        RunExportsJson, WheelArchiveType,
+        RunExportsJson, ValidatedMatchSpecs, WheelArchiveType,
     },
 };
 pub use rattler_conda_types::{
@@ -117,6 +117,10 @@ impl PreconditionChecks {
 pub(crate) struct IndexedPackageRecord {
     record: PackageRecord,
     repodata_revision: RepodataRevision,
+    /// Parsed `index.json` dependency specifications, when this record was
+    /// read from a package archive. Existing repodata records do not retain
+    /// this cache and are parsed only if they are emitted as v3.
+    matchspecs: Option<ValidatedMatchSpecs>,
     wheel_url: Option<UrlOrPath>,
 }
 
@@ -180,11 +184,11 @@ fn indexed_package_record_from_index_json<T: Read>(
     package_as_bytes: impl AsRef<[u8]>,
     index_json_reader: &mut T,
 ) -> std::io::Result<IndexedPackageRecord> {
-    let index = IndexJson::from_reader(index_json_reader)?;
-    index
-        .validate()
+    let validated = IndexJson::from_reader(index_json_reader)?
+        .into_validated()
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    let repodata_revision = index.required_repodata_revision();
+    let repodata_revision = validated.required_repodata_revision();
+    let (index, matchspecs) = validated.into_parts();
 
     let sha256_result =
         rattler_digest::compute_bytes_digest::<rattler_digest::Sha256>(&package_as_bytes);
@@ -222,6 +226,7 @@ fn indexed_package_record_from_index_json<T: Read>(
     Ok(IndexedPackageRecord {
         record: package_record,
         repodata_revision,
+        matchspecs: Some(matchspecs),
         wheel_url: None,
     })
 }
@@ -1091,6 +1096,7 @@ fn package_records_from_repodata(repodata: RepoData) -> ExistingRepodata {
                     IndexedPackageRecord {
                         record,
                         repodata_revision: RepodataRevision::Legacy,
+                        matchspecs: None,
                         wheel_url: None,
                     },
                 )
@@ -1104,6 +1110,7 @@ fn package_records_from_repodata(repodata: RepoData) -> ExistingRepodata {
             IndexedPackageRecord {
                 record,
                 repodata_revision: RepodataRevision::V3,
+                matchspecs: None,
                 wheel_url,
             },
         )
@@ -1116,6 +1123,80 @@ fn package_records_from_repodata(repodata: RepoData) -> ExistingRepodata {
     }
 }
 
+/// Renders package dependency fields in CEP 48's required v3 MatchSpec form.
+///
+/// Fresh package archives retain their parsed MatchSpecs from `index.json`
+/// validation. Records read from existing repodata are parsed here only when
+/// they are emitted into the v3 map.
+fn render_record_matchspecs_for_v3(
+    record: &mut PackageRecord,
+    matchspecs: Option<ValidatedMatchSpecs>,
+) -> Result<(), RepodataError> {
+    let rendered: anyhow::Result<rattler_conda_types::package::RenderedMatchSpecs> =
+        match matchspecs {
+            Some(matchspecs) => matchspecs
+                .render_for_revision(RepodataRevision::V3)
+                .map_err(anyhow::Error::from),
+            None => {
+                let parse_options =
+                    ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3);
+                let render = |spec: &str| -> anyhow::Result<String> {
+                    MatchSpec::from_str(spec, parse_options)
+                        .with_context(|| format!("failed to parse v3 repodata MatchSpec '{spec}'"))?
+                        .to_canonical_string()
+                        .map_err(anyhow::Error::from)
+                };
+                Ok(rattler_conda_types::package::RenderedMatchSpecs {
+                    depends: record
+                        .depends
+                        .iter()
+                        .map(|spec| render(spec))
+                        .collect::<Result<_, _>>()?,
+                    constrains: record
+                        .constrains
+                        .iter()
+                        .map(|spec| render(spec))
+                        .collect::<Result<_, _>>()?,
+                    extra_depends: record
+                        .extra_depends
+                        .iter()
+                        .map(|(group, specs)| {
+                            specs
+                                .iter()
+                                .map(|spec| render(spec))
+                                .collect::<Result<_, _>>()
+                                .map(|rendered| (group.clone(), rendered))
+                        })
+                        .collect::<Result<_, _>>()?,
+                })
+            }
+        };
+    let rendered = rendered?;
+
+    record.depends = rendered.depends;
+    record.constrains = rendered.constrains;
+    record.extra_depends = rendered.extra_depends;
+    Ok(())
+}
+
+/// Canonicalizes all dependency MatchSpecs in the v3 maps before publication.
+///
+/// Patches apply after initial package indexing and can replace dependency
+/// strings, so this is deliberately run immediately before writing repodata
+/// (and before deriving its shards).
+fn canonicalize_v3_repodata_matchspecs(repodata: &mut RepoData) -> Result<(), RepodataError> {
+    for record in repodata.v3.tar_bz2.values_mut() {
+        render_record_matchspecs_for_v3(record, None)?;
+    }
+    for record in repodata.v3.conda.values_mut() {
+        render_record_matchspecs_for_v3(record, None)?;
+    }
+    for record in repodata.v3.whl.values_mut() {
+        render_record_matchspecs_for_v3(&mut record.package_record, None)?;
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn insert_package_record_by_revision(
     packages: &mut IndexMap<DistArchiveIdentifier, PackageRecord, ahash::RandomState>,
@@ -1125,8 +1206,20 @@ fn insert_package_record_by_revision(
     package: IndexedPackageRecord,
     revision: RepodataRevision,
 ) -> Result<(), RepodataError> {
+    if revision.uses_legacy_package_layout()
+        && !package.repodata_revision.uses_legacy_package_layout()
+    {
+        return Err(RepodataError::Other(anyhow::anyhow!(
+            "package requires repodata revision {}, but the effective index revision is legacy",
+            package.repodata_revision
+        )));
+    }
+
     let IndexedPackageRecord {
-        record, wheel_url, ..
+        mut record,
+        wheel_url,
+        matchspecs,
+        ..
     } = package;
 
     if revision.uses_legacy_package_layout() {
@@ -1145,6 +1238,7 @@ fn insert_package_record_by_revision(
             }
         }
     } else if revision == RepodataRevision::V3 {
+        render_record_matchspecs_for_v3(&mut record, matchspecs)?;
         match filename.archive_type {
             DistArchiveType::Conda(CondaArchiveType::TarBz2) => {
                 v3.tar_bz2.insert(filename.identifier, record);
@@ -1288,7 +1382,7 @@ pub async fn write_repodata(
         .await?;
     }
 
-    let repodata = if let Some(instructions) = repodata_patch {
+    let mut repodata = if let Some(instructions) = repodata_patch {
         tracing::info!("Patching repodata");
         let mut patched_repodata = repodata.clone();
         patched_repodata.apply_patches(&instructions);
@@ -1296,6 +1390,7 @@ pub async fn write_repodata(
     } else {
         repodata
     };
+    canonicalize_v3_repodata_matchspecs(&mut repodata)?;
 
     let repodata_bytes = serde_json::to_vec(&repodata)?;
 
@@ -2217,6 +2312,133 @@ mod tests {
     }
 
     #[test]
+    fn latest_assignment_rejects_v3_package_demotion() {
+        let filename = DistArchiveIdentifier::try_from_filename("demo-1.0-0.tar.bz2").unwrap();
+        let indexed = IndexedPackageRecord {
+            record: PackageRecord::new(
+                PackageName::new_unchecked("demo"),
+                Version::from_str("1.0").unwrap(),
+                "0".to_string(),
+            ),
+            repodata_revision: RepodataRevision::V3,
+            matchspecs: None,
+            wheel_url: None,
+        };
+        let revision = PackageRevisionAssignment::Latest
+            .assign(indexed.repodata_revision, RepodataRevision::Legacy);
+        let error = insert_package_record_by_revision(
+            &mut IndexMap::default(),
+            &mut IndexMap::default(),
+            &mut V3Packages::default(),
+            filename,
+            indexed,
+            revision,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("requires repodata revision v3"));
+    }
+
+    #[test]
+    fn latest_assignment_canonicalizes_validated_legacy_index_json() {
+        let filename = DistArchiveIdentifier::try_from_filename("demo-1.0-0.tar.bz2").unwrap();
+        let mut index_json = Cursor::new(
+            br#"{
+                "build": "0",
+                "build_number": 0,
+                "depends": ["python >=3.10"],
+                "name": "demo",
+                "version": "1.0"
+            }"#,
+        );
+        let indexed = indexed_package_record_from_index_json(b"package", &mut index_json).unwrap();
+        assert_eq!(indexed.repodata_revision, RepodataRevision::Legacy);
+
+        let mut v3 = V3Packages::default();
+        insert_package_record_by_revision(
+            &mut IndexMap::default(),
+            &mut IndexMap::default(),
+            &mut v3,
+            filename.clone(),
+            indexed,
+            RepodataRevision::V3,
+        )
+        .unwrap();
+
+        assert_eq!(
+            v3.tar_bz2[&filename.identifier].depends,
+            ["python[version=\">=3.10\"]"]
+        );
+    }
+
+    #[test]
+    fn v3_patches_are_canonicalized_before_publication() {
+        let identifier = ArchiveIdentifier::from_str("demo-1.0-0").unwrap();
+        let mut record = PackageRecord::new(
+            PackageName::new_unchecked("demo"),
+            Version::from_str("1.0").unwrap(),
+            "0".to_string(),
+        );
+        let patch = serde_json::from_value(serde_json::json!({
+            "depends": ["python >=3.10"],
+            "constrains": ["python >=3.10"]
+        }))
+        .unwrap();
+        record.apply_patch(&patch);
+
+        let mut repodata = RepoData {
+            info: None,
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            v3: V3Packages::default(),
+            removed: HashSet::default(),
+            version: Some(1),
+        };
+        repodata.v3.tar_bz2.insert(identifier.clone(), record);
+        canonicalize_v3_repodata_matchspecs(&mut repodata).unwrap();
+
+        let record = &repodata.v3.tar_bz2[&identifier];
+        assert_eq!(record.depends, ["python[version=\">=3.10\"]"]);
+        assert_eq!(record.constrains, ["python[version=\">=3.10\"]"]);
+    }
+
+    #[test]
+    fn v3_records_from_existing_repodata_are_canonicalized() {
+        let filename = DistArchiveIdentifier::try_from_filename("demo-1.0-0.tar.bz2").unwrap();
+        let mut record = PackageRecord::new(
+            PackageName::new_unchecked("demo"),
+            Version::from_str("1.0").unwrap(),
+            "0".to_string(),
+        );
+        record.depends = vec!["python >=3.10".to_string()];
+        record.constrains = vec!["python >=3.10".to_string()];
+        record
+            .extra_depends
+            .insert("test".to_string(), vec!["pytest >=8".to_string()]);
+
+        let mut v3 = V3Packages::default();
+        insert_package_record_by_revision(
+            &mut IndexMap::default(),
+            &mut IndexMap::default(),
+            &mut v3,
+            filename.clone(),
+            IndexedPackageRecord {
+                record,
+                repodata_revision: RepodataRevision::V3,
+                matchspecs: None,
+                wheel_url: None,
+            },
+            RepodataRevision::V3,
+        )
+        .unwrap();
+
+        let record = &v3.tar_bz2[&filename.identifier];
+        assert_eq!(record.depends, ["python[version=\">=3.10\"]"]);
+        assert_eq!(record.constrains, ["python[version=\">=3.10\"]"]);
+        assert_eq!(record.extra_depends["test"], ["pytest[version=\">=8\"]"]);
+    }
+
+    #[test]
     fn indexer_only_produces_legacy_and_v3_package_layouts() {
         let filename = DistArchiveIdentifier::try_from_filename("demo-1.0-0.tar.bz2").unwrap();
         let indexed_record = |revision| IndexedPackageRecord {
@@ -2226,6 +2448,7 @@ mod tests {
                 "0".to_string(),
             ),
             repodata_revision: revision,
+            matchspecs: None,
             wheel_url: None,
         };
 

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -1123,39 +1123,62 @@ fn package_records_from_repodata(repodata: RepoData) -> ExistingRepodata {
     }
 }
 
-/// Renders package dependency fields in CEP 48's required v3 `MatchSpec` form.
+/// Renders package dependency fields for their destination repodata revision.
 ///
 /// Fresh package archives retain their parsed `MatchSpecs` from `index.json`
-/// validation. Records read from existing repodata are parsed here only when
-/// they are emitted into the v3 map.
-fn render_record_matchspecs_for_v3(
+/// validation. Records read from existing repodata are parsed here before they
+/// are re-emitted, so patches and layout migrations cannot publish syntax that
+/// the target revision cannot represent.
+fn render_record_matchspecs_for_revision(
     record: &mut PackageRecord,
     matchspecs: Option<ValidatedMatchSpecs>,
+    revision: RepodataRevision,
 ) -> Result<(), RepodataError> {
+    if revision.uses_legacy_package_layout()
+        && (!record.extra_depends.is_empty() || !record.flags.is_empty())
+    {
+        return Err(RepodataError::Other(anyhow::anyhow!(
+            "legacy repodata cannot represent extra_depends or package flags"
+        )));
+    }
+
     let rendered: anyhow::Result<rattler_conda_types::package::RenderedMatchSpecs> =
         if let Some(matchspecs) = matchspecs {
             matchspecs
-                .render_for_revision(RepodataRevision::V3)
+                .render_for_revision(revision)
                 .map_err(anyhow::Error::from)
         } else {
             let parse_options =
                 ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3);
-            let render = |spec: &str| -> anyhow::Result<String> {
-                MatchSpec::from_str(spec, parse_options)
-                    .with_context(|| format!("failed to parse v3 repodata MatchSpec '{spec}'"))?
-                    .to_canonical_string()
-                    .map_err(anyhow::Error::from)
+            let render = |field: &str, spec: &str| -> anyhow::Result<String> {
+                let parsed = MatchSpec::from_str(spec, parse_options).with_context(|| {
+                    format!("failed to parse {revision} repodata MatchSpec in {field}: '{spec}'")
+                })?;
+                if revision.uses_legacy_package_layout()
+                    && !parsed
+                        .required_repodata_revision()
+                        .uses_legacy_package_layout()
+                {
+                    anyhow::bail!(
+                        "legacy repodata cannot represent MatchSpec in {field}: '{spec}'"
+                    );
+                }
+                if revision.as_u64() >= RepodataRevision::V3.as_u64() {
+                    parsed.to_canonical_string().map_err(anyhow::Error::from)
+                } else {
+                    Ok(parsed.to_string())
+                }
             };
             Ok(rattler_conda_types::package::RenderedMatchSpecs {
                 depends: record
                     .depends
                     .iter()
-                    .map(|spec| render(spec))
+                    .map(|spec| render("depends", spec))
                     .collect::<Result<_, _>>()?,
                 constrains: record
                     .constrains
                     .iter()
-                    .map(|spec| render(spec))
+                    .map(|spec| render("constrains", spec))
                     .collect::<Result<_, _>>()?,
                 extra_depends: record
                     .extra_depends
@@ -1163,7 +1186,7 @@ fn render_record_matchspecs_for_v3(
                     .map(|(group, specs)| {
                         specs
                             .iter()
-                            .map(|spec| render(spec))
+                            .map(|spec| render(&format!("extra_depends.{group}"), spec))
                             .collect::<Result<_, _>>()
                             .map(|rendered| (group.clone(), rendered))
                     })
@@ -1178,20 +1201,30 @@ fn render_record_matchspecs_for_v3(
     Ok(())
 }
 
-/// Canonicalizes all dependency `MatchSpecs` in the v3 maps before publication.
+/// Validates legacy records and canonicalizes v3 dependency `MatchSpecs`.
 ///
 /// Patches apply after initial package indexing and can replace dependency
 /// strings, so this is deliberately run immediately before writing repodata
 /// (and before deriving its shards).
-fn canonicalize_v3_repodata_matchspecs(repodata: &mut RepoData) -> Result<(), RepodataError> {
+fn validate_repodata_matchspecs(repodata: &mut RepoData) -> Result<(), RepodataError> {
+    for record in repodata.packages.values_mut() {
+        render_record_matchspecs_for_revision(record, None, RepodataRevision::Legacy)?;
+    }
+    for record in repodata.conda_packages.values_mut() {
+        render_record_matchspecs_for_revision(record, None, RepodataRevision::Legacy)?;
+    }
     for record in repodata.v3.tar_bz2.values_mut() {
-        render_record_matchspecs_for_v3(record, None)?;
+        render_record_matchspecs_for_revision(record, None, RepodataRevision::V3)?;
     }
     for record in repodata.v3.conda.values_mut() {
-        render_record_matchspecs_for_v3(record, None)?;
+        render_record_matchspecs_for_revision(record, None, RepodataRevision::V3)?;
     }
     for record in repodata.v3.whl.values_mut() {
-        render_record_matchspecs_for_v3(&mut record.package_record, None)?;
+        render_record_matchspecs_for_revision(
+            &mut record.package_record,
+            None,
+            RepodataRevision::V3,
+        )?;
     }
     Ok(())
 }
@@ -1205,12 +1238,13 @@ fn insert_package_record_by_revision(
     package: IndexedPackageRecord,
     revision: RepodataRevision,
 ) -> Result<(), RepodataError> {
-    if revision.uses_legacy_package_layout()
-        && !package.repodata_revision.uses_legacy_package_layout()
+    if package.repodata_revision.as_u64() > RepodataRevision::V3.as_u64()
+        && revision.as_u64() < package.repodata_revision.as_u64()
     {
         return Err(RepodataError::Other(anyhow::anyhow!(
-            "package requires repodata revision {}, but the effective index revision is legacy",
-            package.repodata_revision
+            "package requires repodata revision {}, but the effective index revision is {}",
+            package.repodata_revision,
+            revision
         )));
     }
 
@@ -1222,6 +1256,9 @@ fn insert_package_record_by_revision(
     } = package;
 
     if revision.uses_legacy_package_layout() {
+        // Reparse records placed in legacy maps so v3-origin metadata is
+        // checked against the legacy feature set before it is emitted.
+        render_record_matchspecs_for_revision(&mut record, None, revision)?;
         match filename.archive_type {
             DistArchiveType::Conda(CondaArchiveType::TarBz2) => {
                 packages.insert(filename, record);
@@ -1237,7 +1274,7 @@ fn insert_package_record_by_revision(
             }
         }
     } else if revision == RepodataRevision::V3 {
-        render_record_matchspecs_for_v3(&mut record, matchspecs)?;
+        render_record_matchspecs_for_revision(&mut record, matchspecs, revision)?;
         match filename.archive_type {
             DistArchiveType::Conda(CondaArchiveType::TarBz2) => {
                 v3.tar_bz2.insert(filename.identifier, record);
@@ -1389,7 +1426,7 @@ pub async fn write_repodata(
     } else {
         repodata
     };
-    canonicalize_v3_repodata_matchspecs(&mut repodata)?;
+    validate_repodata_matchspecs(&mut repodata)?;
 
     let repodata_bytes = serde_json::to_vec(&repodata)?;
 
@@ -2311,7 +2348,33 @@ mod tests {
     }
 
     #[test]
-    fn latest_assignment_rejects_v3_package_demotion() {
+    fn latest_assignment_rejects_future_revision_demotion() {
+        let filename = DistArchiveIdentifier::try_from_filename("demo-1.0-0.tar.bz2").unwrap();
+        let indexed = IndexedPackageRecord {
+            record: PackageRecord::new(
+                PackageName::new_unchecked("demo"),
+                Version::from_str("1.0").unwrap(),
+                "0".to_string(),
+            ),
+            repodata_revision: RepodataRevision::from(4),
+            matchspecs: None,
+            wheel_url: None,
+        };
+        let error = insert_package_record_by_revision(
+            &mut IndexMap::default(),
+            &mut IndexMap::default(),
+            &mut V3Packages::default(),
+            filename,
+            indexed,
+            RepodataRevision::V3,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("requires repodata revision v4"));
+    }
+
+    #[test]
+    fn legacy_representable_v3_record_can_be_downleveled() {
         let filename = DistArchiveIdentifier::try_from_filename("demo-1.0-0.tar.bz2").unwrap();
         let indexed = IndexedPackageRecord {
             record: PackageRecord::new(
@@ -2323,19 +2386,47 @@ mod tests {
             matchspecs: None,
             wheel_url: None,
         };
-        let revision = PackageRevisionAssignment::Latest
-            .assign(indexed.repodata_revision, RepodataRevision::Legacy);
-        let error = insert_package_record_by_revision(
-            &mut IndexMap::default(),
+        let mut packages = IndexMap::default();
+        insert_package_record_by_revision(
+            &mut packages,
             &mut IndexMap::default(),
             &mut V3Packages::default(),
-            filename,
+            filename.clone(),
             indexed,
-            revision,
+            RepodataRevision::Legacy,
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert!(error.to_string().contains("requires repodata revision v3"));
+        assert!(packages.contains_key(&filename));
+    }
+
+    #[test]
+    fn legacy_repodata_rejects_v3_matchspecs_after_patching() {
+        let mut repodata = RepoData {
+            info: None,
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            v3: V3Packages::default(),
+            removed: HashSet::default(),
+            version: None,
+        };
+        let mut record = PackageRecord::new(
+            PackageName::new_unchecked("demo"),
+            Version::from_str("1.0").unwrap(),
+            "0".to_string(),
+        );
+        record.depends = vec!["python[extras=[\"test\"]]".to_string()];
+        repodata.packages.insert(
+            DistArchiveIdentifier::try_from_filename("demo-1.0-0.tar.bz2").unwrap(),
+            record,
+        );
+
+        let error = validate_repodata_matchspecs(&mut repodata).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("legacy repodata cannot represent MatchSpec")
+        );
     }
 
     #[test]
@@ -2394,7 +2485,7 @@ mod tests {
             version: Some(1),
         };
         repodata.v3.tar_bz2.insert(identifier.clone(), record);
-        canonicalize_v3_repodata_matchspecs(&mut repodata).unwrap();
+        validate_repodata_matchspecs(&mut repodata).unwrap();
 
         let record = &repodata.v3.tar_bz2[&identifier];
         assert_eq!(record.depends, ["python[version=\">=3.10\"]"]);

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -1123,9 +1123,9 @@ fn package_records_from_repodata(repodata: RepoData) -> ExistingRepodata {
     }
 }
 
-/// Renders package dependency fields in CEP 48's required v3 MatchSpec form.
+/// Renders package dependency fields in CEP 48's required v3 `MatchSpec` form.
 ///
-/// Fresh package archives retain their parsed MatchSpecs from `index.json`
+/// Fresh package archives retain their parsed `MatchSpecs` from `index.json`
 /// validation. Records read from existing repodata are parsed here only when
 /// they are emitted into the v3 map.
 fn render_record_matchspecs_for_v3(
@@ -1133,43 +1133,42 @@ fn render_record_matchspecs_for_v3(
     matchspecs: Option<ValidatedMatchSpecs>,
 ) -> Result<(), RepodataError> {
     let rendered: anyhow::Result<rattler_conda_types::package::RenderedMatchSpecs> =
-        match matchspecs {
-            Some(matchspecs) => matchspecs
+        if let Some(matchspecs) = matchspecs {
+            matchspecs
                 .render_for_revision(RepodataRevision::V3)
-                .map_err(anyhow::Error::from),
-            None => {
-                let parse_options =
-                    ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3);
-                let render = |spec: &str| -> anyhow::Result<String> {
-                    MatchSpec::from_str(spec, parse_options)
-                        .with_context(|| format!("failed to parse v3 repodata MatchSpec '{spec}'"))?
-                        .to_canonical_string()
-                        .map_err(anyhow::Error::from)
-                };
-                Ok(rattler_conda_types::package::RenderedMatchSpecs {
-                    depends: record
-                        .depends
-                        .iter()
-                        .map(|spec| render(spec))
-                        .collect::<Result<_, _>>()?,
-                    constrains: record
-                        .constrains
-                        .iter()
-                        .map(|spec| render(spec))
-                        .collect::<Result<_, _>>()?,
-                    extra_depends: record
-                        .extra_depends
-                        .iter()
-                        .map(|(group, specs)| {
-                            specs
-                                .iter()
-                                .map(|spec| render(spec))
-                                .collect::<Result<_, _>>()
-                                .map(|rendered| (group.clone(), rendered))
-                        })
-                        .collect::<Result<_, _>>()?,
-                })
-            }
+                .map_err(anyhow::Error::from)
+        } else {
+            let parse_options =
+                ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3);
+            let render = |spec: &str| -> anyhow::Result<String> {
+                MatchSpec::from_str(spec, parse_options)
+                    .with_context(|| format!("failed to parse v3 repodata MatchSpec '{spec}'"))?
+                    .to_canonical_string()
+                    .map_err(anyhow::Error::from)
+            };
+            Ok(rattler_conda_types::package::RenderedMatchSpecs {
+                depends: record
+                    .depends
+                    .iter()
+                    .map(|spec| render(spec))
+                    .collect::<Result<_, _>>()?,
+                constrains: record
+                    .constrains
+                    .iter()
+                    .map(|spec| render(spec))
+                    .collect::<Result<_, _>>()?,
+                extra_depends: record
+                    .extra_depends
+                    .iter()
+                    .map(|(group, specs)| {
+                        specs
+                            .iter()
+                            .map(|spec| render(spec))
+                            .collect::<Result<_, _>>()
+                            .map(|rendered| (group.clone(), rendered))
+                    })
+                    .collect::<Result<_, _>>()?,
+            })
         };
     let rendered = rendered?;
 
@@ -1179,7 +1178,7 @@ fn render_record_matchspecs_for_v3(
     Ok(())
 }
 
-/// Canonicalizes all dependency MatchSpecs in the v3 maps before publication.
+/// Canonicalizes all dependency `MatchSpecs` in the v3 maps before publication.
 ///
 /// Patches apply after initial package indexing and can replace dependency
 /// strings, so this is deliberately run immediately before writing repodata

--- a/crates/rattler_index/tests/integration/basic_indexing.rs
+++ b/crates/rattler_index/tests/integration/basic_indexing.rs
@@ -849,8 +849,10 @@ async fn test_index_repodata_revision_from_index_json() {
         r#"{
             "build": "h123_0",
             "build_number": 0,
+            "constrains": ["python >=3.10"],
+            "depends": ["python >=3.10"],
             "extra_depends": {
-                "docs": ["sphinx"]
+                "docs": ["sphinx >=8"]
             },
             "name": "revision-demo",
             "noarch": "generic",
@@ -912,10 +914,18 @@ async fn test_index_repodata_revision_from_index_json() {
             .pointer("/packages/revision-demo-1.0.0-h123_0.tar.bz2")
             .is_none()
     );
-    assert!(
-        repodata_json
-            .pointer("/v3/tar.bz2/revision-demo-1.0.0-h123_0")
-            .is_some()
+    let record = &repodata_json["v3"]["tar.bz2"]["revision-demo-1.0.0-h123_0"];
+    assert_eq!(
+        record["depends"],
+        serde_json::json!(["python[version=\">=3.10\"]"])
+    );
+    assert_eq!(
+        record["constrains"],
+        serde_json::json!(["python[version=\">=3.10\"]"])
+    );
+    assert_eq!(
+        record["extra_depends"]["docs"],
+        serde_json::json!(["sphinx[version=\">=8\"]"])
     );
     let revision = &repodata_json["info"]["repodata_revisions"]["v3"];
     assert_eq!(revision["n_packages"], 1);


### PR DESCRIPTION
### Description

This closes a gap in our CEP 48 implementation. Records under the v3 repodata map must use the canonical `name[...]` MatchSpec representation, but the indexer copied dependency strings from `info/index.json` as-is. This meant positional legacy strings could end up in v3 through normal indexing, `package-revision-assignment = "latest"`, existing repodata, or repodata patches.

The indexer now retains parsed MatchSpecs while validating `index.json` and renders them for the effective destination revision. Legacy records keep the positional representation, while v3 records canonicalize `depends`, `constrains`, and `extra_depends`. It also rejects attempts to demote a package that requires v3 into legacy repodata and canonicalizes v3 records again after patches are applied.

Related rattler-build change: https://github.com/prefix-dev/rattler-build/pull/2758

### How Has This Been Tested?

- `pixi run cargo-fmt`
- `RUSTC_WRAPPER= pixi run -- cargo test -p rattler_conda_types test_validated_matchspecs_render_for_revision`
- `RUSTC_WRAPPER= pixi run -- cargo test -p rattler_index --lib`
- `RUSTC_WRAPPER= pixi run -- cargo test -p rattler_index --test test_index test_index_repodata_revision_from_index_json`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: OpenAI GPT-5.6 via Pi

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
