### PR TITLE
feat: reuse unchanged sharded repodata queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4989,6 +4989,7 @@ dependencies = [
  "rattler_virtual_packages",
  "regex",
  "reqwest",
+ "serde",
  "serde_json",
  "sha2 0.11.0",
  "tempfile",

--- a/crates/coalesced_map/src/lib.rs
+++ b/crates/coalesced_map/src/lib.rs
@@ -211,6 +211,30 @@ where
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = Result<V, E>>,
     {
+        self.initialize(key, init, false).await
+    }
+
+    /// Refreshes the value for `key` using the provided async `init` function.
+    /// Concurrent refreshes and reads are coalesced behind the same in-flight
+    /// initialization.
+    pub async fn refresh<E, Fut, F>(&self, key: K, init: F) -> Result<V, CoalescedGetError<E>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<V, E>>,
+    {
+        self.initialize(key, init, true).await
+    }
+
+    async fn initialize<E, Fut, F>(
+        &self,
+        key: K,
+        init: F,
+        refresh: bool,
+    ) -> Result<V, CoalescedGetError<E>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<V, E>>,
+    {
         // Attempt to occupy or observe the entry.
         let sender = match self.map.entry(key.clone()) {
             Entry::Vacant(entry) => {
@@ -221,7 +245,13 @@ where
                 tx
             }
             Entry::Occupied(mut entry) => match entry.get() {
-                PendingOrFetched::Fetched(v) => return Ok(v.clone()),
+                PendingOrFetched::Fetched(v) if !refresh => return Ok(v.clone()),
+                PendingOrFetched::Fetched(_) => {
+                    let (tx, _) = broadcast::channel(1);
+                    let tx = Arc::new(tx);
+                    entry.insert(PendingOrFetched::Pending(Arc::downgrade(&tx)));
+                    tx
+                }
                 PendingOrFetched::Pending(weak_tx) => {
                     if let Some(tx) = weak_tx.upgrade() {
                         // Subscribe before dropping the entry to avoid missing the send.
@@ -332,6 +362,23 @@ mod tests {
             .unwrap();
 
         assert_eq!(result2, "value1");
+    }
+
+    #[tokio::test]
+    async fn test_refresh() {
+        let map: CoalescedMap<String, String> = CoalescedMap::new();
+        let key = "key".to_string();
+        map.get_or_try_init(key.clone(), || async { Ok::<_, &str>("old".to_string()) })
+            .await
+            .unwrap();
+
+        let refreshed = map
+            .refresh(key.clone(), || async { Ok::<_, &str>("new".to_string()) })
+            .await
+            .unwrap();
+
+        assert_eq!(refreshed, "new");
+        assert_eq!(map.get(&key).as_deref(), Some("new"));
     }
 
     #[tokio::test]

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -72,6 +72,7 @@ rattler_upload = { workspace = true }
 rattler_shell = { workspace = true, default-features = false }
 reqwest = { workspace = true, features = ["stream", "query"] }
 reqwest-middleware = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }

--- a/crates/rattler-bin/src/commands/exec.rs
+++ b/crates/rattler-bin/src/commands/exec.rs
@@ -10,14 +10,17 @@ use rattler_conda_types::{
     Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, Matches, PackageName,
     ParseMatchSpecOptions, Platform,
 };
-use rattler_repodata_gateway::{Gateway, RepoData, SourceConfig};
+use rattler_repodata_gateway::{
+    Gateway, RepoData, RepoDataQueryResult, ShardQuerySnapshot, SourceConfig,
+};
 use rattler_shell::shell::ShellEnum;
 use rattler_solve::{SolverImpl, SolverTask, resolvo::Solver};
 use rattler_virtual_packages::{VirtualPackage, VirtualPackageOverrides};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeSet, HashMap},
-    env,
+    env, fs,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -69,6 +72,25 @@ pub struct Opt {
     /// Disable modification of PS1 to indicate the temporary environment.
     #[clap(long)]
     pub no_modify_ps1: bool,
+}
+
+/// The solver inputs and shard-index entries that produced an exec environment.
+///
+/// This is intentionally private to `rattler exec`: it is a fail-closed cache
+/// validation format, not a lockfile format.
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct ShardStamp {
+    input: ResolutionInput,
+    query_snapshot: ShardQuerySnapshot,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct ResolutionInput {
+    rattler_version: String,
+    specs: Vec<String>,
+    channels: Vec<String>,
+    platform: Platform,
+    virtual_packages: Vec<String>,
 }
 
 /// CLI entry point for `rattler exec`.
@@ -213,16 +235,7 @@ async fn create_exec_prefix(options: CreateExecPrefixOptions<'_>) -> miette::Res
     let prefix = cache_dir.join(EXEC_ENVS_DIR).join(&dir_name);
 
     let sentinel = prefix.join(".exec-ready");
-
-    // If the environment already exists, and we are not forcing a
-    // reinstallation, we can return early.
-    if sentinel.exists() && !force_reinstall {
-        tracing::info!("reusing existing environment in {}", prefix.display());
-        return Ok(prefix);
-    }
-
     let download_client = create_client_with_middleware(offline)?;
-
     let gateway = Gateway::builder()
         .with_cache_dir(cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
         .with_package_cache(PackageCache::new(
@@ -238,20 +251,72 @@ async fn create_exec_prefix(options: CreateExecPrefixOptions<'_>) -> miette::Res
             per_channel: HashMap::new(),
         })
         .finish();
+    let virtual_packages = detect_virtual_packages()?;
+    let input = resolution_input(specs, channels, platform, &virtual_packages);
 
-    let repo_data = wrap_in_async_progress(
-        "fetching repodata",
-        gateway
-            .query(
-                channels.to_vec(),
-                [platform, Platform::NoArch],
-                specs.to_vec(),
-            )
-            .recursive(true),
-    )
-    .await
-    .into_diagnostic()
-    .context("failed to fetch repodata")?;
+    // A ready prefix is reusable only if the exact solver inputs and the
+    // query's complete CEP-16 lookup trace are still unchanged.
+    let mut refreshed_repo_data = None;
+    if sentinel.exists() && !force_reinstall {
+        match read_shard_stamp(&sentinel) {
+            Ok(stamp) if stamp.input == input => {
+                match wrap_in_async_progress(
+                    "checking environment freshness",
+                    gateway
+                        .query(
+                            channels.to_vec(),
+                            [platform, Platform::NoArch],
+                            specs.to_vec(),
+                        )
+                        .recursive(true)
+                        .execute_if_unchanged(&stamp.query_snapshot),
+                )
+                .await
+                {
+                    Ok(RepoDataQueryResult::NotModified) => {
+                        tracing::info!("reusing up-to-date environment in {}", prefix.display());
+                        return Ok(prefix);
+                    }
+                    Ok(RepoDataQueryResult::Updated(output)) => {
+                        tracing::info!(
+                            "environment in {} is stale or cannot use sharded repodata; resolving again",
+                            prefix.display()
+                        );
+                        refreshed_repo_data = Some(output);
+                    }
+                    Err(error) => tracing::info!(
+                        "could not validate cached environment in {} ({error}); resolving again",
+                        prefix.display()
+                    ),
+                }
+            }
+            Ok(_) => tracing::info!(
+                "cached environment in {} has different solver inputs; resolving again",
+                prefix.display()
+            ),
+            Err(error) => tracing::info!(
+                "cached environment in {} has no usable shard stamp ({error}); resolving again",
+                prefix.display()
+            ),
+        }
+    }
+
+    let repo_data = match refreshed_repo_data {
+        Some(output) => output,
+        None => wrap_in_async_progress(
+            "fetching repodata",
+            gateway
+                .query(
+                    channels.to_vec(),
+                    [platform, Platform::NoArch],
+                    specs.to_vec(),
+                )
+                .recursive(true),
+        )
+        .await
+        .into_diagnostic()
+        .context("failed to fetch repodata")?,
+    };
 
     // Surface any non-fatal CEP-42 channel-relation problems.
     for warning in &repo_data.warnings {
@@ -261,16 +326,13 @@ async fn create_exec_prefix(options: CreateExecPrefixOptions<'_>) -> miette::Res
     let total_records: usize = repo_data.iter().map(RepoData::len).sum();
     tracing::debug!("loaded {} records from repodata", total_records);
 
-    // Determine virtual packages of the current platform
-    let virtual_packages: Vec<GenericVirtualPackage> = VirtualPackage::detect(
-        &VirtualPackageOverrides::from_env(),
-        rattler::default_cache_dir().ok().as_deref(),
-    )
-    .into_diagnostic()
-    .context("failed to determine virtual packages")?
-    .into_iter()
-    .map(GenericVirtualPackage::from)
-    .collect();
+    let shard_stamp = repo_data
+        .shard_query_snapshot()
+        .cloned()
+        .map(|query_snapshot| ShardStamp {
+            input,
+            query_snapshot,
+        });
 
     let solver_task = SolverTask {
         specs: specs.to_vec(),
@@ -281,6 +343,14 @@ async fn create_exec_prefix(options: CreateExecPrefixOptions<'_>) -> miette::Res
     let solved = wrap_in_progress("solving environment", || Solver.solve(solver_task))
         .into_diagnostic()
         .context("failed to solve environment")?;
+
+    // A stale prefix must be recreated instead of linked over. Do this only
+    // after resolving successfully, so a solve failure leaves the old prefix intact.
+    if prefix.exists() {
+        fs::remove_dir_all(&prefix)
+            .into_diagnostic()
+            .context("failed to remove stale exec environment")?;
+    }
 
     // Solve the environment
     tracing::info!(
@@ -308,10 +378,13 @@ async fn create_exec_prefix(options: CreateExecPrefixOptions<'_>) -> miette::Res
         .into_diagnostic()
         .context("failed to install environment")?;
 
-    // Mark the environment as ready so future runs can skip solve+install
-    std::fs::write(&sentinel, b"")
-        .into_diagnostic()
-        .context("failed to write sentinel file")?;
+    if let Some(shard_stamp) = shard_stamp {
+        write_shard_stamp(&sentinel, &shard_stamp)?;
+    } else {
+        fs::write(&sentinel, b"")
+            .into_diagnostic()
+            .context("failed to write sentinel file")?;
+    }
 
     if let Some(regex) = list {
         list_environment(specs, &solved.records, regex)?;
@@ -328,6 +401,59 @@ fn parse_specs(raw: &[String]) -> miette::Result<Vec<MatchSpec>> {
                 .with_context(|| format!("failed to parse matchspec '{s}'"))
         })
         .collect()
+}
+
+fn detect_virtual_packages() -> miette::Result<Vec<GenericVirtualPackage>> {
+    VirtualPackage::detect(
+        &VirtualPackageOverrides::from_env(),
+        rattler::default_cache_dir().ok().as_deref(),
+    )
+    .into_diagnostic()
+    .context("failed to determine virtual packages")
+    .map(|packages| {
+        packages
+            .into_iter()
+            .map(GenericVirtualPackage::from)
+            .collect()
+    })
+}
+
+fn resolution_input(
+    specs: &[MatchSpec],
+    channels: &[Channel],
+    platform: Platform,
+    virtual_packages: &[GenericVirtualPackage],
+) -> ResolutionInput {
+    let mut specs: Vec<_> = specs.iter().map(ToString::to_string).collect();
+    specs.sort_unstable();
+    let mut virtual_packages: Vec<_> = virtual_packages.iter().map(ToString::to_string).collect();
+    virtual_packages.sort_unstable();
+    ResolutionInput {
+        rattler_version: env!("CARGO_PKG_VERSION").to_string(),
+        specs,
+        channels: channels
+            .iter()
+            .map(|channel| channel.base_url.to_string())
+            .collect(),
+        platform,
+        virtual_packages,
+    }
+}
+
+fn read_shard_stamp(path: &Path) -> miette::Result<ShardStamp> {
+    let bytes = fs::read(path).into_diagnostic()?;
+    serde_json::from_slice(&bytes).into_diagnostic()
+}
+
+fn write_shard_stamp(path: &Path, stamp: &ShardStamp) -> miette::Result<()> {
+    let temporary_path = path.with_extension("tmp");
+    fs::write(
+        &temporary_path,
+        serde_json::to_vec(stamp).into_diagnostic()?,
+    )
+    .into_diagnostic()?;
+    fs::rename(&temporary_path, path).into_diagnostic()?;
+    Ok(())
 }
 
 /// Produces a deterministic hex hash over (sorted specs, sorted channels, platform).

--- a/crates/rattler_repodata_gateway/src/gateway/barrier_cell.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/barrier_cell.rs
@@ -68,6 +68,12 @@ impl<T> BarrierCell<T> {
         unsafe { (*self.value.get()).assume_init_ref() }
     }
 
+    /// Returns the value when the cell has been initialized.
+    pub fn get(&self) -> Option<&T> {
+        (self.state.load(Ordering::Acquire) == BarrierCellState::Initialized as u8)
+            .then(|| unsafe { (*self.value.get()).assume_init_ref() })
+    }
+
     /// Set the value in the cell, if the cell was already initialized this will return an error.
     pub fn set(&self, value: T) -> Result<(), SetError> {
         // Only one thread should be able to transition from Uninitialized to Initializing.
@@ -127,8 +133,10 @@ mod test {
     #[test]
     pub fn test_drop() {
         let barrier = BarrierCell::new();
+        assert!(barrier.get().is_none());
         let arc = Arc::new(42);
         barrier.set(arc.clone()).unwrap();
+        assert_eq!(barrier.get().map(AsRef::as_ref), Some(&42));
         assert_eq!(Arc::strong_count(&arc), 2);
         drop(barrier);
         assert_eq!(Arc::strong_count(&arc), 1);

--- a/crates/rattler_repodata_gateway/src/gateway/channel_expander.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_expander.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use rattler_conda_types::{Channel, ChannelRelations, ChannelUrl, Platform};
+use serde::{Deserialize, Serialize};
 
 use super::{
     channel_relations::{EdgeSource, PriorityEdge, Resolution, resolve_channel_priority},
@@ -22,7 +23,8 @@ use crate::Reporter;
 /// failing the query and are returned as [`ChannelRelationsWarning`]s.
 ///
 /// [CEP-42]: https://github.com/conda/ceps/blob/main/cep-0042.md
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ChannelRelationsMode {
     /// Ignore declared relations. Same as `channel_relations_max_depth(0)`.
     Disabled,

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -35,7 +35,10 @@ use coalesced_map::{CoalescedGetError, CoalescedMap};
 pub use error::GatewayError;
 #[cfg(feature = "indicatif")]
 pub use indicatif::{IndicatifReporter, IndicatifReporterBuilder};
-pub use query::{NamesQuery, NamesQueryOutput, RepoDataQuery, RepoDataQueryOutput};
+pub use query::{
+    NamesQuery, NamesQueryOutput, RepoDataQuery, RepoDataQueryOutput, RepoDataQueryResult,
+    ShardQuerySnapshot,
+};
 #[cfg(not(target_arch = "wasm32"))]
 use rattler_cache::package_cache::PackageCache;
 use rattler_conda_types::{Channel, ChannelRelations, MatchSpec, Platform, RepoDataRecord};
@@ -374,6 +377,29 @@ struct GatewayInner {
 }
 
 impl GatewayInner {
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn revalidate_subdir(
+        &self,
+        channel: &Channel,
+        platform: Platform,
+    ) -> Result<Arc<Subdir>, GatewayError> {
+        let channel = channel.clone();
+        self.subdirs
+            .refresh((channel.clone(), platform), || async {
+                self.create_subdir(&channel, platform, None)
+                    .await
+                    .map(Arc::new)
+            })
+            .await
+            .map_err(|error| match error {
+                CoalescedGetError::Init(error) => error,
+                CoalescedGetError::CoalescedRequestFailed => GatewayError::IoError(
+                    "a coalesced request failed".to_string(),
+                    std::io::ErrorKind::Other.into(),
+                ),
+            })
+    }
+
     /// Returns the [`Subdir`] for the given channel and platform. This
     /// function will create the [`Subdir`] if it does not exist yet, otherwise
     /// it will return the previously created subdir.

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -1,14 +1,15 @@
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     future::{Future, IntoFuture},
     sync::Arc,
 };
 
 use futures::{FutureExt, StreamExt, select_biased, stream::FuturesUnordered};
 use rattler_conda_types::{
-    Channel, ChannelUrl, MatchSpec, Matches, PackageName, PackageNameMatcher, Platform,
-    RepoDataRecord,
+    Channel, ChannelRelations, ChannelUrl, MatchSpec, Matches, PackageName, PackageNameMatcher,
+    Platform, RepoDataRecord, ShardedRepodata,
 };
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use super::{
@@ -30,6 +31,9 @@ type RecordPatch = dyn Fn(&RepoDataRecord) -> Option<RepoDataRecord> + Send + Sy
 /// it like a `Vec<RepoData>`.
 #[derive(Debug, Default)]
 pub struct RepoDataQueryOutput {
+    /// A replayable CEP-16 snapshot of the exact package-name lookups used by
+    /// this query. `None` means the query used an unsupported source or shape.
+    shard_snapshot: Option<ShardQuerySnapshot>,
     /// One bucket per source. CEP-42-discovered channels are inserted
     /// next to the channel that introduced them; caller-supplied
     /// sources keep their positions.
@@ -40,6 +44,17 @@ pub struct RepoDataQueryOutput {
     /// Non-fatal warnings encountered during the query. Also streamed
     /// to [`Reporter::on_gateway_warning`] as they are recorded.
     pub warnings: Vec<GatewayWarning>,
+}
+
+impl RepoDataQueryOutput {
+    /// Returns the CEP-16 snapshot that can conditionally replay this query.
+    ///
+    /// A snapshot is available only for supported exact-name queries against
+    /// sharded repodata. Persist it together with any inputs that influence
+    /// the subsequent solve.
+    pub fn shard_query_snapshot(&self) -> Option<&ShardQuerySnapshot> {
+        self.shard_snapshot.as_ref()
+    }
 }
 
 impl std::ops::Deref for RepoDataQueryOutput {
@@ -56,6 +71,116 @@ impl IntoIterator for RepoDataQueryOutput {
 
     fn into_iter(self) -> Self::IntoIter {
         self.repodata.into_iter()
+    }
+}
+
+/// Result of conditionally replaying a repodata query from a shard snapshot.
+#[derive(Debug)]
+pub enum RepoDataQueryResult {
+    /// The previous query's candidate universe remains unchanged.
+    NotModified,
+    /// The candidate universe may have changed; use the returned repodata for
+    /// the normal solve and persist its fresh snapshot.
+    Updated(RepoDataQueryOutput),
+}
+
+/// An opaque, serializable trace of the CEP-16 shard lookups made by a query.
+///
+/// It implements [`Serialize`] and [`Deserialize`], so callers can persist it
+/// with any serde format. It includes absent-name lookups and, when channel
+/// relations are enabled, their declared state. Consumers must treat an
+/// unsupported or missing snapshot as a normal-query fallback.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ShardQuerySnapshot {
+    version: u8,
+    query: ShardQueryIdentity,
+    indexes: Vec<ShardQueryIndex>,
+}
+
+/// The query shape that determines whether a shard snapshot can be replayed.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct ShardQueryIdentity {
+    recursive: bool,
+    channel_relations_mode: ChannelRelationsMode,
+    channel_relations_max_depth: usize,
+    channels: Vec<ChannelUrl>,
+    platforms: Vec<Platform>,
+    specs: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct ShardQueryIndex {
+    channel: ChannelUrl,
+    subdir: Platform,
+    channel_relations: Option<ChannelRelations>,
+    hashes: BTreeMap<String, Option<String>>,
+}
+
+impl ShardQueryIndex {
+    fn from_repodata(
+        channel: &Channel,
+        platform: Platform,
+        names: &[String],
+        repodata: &ShardedRepodata,
+        include_channel_relations: bool,
+    ) -> Self {
+        let channel_relations = include_channel_relations
+            .then(|| repodata.info.channel_relations.clone())
+            .flatten();
+        let hashes = names
+            .iter()
+            .map(|name| (name.clone(), repodata.shards.get(name).map(hex::encode)))
+            .collect();
+        Self {
+            channel: channel.base_url.clone(),
+            subdir: platform,
+            channel_relations,
+            hashes,
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn matches(
+        &self,
+        gateway: &GatewayInner,
+        include_channel_relations: bool,
+    ) -> Result<bool, GatewayError> {
+        let channel = Channel::from_url(self.channel.url().as_ref().clone());
+        let platform = self.subdir;
+        let subdir = gateway.revalidate_subdir(&channel, platform).await?;
+        let Some(repodata) = subdir.sharded_repodata() else {
+            return Ok(false);
+        };
+        let current = Self::from_repodata(
+            &channel,
+            platform,
+            self.hashes.keys().cloned().collect::<Vec<_>>().as_slice(),
+            repodata,
+            include_channel_relations,
+        );
+        Ok(self == &current)
+    }
+}
+
+impl ShardQuerySnapshot {
+    #[cfg(not(target_arch = "wasm32"))]
+    fn is_valid(&self) -> bool {
+        self.version == 1 && !self.indexes.is_empty()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn matches(&self, gateway: &GatewayInner) -> Result<bool, GatewayError> {
+        let include_channel_relations = !matches!(
+            self.query.channel_relations_mode,
+            ChannelRelationsMode::Disabled
+        );
+        let matches = futures::future::try_join_all(
+            self.indexes
+                .iter()
+                .map(|index| index.matches(gateway, include_channel_relations)),
+        )
+        .await?;
+        Ok(matches.into_iter().all(std::convert::identity))
     }
 }
 
@@ -332,6 +457,68 @@ impl RepoDataQuery {
         let executor = QueryExecutor::new(self)?;
         executor.run().await
     }
+
+    /// Replays this query against a snapshot produced by an earlier
+    /// [`RepoDataQuery::execute`].
+    ///
+    /// The gateway revalidates only the snapshot's indexes. If their relevant
+    /// entries and metadata are unchanged, no package shards are fetched and
+    /// [`RepoDataQueryResult::NotModified`] is returned. Otherwise this
+    /// executes the normal query and returns [`RepoDataQueryResult::Updated`].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn execute_if_unchanged(
+        self,
+        snapshot: &ShardQuerySnapshot,
+    ) -> Result<RepoDataQueryResult, GatewayError> {
+        if !snapshot.is_valid() || self.shard_query_identity().as_ref() != Some(&snapshot.query) {
+            return self.execute().await.map(RepoDataQueryResult::Updated);
+        }
+
+        if snapshot.matches(&self.gateway).await? {
+            Ok(RepoDataQueryResult::NotModified)
+        } else {
+            // Validation refreshed the normal gateway cache, so the full query
+            // can reuse those subdirs without fetching their indexes again.
+            self.execute().await.map(RepoDataQueryResult::Updated)
+        }
+    }
+
+    /// WASM does not currently expose an index-only refresh path, so it always
+    /// falls back to the ordinary query.
+    #[cfg(target_arch = "wasm32")]
+    pub async fn execute_if_unchanged(
+        self,
+        _snapshot: &ShardQuerySnapshot,
+    ) -> Result<RepoDataQueryResult, GatewayError> {
+        self.execute().await.map(RepoDataQueryResult::Updated)
+    }
+
+    fn shard_query_identity(&self) -> Option<ShardQueryIdentity> {
+        if self.record_patch.is_some()
+            || self.specs.iter().any(|spec| {
+                spec.url.is_some() || !matches!(&spec.name, PackageNameMatcher::Exact(_))
+            })
+        {
+            return None;
+        }
+
+        let channels = self
+            .sources
+            .iter()
+            .map(|source| match source {
+                Source::Channel(channel) => Some(channel.base_url.clone()),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()?;
+        Some(ShardQueryIdentity {
+            recursive: self.recursive,
+            channel_relations_mode: self.channel_relations_mode,
+            channel_relations_max_depth: self.channel_relations_max_depth,
+            channels,
+            platforms: self.platforms.clone(),
+            specs: self.specs.iter().map(ToString::to_string).collect(),
+        })
+    }
 }
 
 /// Owns all mutable state during query execution and provides methods for each phase.
@@ -342,6 +529,7 @@ struct QueryExecutor {
     recursive: bool,
     record_patch: Option<Arc<RecordPatch>>,
     reporter: Option<Arc<dyn Reporter>>,
+    shard_query_identity: Option<ShardQueryIdentity>,
 
     // Specs categorized at construction
     direct_url_specs: Vec<DirectUrlSpec>,
@@ -440,6 +628,8 @@ impl NoticeCollector {
 impl QueryExecutor {
     /// Construct executor, categorizing specs and initializing subdirs.
     fn new(query: RepoDataQuery) -> Result<Self, GatewayError> {
+        let shard_query_identity = query.shard_query_identity();
+
         // Destructure query to take ownership of all fields
         let RepoDataQuery {
             gateway,
@@ -615,6 +805,7 @@ impl QueryExecutor {
             recursive,
             record_patch,
             reporter,
+            shard_query_identity,
             direct_url_specs,
             direct_url_result,
             pending_pattern_specs,
@@ -1091,6 +1282,53 @@ impl QueryExecutor {
         self.spawn_package_fetches_for_new_handle(handle_idx);
     }
 
+    fn capture_shard_snapshot(
+        &self,
+        handles: &[SubdirHandle],
+    ) -> Result<Option<ShardQuerySnapshot>, GatewayError> {
+        let Some(query) = &self.shard_query_identity else {
+            return Ok(None);
+        };
+
+        let mut names: Vec<String> = self
+            .all_queued_specs
+            .keys()
+            .map(|name| name.as_normalized().to_string())
+            .collect();
+        names.sort_unstable();
+
+        let mut indexes = Vec::with_capacity(handles.len());
+        for handle in handles {
+            let SubdirKind::Channel { url, platform } = &handle.kind else {
+                return Ok(None);
+            };
+            let channel = Channel::from_url(url.url().as_ref().clone());
+            let Some(repodata) = handle
+                .barrier
+                .get()
+                .and_then(|subdir| subdir.sharded_repodata())
+            else {
+                return Ok(None);
+            };
+            indexes.push(ShardQueryIndex::from_repodata(
+                &channel,
+                *platform,
+                &names,
+                repodata,
+                self.expander.enabled(),
+            ));
+        }
+        indexes.sort_by(|left, right| {
+            (&left.channel, left.subdir).cmp(&(&right.channel, right.subdir))
+        });
+
+        Ok(Some(ShardQuerySnapshot {
+            version: 1,
+            query: query.clone(),
+            indexes,
+        }))
+    }
+
     /// Build the final [`RepoDataQueryOutput`]. When relations were
     /// observed, buckets sort by
     /// `(caller anchor, CEP-42 priority, platform, original index)`:
@@ -1099,6 +1337,7 @@ impl QueryExecutor {
     /// introduced them) and priority orders channels within an
     /// anchor, placing bases before the declaring channel.
     fn finalize_channel_relations(mut self) -> Result<RepoDataQueryOutput, GatewayError> {
+        let shard_snapshot = self.capture_shard_snapshot(&self.subdir_handles)?;
         let direct = self.direct_url_result;
         let mut handles = self.subdir_handles;
 
@@ -1180,6 +1419,7 @@ impl QueryExecutor {
         }
         repodata.extend(handles.into_iter().map(|h| h.data));
         Ok(RepoDataQueryOutput {
+            shard_snapshot,
             repodata,
             notices: self.notices.collected,
             warnings: self

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -182,24 +182,30 @@ mod tests {
         http::{Response, StatusCode},
         routing::get,
     };
-    use rattler_conda_types::{Channel, RepodataRevisions, ShardedRepodata, ShardedSubdirInfo};
+    use rattler_conda_types::{
+        Channel, PackageName, Platform, RepodataRevisions, Shard, ShardedRepodata,
+        ShardedSubdirInfo,
+    };
     use rattler_digest::{Sha256, parse_digest_from_hex};
-    use std::future::IntoFuture;
     use std::net::SocketAddr;
     use std::path::Path;
     use std::sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     };
+    use std::{future::IntoFuture, str::FromStr};
     use tokio::sync::oneshot;
     use url::Url;
 
     use super::{ShardCachePolicy, ShardedSubdir};
+    use crate::{Gateway, RepoDataQueryResult, ShardQuerySnapshot, SourceConfig};
 
     /// A mock server that serves a sharded repodata index but returns
     /// configurable responses for shard requests.
     struct MockShardedServer {
         local_addr: SocketAddr,
+        sharded_index: Arc<Mutex<ShardedRepodata>>,
+        index_requests: Arc<AtomicUsize>,
         shard_requests: Arc<AtomicUsize>,
         _shutdown_sender: oneshot::Sender<()>,
     }
@@ -227,23 +233,41 @@ mod tests {
                 shards,
             };
 
-            // Encode the index as msgpack and compress with zstd
-            let index_bytes = rmp_serde::to_vec_named(&sharded_index).unwrap();
-            let compressed_index = zstd::encode_all(index_bytes.as_slice(), 3).unwrap();
+            let sharded_index = Arc::new(Mutex::new(sharded_index));
+            let valid_shard = zstd::encode_all(
+                rmp_serde::to_vec_named(&Shard::default())
+                    .unwrap()
+                    .as_slice(),
+                3,
+            )
+            .unwrap();
 
+            let index_requests = Arc::new(AtomicUsize::new(0));
             let shard_requests = Arc::new(AtomicUsize::new(0));
             let app = Router::new()
                 .route(
                     "/linux-64/repodata_shards.msgpack.zst",
-                    get(move || async move {
-                        Response::builder()
-                            .status(StatusCode::OK)
-                            .header("Content-Type", "application/octet-stream")
-                            // Keep the cached copy fresh, so `UseCacheOnly`
-                            // accepts it in the cold-shard tests.
-                            .header("Cache-Control", "max-age=3600")
-                            .body(Body::from(compressed_index.clone()))
-                            .unwrap()
+                    get({
+                        let sharded_index = Arc::clone(&sharded_index);
+                        let index_requests = Arc::clone(&index_requests);
+                        move || {
+                            let sharded_index = Arc::clone(&sharded_index);
+                            let index_requests = Arc::clone(&index_requests);
+                            async move {
+                                index_requests.fetch_add(1, Ordering::SeqCst);
+                                let index_bytes =
+                                    rmp_serde::to_vec_named(&*sharded_index.lock().unwrap())
+                                        .unwrap();
+                                let compressed_index =
+                                    zstd::encode_all(index_bytes.as_slice(), 3).unwrap();
+                                Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header("Content-Type", "application/octet-stream")
+                                    .header("Cache-Control", "max-age=3600")
+                                    .body(Body::from(compressed_index))
+                                    .unwrap()
+                            }
+                        }
                     }),
                 )
                 .route(
@@ -253,6 +277,10 @@ mod tests {
                         move || async move {
                             shard_requests.fetch_add(1, Ordering::SeqCst);
                             match shard_response {
+                                MockShardResponse::Valid => Response::builder()
+                                    .status(StatusCode::OK)
+                                    .body(Body::from(valid_shard.clone()))
+                                    .unwrap(),
                                 MockShardResponse::Empty => Response::builder()
                                     .status(StatusCode::OK)
                                     .body(Body::empty())
@@ -284,6 +312,8 @@ mod tests {
 
             Self {
                 local_addr,
+                sharded_index,
+                index_requests,
                 shard_requests,
                 _shutdown_sender: tx,
             }
@@ -297,6 +327,21 @@ mod tests {
             Channel::from_url(self.url())
         }
 
+        fn index_request_count(&self) -> usize {
+            self.index_requests.load(Ordering::SeqCst)
+        }
+
+        fn refresh_created_at(&self) {
+            self.sharded_index.lock().unwrap().info.created_at = Some(jiff::Timestamp::now());
+        }
+
+        fn replace_shard_hash(&self, hash: &str) {
+            self.sharded_index.lock().unwrap().shards.insert(
+                "test-package".to_string(),
+                parse_digest_from_hex::<Sha256>(hash).unwrap(),
+            );
+        }
+
         /// How many shard downloads the server has answered so far. The index
         /// request is not counted.
         fn shard_request_count(&self) -> usize {
@@ -306,6 +351,7 @@ mod tests {
 
     #[derive(Clone, Copy)]
     enum MockShardResponse {
+        Valid,
         Empty,
         Truncated,
     }
@@ -503,6 +549,114 @@ mod tests {
         )
         .await
         .expect("the index comes from the cache")
+    }
+
+    #[tokio::test]
+    async fn query_snapshot_ignores_volatile_index_metadata() {
+        let server = MockShardedServer::new(MockShardResponse::Valid).await;
+        let cache_dir = tempfile::tempdir().unwrap();
+        let gateway = Gateway::builder()
+            .with_cache_dir(cache_dir.path())
+            .with_channel_config(crate::ChannelConfig {
+                default: SourceConfig {
+                    cache_action: CacheAction::NoCache,
+                    ..SourceConfig::default()
+                },
+                per_channel: std::collections::HashMap::default(),
+            })
+            .finish();
+        let package = PackageName::from_str("test-package").unwrap();
+
+        let initial = gateway
+            .query(
+                vec![server.channel()],
+                [Platform::Linux64],
+                [package.clone()],
+            )
+            .recursive(true)
+            .execute()
+            .await
+            .unwrap();
+        let snapshot = initial
+            .shard_query_snapshot()
+            .cloned()
+            .expect("exact-name sharded query has a replay snapshot");
+        let serialized = serde_json::to_vec(&snapshot).unwrap();
+        let round_tripped: ShardQuerySnapshot = serde_json::from_slice(&serialized).unwrap();
+        assert_eq!(round_tripped, snapshot);
+        assert_eq!(server.shard_request_count(), 1);
+
+        let mut forged = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(forged["version"], 1);
+        assert_eq!(forged["query"]["channel_relations_mode"], "warn");
+        forged["indexes"] = serde_json::Value::Array(Vec::new());
+        let forged: ShardQuerySnapshot = serde_json::from_value(forged).unwrap();
+        let replay = gateway
+            .query(
+                vec![server.channel()],
+                [Platform::Linux64],
+                [package.clone()],
+            )
+            .recursive(true)
+            .execute_if_unchanged(&forged)
+            .await
+            .unwrap();
+        assert!(matches!(replay, RepoDataQueryResult::Updated(_)));
+        assert_eq!(server.shard_request_count(), 1);
+
+        server.refresh_created_at();
+        let replay = gateway
+            .query(vec![server.channel()], [Platform::Linux64], [package])
+            .recursive(true)
+            .execute_if_unchanged(&snapshot)
+            .await
+            .unwrap();
+
+        assert!(matches!(replay, RepoDataQueryResult::NotModified));
+        assert_eq!(server.shard_request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn query_snapshot_falls_back_when_a_shard_hash_changes() {
+        let server = MockShardedServer::new(MockShardResponse::Valid).await;
+        let cache_dir = tempfile::tempdir().unwrap();
+        let gateway = Gateway::builder()
+            .with_cache_dir(cache_dir.path())
+            .with_channel_config(crate::ChannelConfig {
+                default: SourceConfig {
+                    cache_action: CacheAction::NoCache,
+                    ..SourceConfig::default()
+                },
+                per_channel: std::collections::HashMap::default(),
+            })
+            .finish();
+        let package = PackageName::from_str("test-package").unwrap();
+
+        let initial = gateway
+            .query(
+                vec![server.channel()],
+                [Platform::Linux64],
+                [package.clone()],
+            )
+            .recursive(true)
+            .execute()
+            .await
+            .unwrap();
+        let snapshot = initial.shard_query_snapshot().cloned().unwrap();
+        assert_eq!(server.index_request_count(), 1);
+        server
+            .replace_shard_hash("c3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+
+        let replay = gateway
+            .query(vec![server.channel()], [Platform::Linux64], [package])
+            .recursive(true)
+            .execute_if_unchanged(&snapshot)
+            .await
+            .unwrap();
+
+        assert!(matches!(replay, RepoDataQueryResult::Updated(_)));
+        assert_eq!(server.index_request_count(), 2);
+        assert_eq!(server.shard_request_count(), 2);
     }
 
     /// The cache-only modes a cold shard behaves the same under.

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
@@ -314,6 +314,10 @@ impl SubdirClient for ShardedSubdir {
         self.sharded_repodata.shards.keys().cloned().collect()
     }
 
+    fn sharded_repodata(&self) -> Option<&ShardedRepodata> {
+        Some(&self.sharded_repodata)
+    }
+
     fn repodata_revisions(&self) -> &RepodataRevisions {
         &self.sharded_repodata.info.repodata_revisions
     }

--- a/crates/rattler_repodata_gateway/src/gateway/subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use ahash::HashMap;
-use rattler_conda_types::{ChannelRelations, PackageName, RepoDataRecord, RepodataRevisions};
+use rattler_conda_types::{
+    ChannelRelations, PackageName, RepoDataRecord, RepodataRevisions, ShardedRepodata,
+};
 
 use super::GatewayError;
 use crate::Reporter;
@@ -96,6 +98,14 @@ impl Subdir {
         }
     }
 
+    /// Returns the sharded-repodata index, if this subdirectory used CEP-16.
+    pub fn sharded_repodata(&self) -> Option<&ShardedRepodata> {
+        match self {
+            Subdir::Found(subdir) => subdir.sharded_repodata(),
+            Subdir::NotFound => None,
+        }
+    }
+
     /// Returns repodata revisions advertised by this subdirectory.
     pub fn repodata_revisions(&self) -> &RepodataRevisions {
         match self {
@@ -162,6 +172,10 @@ impl SubdirData {
         self.client.package_names()
     }
 
+    pub fn sharded_repodata(&self) -> Option<&ShardedRepodata> {
+        self.client.sharded_repodata()
+    }
+
     pub fn repodata_revisions(&self) -> &RepodataRevisions {
         self.client.repodata_revisions()
     }
@@ -188,6 +202,11 @@ pub trait SubdirClient: Send + Sync {
 
     /// Returns the names of all packages in the subdirectory.
     fn package_names(&self) -> Vec<String>;
+
+    /// Returns the sharded-repodata index when this source uses CEP-16.
+    fn sharded_repodata(&self) -> Option<&ShardedRepodata> {
+        None
+    }
 
     /// Returns repodata revisions advertised by the subdirectory.
     fn repodata_revisions(&self) -> &RepodataRevisions {

--- a/crates/rattler_repodata_gateway/src/lib.rs
+++ b/crates/rattler_repodata_gateway/src/lib.rs
@@ -80,7 +80,8 @@ pub use gateway::{
     CacheClearMode, ChannelConfig, ChannelNoticeResult, ChannelRelationsMode,
     ChannelRelationsWarning, DEFAULT_CHANNEL_RELATIONS_MAX_DEPTH, Gateway, GatewayBuilder,
     GatewayError, GatewayWarning, MaxConcurrency, NamesQuery, NamesQueryOutput, RepoData,
-    RepoDataQuery, RepoDataQueryOutput, RepoDataSource, Source, SourceConfig, SubdirSelection,
+    RepoDataQuery, RepoDataQueryOutput, RepoDataQueryResult, RepoDataSource, ShardQuerySnapshot,
+    Source, SourceConfig, SubdirSelection,
 };
 #[cfg(feature = "indicatif")]
 pub use gateway::{IndicatifReporter, IndicatifReporterBuilder};


### PR DESCRIPTION
`rattler exec` currently resolves again whenever its cached prefix is used. For sharded channels we can cheaply prove that the exact candidate set is still the same, then reuse the prefix without fetching package shards or invoking the solver.

This moves the check into `RepoDataQuery`. A successful exact-name sharded query now exposes a serializable snapshot, and `execute_if_unchanged` either returns `NotModified` or the current repodata for the normal solve. `rattler exec` persists that snapshot together with the typed solver inputs that are not owned by the gateway.

The replay check validates the queried name-to-shard-hash mappings, including absent names. It ignores volatile index metadata such as `created_at`, but still tracks CEP-42 channel relations because those can change the queried channel set. Index revalidations run concurrently and refresh the normal gateway cache, so a changed query can reuse those subdirs during the full fallback query.

Local release profiling found warm prefix reuse takes about 14–15 ms before command activation. A stale index check is bounded by the slower of the concurrent platform/noarch requests rather than their combined latency. #2724 separately fixes repeated HTTP revalidation after a 304 response.

## Testing

- `pixi run cargo-fmt`
- `pixi run -- cargo test -p coalesced_map`
- `pixi run -- cargo test -p rattler_repodata_gateway --features gateway query_snapshot`
- `pixi run -- cargo test -p rattler-bin --bin rattler`
- `pixi run -- cargo clippy -p rattler_repodata_gateway --all-targets --features gateway --no-deps -- -D warnings`
- `pixi run -- cargo clippy -p rattler-bin --no-deps -- -D warnings`
