### PR TITLE
fix: keep legacy-compatible extra_depends in legacy repodata

### DIFF
--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -134,7 +134,7 @@ impl IndexJson {
             return revision;
         }
 
-        if !self.extra_depends.is_empty() || !self.flags.is_empty() {
+        if !self.flags.is_empty() {
             return RepodataRevision::V3;
         }
 
@@ -144,6 +144,7 @@ impl IndexJson {
             .depends
             .iter()
             .chain(self.constrains.iter())
+            .chain(self.extra_depends.values().flatten())
             .any(|spec| matchspec_requires_v3(spec, parse_options))
         {
             RepodataRevision::V3
@@ -180,11 +181,11 @@ impl IndexJson {
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
         let required_revision = self.repodata_revision.unwrap_or_else(|| {
-            if !self.extra_depends.is_empty()
-                || !self.flags.is_empty()
+            if !self.flags.is_empty()
                 || depends
                     .iter()
                     .chain(constrains.iter())
+                    .chain(extra_depends.values().flatten())
                     .any(|spec| spec.required_repodata_revision() == RepodataRevision::V3)
             {
                 RepodataRevision::V3
@@ -193,9 +194,6 @@ impl IndexJson {
             }
         });
 
-        if required_revision.uses_legacy_package_layout() && !self.extra_depends.is_empty() {
-            return Err(ValidateIndexJsonError::LegacyExtraDepends);
-        }
         if required_revision.uses_legacy_package_layout() && !self.flags.is_empty() {
             return Err(ValidateIndexJsonError::LegacyFlags);
         }
@@ -367,10 +365,6 @@ fn matchspec_requires_v3(spec: &str, parse_options: ParseMatchSpecOptions) -> bo
 /// An error when validating an [`IndexJson`] value.
 #[derive(Debug, Error)]
 pub enum ValidateIndexJsonError {
-    /// Legacy repodata cannot represent `extra_depends`.
-    #[error("legacy repodata cannot represent extra_depends")]
-    LegacyExtraDepends,
-
     /// Legacy repodata cannot represent package flags.
     #[error("legacy repodata cannot represent flags")]
     LegacyFlags,
@@ -458,8 +452,27 @@ mod test {
         .unwrap();
         assert_eq!(
             inferred_revision.required_repodata_revision(),
+            RepodataRevision::Legacy
+        );
+        inferred_revision.validate().unwrap();
+
+        let inferred_revision: IndexJson = serde_json::from_str(
+            r#"{
+                "build": "0",
+                "build_number": 0,
+                "extra_depends": {
+                    "test": ["pytest[when=\"python >=3.10\"]"]
+                },
+                "name": "demo",
+                "version": "1.0"
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            inferred_revision.required_repodata_revision(),
             RepodataRevision::V3
         );
+        inferred_revision.validate().unwrap();
 
         let inferred_revision: IndexJson = serde_json::from_str(
             r#"{
@@ -570,10 +583,7 @@ mod test {
             }"#,
         )
         .unwrap();
-        assert!(matches!(
-            extra_depends.validate(),
-            Err(ValidateIndexJsonError::LegacyExtraDepends)
-        ));
+        extra_depends.validate().unwrap();
 
         let extras_matchspec: IndexJson = serde_json::from_str(
             r#"{
@@ -604,6 +614,24 @@ mod test {
         .unwrap();
         assert!(matches!(
             conditional_matchspec.validate(),
+            Err(ValidateIndexJsonError::LegacyMatchSpecCondition { .. })
+        ));
+
+        let conditional_extra_dependency: IndexJson = serde_json::from_str(
+            r#"{
+                "build": "0",
+                "build_number": 0,
+                "extra_depends": {
+                    "test": ["pytest[when=\"python >=3.10\"]"]
+                },
+                "name": "demo",
+                "repodata_revision": 0,
+                "version": "1.0"
+            }"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            conditional_extra_dependency.validate(),
             Err(ValidateIndexJsonError::LegacyMatchSpecCondition { .. })
         ));
 

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -1134,11 +1134,9 @@ fn render_record_matchspecs_for_revision(
     matchspecs: Option<ValidatedMatchSpecs>,
     revision: RepodataRevision,
 ) -> Result<(), RepodataError> {
-    if revision.uses_legacy_package_layout()
-        && (!record.extra_depends.is_empty() || !record.flags.is_empty())
-    {
+    if revision.uses_legacy_package_layout() && !record.flags.is_empty() {
         return Err(RepodataError::Other(anyhow::anyhow!(
-            "legacy repodata cannot represent extra_depends or package flags"
+            "legacy repodata cannot represent package flags"
         )));
     }
 

--- a/crates/rattler_index/tests/integration/basic_indexing.rs
+++ b/crates/rattler_index/tests/integration/basic_indexing.rs
@@ -387,7 +387,7 @@ async fn test_reindex_derives_authoritative_legacy_and_v3_stats_and_message_prec
             r#"{
                 "build": "0",
                 "build_number": 0,
-                "extra_depends": { "docs": ["sphinx"] },
+                "extra_depends": { "docs": ["sphinx[when=\"python >=3.10\"]"] },
                 "name": "v3-stats",
                 "noarch": "generic",
                 "subdir": "noarch",
@@ -909,28 +909,18 @@ async fn test_index_repodata_revision_from_index_json() {
             .pointer("/packages.conda/empty-0.1.0-h4616a5c_0.conda")
             .is_some()
     );
-    assert!(
-        repodata_json
-            .pointer("/packages/revision-demo-1.0.0-h123_0.tar.bz2")
-            .is_none()
-    );
-    let record = &repodata_json["v3"]["tar.bz2"]["revision-demo-1.0.0-h123_0"];
-    assert_eq!(
-        record["depends"],
-        serde_json::json!(["python[version=\">=3.10\"]"])
-    );
-    assert_eq!(
-        record["constrains"],
-        serde_json::json!(["python[version=\">=3.10\"]"])
-    );
+    let record = &repodata_json["packages"][package_name];
+    assert_eq!(record["depends"], serde_json::json!(["python >=3.10"]));
+    assert_eq!(record["constrains"], serde_json::json!(["python >=3.10"]));
     assert_eq!(
         record["extra_depends"]["docs"],
-        serde_json::json!(["sphinx[version=\">=8\"]"])
+        serde_json::json!(["sphinx >=8"])
     );
-    let revision = &repodata_json["info"]["repodata_revisions"]["v3"];
-    assert_eq!(revision["n_packages"], 1);
-    assert_eq!(revision["oldest"], 1710000000000i64);
-    assert_eq!(revision["newest"], 1710000000000i64);
+    assert!(
+        repodata_json
+            .pointer("/v3/tar.bz2/revision-demo-1.0.0-h123_0")
+            .is_none()
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Description

`extra_depends` is additive metadata, so a package whose extra dependency MatchSpecs only use legacy syntax does not need V3 repodata. Previously, any non-empty `extra_depends` map forced the package into V3, which meant older clients could not see the record in `packages` or `packages.conda`.

This keeps legacy-compatible extras in the legacy maps and preserves their legacy MatchSpec strings. Packages still use V3 when an extra dependency uses a V3-only field such as `when`, and explicitly legacy records still reject those MatchSpecs.

### How Has This Been Tested?

- `pixi run --environment lint cargo-fmt`
- `pixi run -- cargo nextest run -p rattler_conda_types test_required_repodata_revision`
- `pixi run -- cargo nextest run -p rattler_conda_types test_validate_legacy_repodata_revision`
- `pixi run -- cargo nextest run -p rattler_index test_index_repodata_revision_from_index_json`
- `pixi run -- cargo nextest run -p rattler_index test_reindex_derives_authoritative_legacy_and_v3_stats_and_message_precedence`
- `pixi run -- cargo clippy -p rattler_conda_types -p rattler_index --all-targets -- -D warnings`
- Published a `noarch` test package with `extra_depends` to Anaconda.org and verified the field in both [repodata.json](https://conda.anaconda.org/baszalmstra/label/extra-depends-test/noarch/repodata.json) and the [served archive](https://conda.anaconda.org/baszalmstra/label/extra-depends-test/noarch/extra-depends-upload-test-0.0.1-0.tar.bz2). The package remains in the `extra-depends-test` label as a public demo.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Pi

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
