### PR TITLE
fix: refresh sharded index cache policy after 304

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -200,12 +200,20 @@ mod tests {
     /// configurable responses for shard requests.
     struct MockShardedServer {
         local_addr: SocketAddr,
+        index_requests: Arc<AtomicUsize>,
         shard_requests: Arc<AtomicUsize>,
         _shutdown_sender: oneshot::Sender<()>,
     }
 
     impl MockShardedServer {
         async fn new(shard_response: MockShardResponse) -> Self {
+            Self::new_with_revalidation(shard_response, false).await
+        }
+
+        async fn new_with_revalidation(
+            shard_response: MockShardResponse,
+            revalidate: bool,
+        ) -> Self {
             // Create a minimal sharded index with one package
             let mut shards = ahash::HashMap::default();
             // Use a known hash for the "test-package" shard (SHA256 of empty string)
@@ -231,19 +239,42 @@ mod tests {
             let index_bytes = rmp_serde::to_vec_named(&sharded_index).unwrap();
             let compressed_index = zstd::encode_all(index_bytes.as_slice(), 3).unwrap();
 
+            let index_requests = Arc::new(AtomicUsize::new(0));
             let shard_requests = Arc::new(AtomicUsize::new(0));
             let app = Router::new()
                 .route(
                     "/linux-64/repodata_shards.msgpack.zst",
-                    get(move || async move {
-                        Response::builder()
-                            .status(StatusCode::OK)
-                            .header("Content-Type", "application/octet-stream")
-                            // Keep the cached copy fresh, so `UseCacheOnly`
-                            // accepts it in the cold-shard tests.
-                            .header("Cache-Control", "max-age=3600")
-                            .body(Body::from(compressed_index.clone()))
-                            .unwrap()
+                    get({
+                        let index_requests = Arc::clone(&index_requests);
+                        move |headers: axum::http::HeaderMap| {
+                            let index_requests = Arc::clone(&index_requests);
+                            let compressed_index = compressed_index.clone();
+                            async move {
+                                index_requests.fetch_add(1, Ordering::SeqCst);
+                                if revalidate && headers.contains_key("if-none-match") {
+                                    return Response::builder()
+                                        .status(StatusCode::NOT_MODIFIED)
+                                        .header("Cache-Control", "max-age=3600")
+                                        .header("ETag", "\"test-index\"")
+                                        .body(Body::empty())
+                                        .unwrap();
+                                }
+                                Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header("Content-Type", "application/octet-stream")
+                                    .header(
+                                        "Cache-Control",
+                                        if revalidate {
+                                            "max-age=0"
+                                        } else {
+                                            "max-age=3600"
+                                        },
+                                    )
+                                    .header("ETag", "\"test-index\"")
+                                    .body(Body::from(compressed_index))
+                                    .unwrap()
+                            }
+                        }
                     }),
                 )
                 .route(
@@ -284,6 +315,7 @@ mod tests {
 
             Self {
                 local_addr,
+                index_requests,
                 shard_requests,
                 _shutdown_sender: tx,
             }
@@ -295,6 +327,10 @@ mod tests {
 
         fn channel(&self) -> Channel {
             Channel::from_url(self.url())
+        }
+
+        fn index_request_count(&self) -> usize {
+            self.index_requests.load(Ordering::SeqCst)
         }
 
         /// How many shard downloads the server has answered so far. The index
@@ -503,6 +539,35 @@ mod tests {
         )
         .await
         .expect("the index comes from the cache")
+    }
+
+    #[tokio::test]
+    async fn not_modified_index_refreshes_its_cache_policy() {
+        let server = MockShardedServer::new_with_revalidation(MockShardResponse::Empty, true).await;
+        let cache_dir = tempfile::tempdir().unwrap();
+        let client = rattler_networking::LazyClient::default();
+
+        for _ in 0..3 {
+            ShardedSubdir::new(
+                server.channel(),
+                "linux-64".to_string(),
+                client.clone(),
+                cache_dir.path().to_path_buf(),
+                ShardCachePolicy {
+                    action: CacheAction::CacheOrFetch,
+                    missing_shards_are_empty: false,
+                },
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        // The initial 200 is immediately stale, the 304 refreshes its policy,
+        // and the third load must use the now-fresh cache.
+        assert_eq!(server.index_request_count(), 2);
     }
 
     /// The cache-only modes a cold shard behaves the same under.

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/index.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/index.rs
@@ -121,6 +121,32 @@ pub async fn fetch_index(
         Ok(sharded_index)
     }
 
+    async fn update_cached_index(
+        cache_reader: &mut BufReader<RwLockWriteGuard<File>>,
+        cache_path: &Path,
+        policy: CachePolicy,
+    ) -> Result<Option<ShardedRepodata>, GatewayError> {
+        let (shard_index, bytes) = match read_shard_index_with_bytes(cache_reader).await {
+            Ok(cached_index) => cached_index,
+            Err(error) => {
+                tracing::warn!("the cached shard index has been corrupted: {error}");
+                return Ok(None);
+            }
+        };
+        write_shard_index_cache(cache_reader.get_mut().inner_mut(), policy, bytes)
+            .await
+            .map_err(|error| {
+                GatewayError::IoError(
+                    format!(
+                        "failed to update shard index cache at {}",
+                        cache_path.display()
+                    ),
+                    error,
+                )
+            })?;
+        Ok(Some(shard_index))
+    }
+
     // Fetch the sharded repodata from the remote server
     let canonical_shards_url = channel_base_url
         .join(REPODATA_SHARDS_FILENAME)
@@ -272,26 +298,20 @@ pub async fn fetch_index(
                         &response,
                         SystemTime::now(),
                     ) {
-                        AfterResponse::NotModified(_policy, _) => {
-                            // The cached file is still valid
-                            match read_shard_index_from_reader(&mut cache_reader).await {
-                                Ok(shard_index) => {
-                                    tracing::debug!("shard index cache was not modified");
-                                    if let Some((reporter, index)) = download_reporter {
-                                        reporter.on_download_complete(response.url(), index);
-                                    }
-                                    // If reading the file failed for some reason we'll just
-                                    // fetch it again.
-                                    return Ok(shard_index);
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        "the cached shard index has been corrupted: {e}"
-                                    );
-                                    if let Some((reporter, index)) = download_reporter {
-                                        reporter.on_download_complete(response.url(), index);
-                                    }
-                                }
+                        AfterResponse::NotModified(policy, _) => {
+                            // Preserve the body while updating its cache policy. Without this,
+                            // a 304 leaves the old policy in place and the next process
+                            // immediately revalidates the same index again.
+                            let shard_index =
+                                update_cached_index(&mut cache_reader, &cache_path, policy).await?;
+
+                            if let Some((reporter, index)) = download_reporter {
+                                reporter.on_download_complete(response.url(), index);
+                            }
+
+                            if let Some(shard_index) = shard_index {
+                                tracing::debug!("shard index cache was not modified");
+                                return Ok(shard_index);
                             }
                         }
                         AfterResponse::Modified(policy, _) => {
@@ -467,14 +487,22 @@ async fn write_not_found_cache(cache_file: &mut File, policy: CachePolicy) -> st
 pub async fn read_shard_index_from_reader<R: AsyncRead + Unpin>(
     reader: &mut BufReader<R>,
 ) -> Result<ShardedRepodata, GatewayError> {
-    // Read the file to memory
+    Ok(read_shard_index_with_bytes(reader).await?.0)
+}
+
+async fn read_shard_index_with_bytes<R: AsyncRead + Unpin>(
+    reader: &mut BufReader<R>,
+) -> Result<(ShardedRepodata, Bytes), GatewayError> {
     let mut bytes = Vec::new();
     reader
         .read_to_end(&mut bytes)
         .await
         .map_err(|e| GatewayError::IoError("failed to read shard index buffer".to_string(), e))?;
+    let bytes = Bytes::from(bytes);
+    Ok((parse_shard_index(bytes.clone()).await?, bytes))
+}
 
-    // Deserialize the bytes
+async fn parse_shard_index(bytes: Bytes) -> Result<ShardedRepodata, GatewayError> {
     run_blocking_task(move || {
         rmp_serde::from_slice(&bytes)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))


### PR DESCRIPTION
### Description

While working on CEP-16 query replay, we found that a `304 Not Modified` response updated the cache policy only for the current request. The cached index kept its old stale policy, so every new process revalidated the same unchanged index again.

This keeps the cached index body and rewrites the cache entry with the refreshed policy. The regression test covers a stale `200`, a cache-refreshing `304`, and a third load that stays local.

### How Has This Been Tested?

- `pixi run -- cargo test -p rattler_repodata_gateway --features gateway not_modified_index`
- `pixi run -- cargo clippy -p rattler_repodata_gateway --all-targets --features gateway --no-deps -- -D warnings`
- `pixi run cargo-fmt`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Pi

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
