### PR TITLE
feat: add azure-options to rattler_config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5199,12 +5199,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "dirs",
  "fs-err",
  "indexmap 2.14.0",
  "insta",
+ "rattler_azure",
  "rattler_conda_types",
  "serde",
  "serde_ignored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,6 +4083,7 @@ checksum = "96c9c85ce253ff87225e7669979d877a20c98a06604ec9d6dd5f4473e08f1ae1"
 dependencies = [
  "opendal-core",
  "opendal-layer-retry",
+ "opendal-service-azblob",
  "opendal-service-fs",
  "opendal-service-s3",
 ]
@@ -4123,6 +4124,37 @@ checksum = "7b2a25a718afb81fad81cb9a0580a1cb989221fa2317f888c6a37f8dad408eb7"
 dependencies = [
  "backon",
  "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-service-azblob"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0030644366ef5d8cbe3a4a5822bf99a4aafddc1666e9d24b44d158d9062fc76a"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.5.0",
+ "log",
+ "opendal-core",
+ "opendal-service-azure-common",
+ "quick-xml 0.39.4",
+ "reqsign-azure-storage",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "sha2 0.11.0",
+ "uuid",
+]
+
+[[package]]
+name = "opendal-service-azure-common"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b489f13c42e69d69bdd72952b634356ec43a7881a20259b38b540fcecdf4051"
+dependencies = [
+ "http 1.5.0",
  "opendal-core",
 ]
 
@@ -4366,12 +4398,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -4523,12 +4575,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2 0.10.9",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki",
 ]
 
@@ -4996,6 +5065,24 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "rattler_azure"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "indexmap 2.14.0",
+ "jiff",
+ "opendal",
+ "percent-encoding",
+ "secrecy",
+ "serde",
+ "thiserror 2.0.20",
+ "tokio",
+ "toml",
+ "url",
+ "which",
 ]
 
 [[package]]
@@ -5789,6 +5876,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqsign-azure-storage"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f1fbc9add082f54e51e3bd9730f18d850a1f09d246baff5cd612c74ae4290e"
+dependencies = [
+ "anyhow",
+ "base64 0.23.1",
+ "bytes",
+ "form_urlencoded",
+ "http 1.5.0",
+ "log",
+ "pem 4.0.0",
+ "percent-encoding",
+ "reqsign-core",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+]
+
+[[package]]
 name = "reqsign-core"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5805,6 +5913,9 @@ dependencies = [
  "log",
  "mea",
  "percent-encoding",
+ "rsa",
+ "serde",
+ "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",
  "windows-sys 0.61.2",
@@ -5956,6 +6067,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -6160,6 +6272,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6206,6 +6327,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "sec1"
@@ -6593,7 +6725,7 @@ dependencies = [
  "const-oid 0.9.6",
  "der",
  "digest 0.10.7",
- "pem",
+ "pem 3.0.6",
  "rand_core 0.9.5",
  "sha2 0.10.9",
  "signature",
@@ -6769,7 +6901,7 @@ checksum = "236474c535a3157839926a0ae18f9c0c22b151e49634da6e5b18ad7cac8a3b69"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "pem",
+ "pem 3.0.6",
  "serde",
  "serde_json",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ rstest = { version = "0.26" }
 rstest_reuse = "0.7"
 rustix = { version = "1.1", default-features = false }
 simd-json = { version = "0.17", features = ["serde_impl"] }
+secrecy = "0.10"
 self_cell = "1"
 semver = "1"
 send_wrapper = "0.6"
@@ -217,6 +218,7 @@ coalesced_map = { path = "crates/coalesced_map", version = "=0.1.4", default-fea
 file_url = { path = "crates/file_url", version = "=0.3.2", default-features = false }
 path_resolver = { path = "crates/path_resolver", version = "=0.2.13", default-features = false }
 rattler = { path = "crates/rattler", version = "=0.48.5", default-features = false }
+rattler_azure = { path = "crates/rattler_azure", version = "=0.1.0", default-features = false }
 rattler_cache = { path = "crates/rattler_cache", version = "=0.10.8", default-features = false }
 rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.52.0", default-features = false }
 rattler_conda_version = { path = "crates/rattler_conda_version", version = "=0.1.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ rattler_azure = { path = "crates/rattler_azure", version = "=0.1.0", default-fea
 rattler_cache = { path = "crates/rattler_cache", version = "=0.10.8", default-features = false }
 rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.52.0", default-features = false }
 rattler_conda_version = { path = "crates/rattler_conda_version", version = "=0.1.1", default-features = false }
-rattler_config = { path = "crates/rattler_config", version = "=0.7.3", default-features = false }
+rattler_config = { path = "crates/rattler_config", version = "=0.8.0", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.3.2", default-features = false }
 rattler_git = { path = "crates/rattler_git", version = "=0.3.3", default-features = false }
 rattler_index = { path = "crates/rattler_index", version = "=0.31.3", default-features = false }

--- a/crates/rattler_azure/Cargo.toml
+++ b/crates/rattler_azure/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "rattler_azure"
+version = "0.1.0"
+description = "A crate to streamline interaction with Azure Blob storage for rattler"
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+readme.workspace = true
+
+[features]
+default = []
+# CLI credential options; resolving them may mint a short-lived user-delegation
+# SAS by shelling out to the Azure CLI (which needs `jiff` for the expiry and
+# `tokio` to run `az` without blocking the async runtime).
+clap = ["dep:clap", "dep:jiff", "dep:which", "dep:tokio"]
+opendal = ["dep:opendal"]
+# Serde derives for the types of the `azure-options` config table. Pulls in
+# `serde` and `indexmap/serde` only, so config crates can depend on this crate
+# with default features off.
+serde = ["dep:serde", "indexmap/serde"]
+
+[dependencies]
+clap = { workspace = true, optional = true }
+# The per-container grant table. Order is kept for tables built in memory;
+# deserialized TOML arrives in byte order, since `toml::Table` is a `BTreeMap`.
+indexmap = { workspace = true }
+jiff = { workspace = true, optional = true }
+opendal = { workspace = true, default-features = false, features = [
+  "services-azblob",
+], optional = true }
+percent-encoding = { workspace = true }
+secrecy = { workspace = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["process"], optional = true }
+url = { workspace = true }
+which = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+toml = { workspace = true }

--- a/crates/rattler_azure/src/azblob.rs
+++ b/crates/rattler_azure/src/azblob.rs
@@ -1,0 +1,162 @@
+use secrecy::ExposeSecret;
+
+use crate::{AzureCredentials, AzureLocation, AzureScheme, AzureUrlError};
+
+/// opendal's azblob core builds every request URI as `{endpoint}/{container}/{path}`
+/// and carries no account field, so under a path-style key the account can only
+/// reach the URL through `endpoint` — which is exactly what the key spells, under
+/// both shapes. `root` is the channel path past the key and the container.
+///
+/// `account_name` is mandatory under both shapes: opendal infers it only from
+/// three known Azure suffixes and returns `None` rather than an error otherwise,
+/// so omitting it makes shared-key signing quietly never engage and surfaces as a
+/// 403.
+///
+/// The endpoint never ends in a slash. `AzblobBuilder::endpoint` trims one, but
+/// this builds the config struct literally, where nothing does.
+pub fn azblob_config(
+    credentials: &AzureCredentials,
+    location: &AzureLocation,
+    scheme: AzureScheme,
+) -> Result<opendal::services::AzblobConfig, AzureUrlError> {
+    let (key, container) = location.addressed()?;
+    let endpoint = format!("{scheme}://{key}");
+
+    // Percent-decode each segment: `path_segments()` yields still-encoded segments
+    // and opendal percent-encodes `root + path` again, so passing them through
+    // verbatim would double-encode a prefix containing a space or a `+`.
+    // `addressed` has already confirmed the consumed segments exist.
+    let root = format!(
+        "/{}",
+        location
+            .channel()
+            .path_segments()
+            .skip(key.segments_before_root())
+            // Infallible in practice: `AzureChannelUrl::parse` rejects a segment that
+            // does not decode to UTF-8. Erroring rather than substituting U+FFFD is
+            // what keeps that a guarantee instead of an assumption.
+            .map(|segment| {
+                percent_encoding::percent_decode_str(segment)
+                    .decode_utf8()
+                    .map_err(|source| AzureUrlError::NonUtf8Path {
+                        segment: segment.to_string(),
+                        source,
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .join("/")
+    );
+
+    let (account_key, sas_token) = match credentials {
+        AzureCredentials::AccountKey(key) => (Some(key.expose_secret().to_string()), None),
+        AzureCredentials::SasToken(token) => {
+            let token = token.expose_secret();
+            (
+                None,
+                Some(token.strip_prefix('?').unwrap_or(token).to_string()),
+            )
+        }
+    };
+
+    Ok(opendal::services::AzblobConfig {
+        endpoint: Some(endpoint),
+        account_name: Some(key.account().as_str().to_string()),
+        container: container.as_str().to_string(),
+        root: Some(root),
+        account_key,
+        sas_token,
+        ..Default::default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{located, path_style};
+
+    /// Asserted string by string, because every field but `container` differs from
+    /// host-style and each fails silently when wrong: a missing `account_name` is a
+    /// 403, a stray slash gives `//container/…`, a short `root` writes the channel
+    /// one directory too deep.
+    #[test]
+    fn azblob_config_under_path_style() {
+        let config = azblob_config(
+            &AzureCredentials::AccountKey("key".into()),
+            &path_style("az://127.0.0.1:10000/devstoreaccount1/general/mychannel"),
+            AzureScheme::Http,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.endpoint.as_deref(),
+            Some("http://127.0.0.1:10000/devstoreaccount1")
+        );
+        assert_eq!(config.account_name.as_deref(), Some("devstoreaccount1"));
+        assert_eq!(config.container, "general");
+        assert_eq!(config.root.as_deref(), Some("/mychannel"));
+        assert_eq!(config.account_key.as_deref(), Some("key"));
+
+        let endpoint = config.endpoint.unwrap();
+        assert!(!endpoint.ends_with('/'), "{endpoint}");
+        let root = config.root.unwrap();
+        assert!(
+            !root.contains("general"),
+            "the container must not appear in the root: {root}"
+        );
+        assert!(
+            !root.contains("devstoreaccount1"),
+            "the account must not appear in the root: {root}"
+        );
+    }
+
+    /// A bare `account/container` leaves nothing for the root, which must still be
+    /// `/`, not the empty string opendal treats as a relative path.
+    #[test]
+    fn azblob_config_path_style_without_a_prefix() {
+        let config = azblob_config(
+            &AzureCredentials::SasToken("?sv=token".into()),
+            &path_style("az://127.0.0.1:10000/devstoreaccount1/general"),
+            AzureScheme::Http,
+        )
+        .unwrap();
+
+        assert_eq!(config.root.as_deref(), Some("/"));
+        assert_eq!(config.container, "general");
+        assert_eq!(config.sas_token.as_deref(), Some("sv=token"));
+    }
+
+    #[test]
+    fn azblob_config_under_host_style_is_unchanged() {
+        let config = azblob_config(
+            &AzureCredentials::SasToken("sv=token".into()),
+            &located(
+                "az://stcondachannel.blob.core.windows.net/general/sub/dir",
+                &[],
+            ),
+            AzureScheme::Https,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.endpoint.as_deref(),
+            Some("https://stcondachannel.blob.core.windows.net")
+        );
+        assert_eq!(config.account_name.as_deref(), Some("stcondachannel"));
+        assert_eq!(config.container, "general");
+        assert_eq!(config.root.as_deref(), Some("/sub/dir"));
+        assert_eq!(config.sas_token.as_deref(), Some("sv=token"));
+        assert_eq!(config.account_key, None);
+    }
+
+    #[test]
+    fn azblob_config_decodes_the_root() {
+        let config = azblob_config(
+            &AzureCredentials::AccountKey("key".into()),
+            &located("az://acct.blob.core.windows.net/general/with%20space", &[]),
+            AzureScheme::Https,
+        )
+        .unwrap();
+
+        assert_eq!(config.root.as_deref(), Some("/with space"));
+    }
+}

--- a/crates/rattler_azure/src/channel_url.rs
+++ b/crates/rattler_azure/src/channel_url.rs
@@ -1,0 +1,639 @@
+use url::Url;
+
+use crate::{AzureHost, AzureScheme, AzureUrlError};
+
+/// A validated Azure Blob **channel** URL, which has two spellings: `az://…` as
+/// the user writes it and in configuration, and `http(s)://…` on the wire.
+///
+/// The parts are stored rather than a `Url`, because a `Url`'s port is
+/// scheme-relative: storing `az://host:443/…` as `https` drops the port, and
+/// [`wire`](Self::wire) would then hand out `http://host/…`, a different endpoint.
+/// [`AzureHost`] holds host and port explicitly and normalizes both without a
+/// scheme. Every spelling is built from those same parts, so no two spellings can
+/// disagree.
+///
+/// The wire scheme is an argument to [`wire`](Self::wire) rather than a field
+/// because it comes from the matched `azure-options` entry, while
+/// [`parse`](Self::parse) runs as a clap `value_parser`, before any config file is
+/// read. `rattler-index` takes it from that entry; `rattler_upload` passes the
+/// default, because it reads no config file at all.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct AzureChannelUrl {
+    host: AzureHost,
+
+    /// The path as the URL Standard normalizes it: always a leading `/`, still
+    /// percent-encoded.
+    path: String,
+
+    /// A SAS token may be written inline.
+    query: Option<String>,
+
+    /// Kept so [`canonical`](Self::canonical) spells the channel back the way the
+    /// user wrote it. It reaches no server: an HTTP request carries only the path
+    /// and query.
+    fragment: Option<String>,
+}
+
+/// `\` is a path separator as much as `/` is: the URL Standard's special-scheme
+/// parser (what the `url` crate implements for `http`/`https`, which is what
+/// [`AzureChannelUrl::parse`] parses the tail as) folds `\` into `/` while
+/// parsing a special-scheme URL's path, so anything validated against this
+/// type's own idea of "separator" has to agree.
+const PATH_SEPARATORS: [char; 2] = ['/', '\\'];
+
+/// Starts a query (`?`) or fragment (`#`), ending whatever came before it.
+const QUERY_OR_FRAGMENT_MARKERS: [char; 2] = ['?', '#'];
+
+/// [`PATH_SEPARATORS`] and [`QUERY_OR_FRAGMENT_MARKERS`] combined, written out
+/// because `const` arrays cannot be concatenated: anything that is none of
+/// these can still be part of an authority.
+const AUTHORITY_TERMINATORS: [char; 4] = ['/', '\\', '?', '#'];
+
+impl AzureChannelUrl {
+    /// Parse and validate an `az://` channel URL.
+    ///
+    /// The only accepted spelling is `az://<host>/<…>`. A bare `http(s)://` URL is
+    /// not accepted, so there is one canonical spelling for an Azure channel.
+    ///
+    /// Account and container derivation happens in [`locate`](crate::locate), not
+    /// here: it depends on which [`AzureEndpointKey`](crate::AzureEndpointKey) the
+    /// URL matches, which is config that does not exist yet at clap parse time.
+    pub fn parse(value: &str) -> Result<Self, AzureUrlError> {
+        let rest = strip_az_scheme(value)
+            .ok_or_else(|| AzureUrlError::InvalidScheme(value.to_string()))?;
+
+        let (authority, tail) = split_authority(rest);
+        let host = AzureHost::parse(authority)?;
+        let url = parse_wire_url(value, authority, tail)?;
+
+        let written_segments = decode_written_path_segments(tail)?;
+        if let Some(segment) = has_dot_segment(&written_segments) {
+            return Err(AzureUrlError::DotSegmentInPath(segment.to_string()));
+        }
+
+        let segments = url
+            .path_segments()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        if has_empty_segments(&segments) {
+            return Err(AzureUrlError::EmptyPathSegment {
+                path: url.path().to_string(),
+            });
+        }
+        if let Some((segment, escape)) = malformed_percent_escape_in(&segments) {
+            return Err(AzureUrlError::MalformedPercentEscape { segment, escape });
+        }
+
+        Ok(Self {
+            host,
+            path: url.path().to_string(),
+            query: url.query().map(str::to_string),
+            fragment: url.fragment().map(str::to_string),
+        })
+    }
+
+    pub fn canonical(&self) -> Url {
+        self.spelled("az", Sas::Masked)
+    }
+
+    pub fn wire(&self, scheme: AzureScheme) -> Url {
+        self.spelled(scheme.as_str(), Sas::Exposed)
+    }
+
+    fn spelled(&self, scheme: &str, sas: Sas) -> Url {
+        let mut text = format!("{scheme}://{}{}", self.host, self.path);
+        if let Some(query) = &self.query {
+            text.push('?');
+            match sas {
+                Sas::Exposed => text.push_str(query),
+                Sas::Masked => text.push_str(&mask_sas_signature(query)),
+            }
+        }
+        if let Some(fragment) = &self.fragment {
+            text.push('#');
+            // Masked on the same terms as the query: this spelling is the one that
+            // reaches logs and error messages, and a `sig` is no less a signature
+            // for having been written after a `#`.
+            match sas {
+                Sas::Exposed => text.push_str(fragment),
+                Sas::Masked => text.push_str(&mask_sas_signature(fragment)),
+            }
+        }
+        // Cannot fail: the authority re-serializes to the normalized form it was
+        // parsed from, and the path, query and fragment are already-encoded output
+        // of a `Url` parse. Every host shape `AzureHost` can hold (normalized
+        // domain, IPv4 literal, bracketed IPv6) is valid both to the special-scheme
+        // host parser and to the opaque-host parser `az://` gets.
+        Url::parse(&text).expect("a normalized authority, path and query is a valid URL")
+    }
+
+    pub fn host(&self) -> &AzureHost {
+        &self.host
+    }
+
+    pub(crate) fn query(&self) -> Option<&str> {
+        self.query.as_deref()
+    }
+
+    pub(crate) fn fragment(&self) -> Option<&str> {
+        self.fragment.as_deref()
+    }
+
+    /// The still-encoded path segments, exactly as [`Url::path_segments`] would
+    /// yield them for the wire spelling.
+    pub(crate) fn path_segments(&self) -> std::str::Split<'_, char> {
+        self.path.strip_prefix('/').unwrap_or(&self.path).split('/')
+    }
+}
+
+impl std::fmt::Display for AzureChannelUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.canonical())
+    }
+}
+
+impl std::fmt::Debug for AzureChannelUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Derived, this would print the raw query and hand a `{:?}` on any struct
+        // holding a channel the signature that `canonical()` exists to withhold.
+        f.debug_tuple("AzureChannelUrl")
+            .field(&self.canonical().as_str())
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Sas {
+    Exposed,
+    Masked,
+}
+
+/// The other SAS parameters (`sv`, `se`, `sp`, …) only describe the grant; `sig`
+/// is the secret that makes it usable.
+fn mask_sas_signature(query: &str) -> String {
+    query
+        .split('&')
+        .map(|parameter| match parameter.split_once('=') {
+            Some((name, _)) if name.eq_ignore_ascii_case("sig") => format!("{name}=REDACTED"),
+            _ => parameter.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+impl std::str::FromStr for AzureChannelUrl {
+    type Err = AzureUrlError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+// URL schemes are case-insensitive and `Url` lowercases them, so `AZ://…`
+// reaches every downstream `scheme() == "az"` comparison as `az`.
+fn strip_az_scheme(value: &str) -> Option<&str> {
+    const PREFIX: &str = "az://";
+    let prefix = value.get(..PREFIX.len())?;
+    prefix
+        // `str` has no case-insensitive `starts_with`
+        .eq_ignore_ascii_case(PREFIX)
+        .then(|| &value[PREFIX.len()..])
+}
+
+/// Splits `az://<host>/<…>`'s tail into the authority and everything after
+/// it. The authority runs to the first [`AUTHORITY_TERMINATORS`] character,
+/// so it ends at the same point the URL Standard's special-scheme parser
+/// would end it.
+fn split_authority(rest: &str) -> (&str, &str) {
+    let authority_end = rest.find(AUTHORITY_TERMINATORS).unwrap_or(rest.len());
+    rest.split_at(authority_end)
+}
+
+/// Parses `<authority><tail>` as an `https` URL: the URL Standard's
+/// special-scheme parser is what normalizes the path, query and fragment, and
+/// [`AzureChannelUrl::wire`] hands them straight to an `http(s)` URL, so they
+/// have to be normalized that same way.
+fn parse_wire_url(value: &str, authority: &str, tail: &str) -> Result<Url, AzureUrlError> {
+    Url::parse(&format!("https://{authority}{tail}")).map_err(|source| AzureUrlError::InvalidUrl {
+        value: value.to_string(),
+        source,
+    })
+}
+
+/// Percent-decodes and UTF-8-validates every segment of the path as the user
+/// wrote it, pairing each with the raw (still-encoded) text it came from.
+///
+/// The segments are taken from the text the user wrote, not from a `Url`,
+/// because by the time a `Url` exists the pre-resolution evidence dot-segment
+/// detection needs is gone: the URL Standard's special-scheme parser resolves
+/// dot segments while parsing.
+///
+/// This is also the only place a segment's percent-decoded bytes are checked
+/// for validity as UTF-8: every segment `Url::path_segments` later yields for
+/// this same tail carries the identical escapes (the special-scheme parser
+/// only adds percent-encoding around characters that were not already
+/// escaped, and decoding those trivially succeeds), so re-decoding them there
+/// would just repeat this check.
+fn decode_written_path_segments(tail: &str) -> Result<Vec<(&str, String)>, AzureUrlError> {
+    let written = match tail
+        .split(QUERY_OR_FRAGMENT_MARKERS)
+        .next()
+        .unwrap_or_default()
+    {
+        "" => "/",
+        path => path,
+    };
+    written
+        .trim_start_matches(PATH_SEPARATORS)
+        .split(PATH_SEPARATORS)
+        .map(|segment| {
+            let decoded = percent_encoding::percent_decode_str(segment)
+                .decode_utf8()
+                .map_err(|source| AzureUrlError::NonUtf8Path {
+                    segment: segment.to_string(),
+                    source,
+                })?;
+            Ok((segment, decoded.into_owned()))
+        })
+        .collect()
+}
+
+/// A dot segment — `%2e%2e` as much as `..` — anywhere in the path lets a path
+/// reading as one container (path-style: one *account*) address another:
+/// `/general/a/../../evil/x` eats backwards into the container from a segment
+/// that reads as harmless, and `/general\..\..\evil/x` climbs exactly as far
+/// because the special-scheme parser treats `\` as a separator too. Returns
+/// the raw (still-encoded) offending segment, since that is what the error
+/// quotes back to the user.
+fn has_dot_segment<'a>(segments: &[(&'a str, String)]) -> Option<&'a str> {
+    segments
+        .iter()
+        .find(|(_, decoded)| decoded == "." || decoded == "..")
+        .map(|(raw, _)| *raw)
+}
+
+/// Whether an empty segment appears anywhere but at the end of the path.
+///
+/// An empty segment is not a blob name and not a container name, but
+/// `path_segments()` yields it, so without this `az://host//general` reads as
+/// "no container" and downgrades a granted fetch to anonymous. A trailing one
+/// is just a trailing slash, so it is excluded rather than reported.
+fn has_empty_segments(segments: &[&str]) -> bool {
+    let last = segments.len().saturating_sub(1);
+    segments[..last].iter().any(|segment| segment.is_empty())
+}
+
+/// The first `%` that does not start a valid escape, and the malformed escape
+/// itself: the one encoding defect the user cannot be left to own.
+/// `percent_decode` passes it through literally, so the fetch path sends
+/// `gen%eral` while opendal re-encodes the decoded form to `gen%25eral` and
+/// indexes under a different blob.
+fn malformed_percent_escape_in(segments: &[&str]) -> Option<(String, String)> {
+    segments.iter().find_map(|segment| {
+        malformed_percent_escape(segment).map(|escape| (segment.to_string(), escape))
+    })
+}
+
+fn malformed_percent_escape(segment: &str) -> Option<String> {
+    let bytes = segment.as_bytes();
+    bytes.iter().enumerate().find_map(|(index, byte)| {
+        if *byte != b'%' {
+            return None;
+        }
+        let escape = bytes
+            .get(index..index + 3)
+            .filter(|escape| escape[1..].iter().all(u8::is_ascii_hexdigit));
+        escape
+            .is_none()
+            .then(|| segment[index..].chars().take(3).collect())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{channel, container, located};
+
+    #[test]
+    fn parse_requires_the_az_scheme() {
+        for input in [
+            "https://acct.blob.core.windows.net/general",
+            "http://acct.blob.core.windows.net/general",
+            "ftp://acct.blob.core.windows.net/general",
+            "acct.blob.core.windows.net/general",
+        ] {
+            assert!(
+                matches!(
+                    AzureChannelUrl::parse(input),
+                    Err(AzureUrlError::InvalidScheme(_))
+                ),
+                "expected InvalidScheme for {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_accepts_a_scheme_in_any_case() {
+        for input in [
+            "AZ://acct.blob.core.windows.net/general",
+            "Az://acct.blob.core.windows.net/general",
+            "aZ://acct.blob.core.windows.net/general",
+        ] {
+            let channel = AzureChannelUrl::parse(input)
+                .unwrap_or_else(|err| panic!("{input} should parse: {err}"));
+            assert_eq!(
+                channel.canonical().as_str(),
+                "az://acct.blob.core.windows.net/general"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_and_wire_round_trip() {
+        let channel =
+            AzureChannelUrl::parse("az://acct.blob.core.windows.net/general/noarch").unwrap();
+
+        assert_eq!(
+            channel.canonical().as_str(),
+            "az://acct.blob.core.windows.net/general/noarch"
+        );
+        assert_eq!(
+            channel.wire(AzureScheme::Https).as_str(),
+            "https://acct.blob.core.windows.net/general/noarch"
+        );
+        assert_eq!(
+            channel.wire(AzureScheme::Http).as_str(),
+            "http://acct.blob.core.windows.net/general/noarch"
+        );
+        assert_eq!(channel.to_string(), channel.canonical().to_string());
+        assert_eq!(
+            channel,
+            channel
+                .canonical()
+                .as_str()
+                .parse::<AzureChannelUrl>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn spellings_cannot_disagree() {
+        for input in [
+            "az://acct.blob.core.windows.net/general/noarch",
+            "az://127.0.0.1:10000/devstoreaccount1/general",
+            "az://acct.blob.core.windows.net/general/with%20space?sv=token",
+            // An IPv6 literal is the host shape most likely to break the canonical
+            // rebuild, since it has to survive being re-parsed as an opaque host.
+            "az://[::1]:10000/devstoreaccount1/general",
+            "az://azurite.local:443/devstoreaccount1/general",
+            "az://azurite.local:80/devstoreaccount1/general",
+        ] {
+            let channel = AzureChannelUrl::parse(input).unwrap();
+            let canonical = channel.canonical();
+            for scheme in [AzureScheme::Https, AzureScheme::Http] {
+                let wire = channel.wire(scheme);
+                assert_eq!(wire.scheme(), scheme.as_str());
+                assert_eq!(canonical.host_str(), wire.host_str(), "{input}");
+                assert_eq!(canonical.path(), wire.path(), "{input}");
+                assert_eq!(canonical.query(), wire.query(), "{input}");
+
+                // Ports are compared semantically, not textually: `az` has no
+                // default port so the canonical form always spells one out when the
+                // URL has one, while a wire URL omits a port equal to its scheme's
+                // default. An omitted port on `http` *is* 80, so those agree.
+                let default = match scheme {
+                    AzureScheme::Https => 443,
+                    AzureScheme::Http => 80,
+                };
+                assert_eq!(
+                    wire.port_or_known_default(),
+                    Some(canonical.port().unwrap_or(default)),
+                    "{input} over {scheme}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_written_default_port_survives() {
+        let channel =
+            AzureChannelUrl::parse("az://azurite.local:443/devstoreaccount1/general").unwrap();
+
+        assert_eq!(channel.host().to_string(), "azurite.local:443");
+        assert_eq!(channel.host().port(), Some(443));
+        assert_eq!(
+            channel.canonical().as_str(),
+            "az://azurite.local:443/devstoreaccount1/general"
+        );
+        assert_eq!(
+            channel.wire(AzureScheme::Http).as_str(),
+            "http://azurite.local:443/devstoreaccount1/general"
+        );
+        assert_eq!(
+            channel.wire(AzureScheme::Https).as_str(),
+            "https://azurite.local/devstoreaccount1/general"
+        );
+
+        // Identity must not be scheme-relative either: a host on 443 is not the
+        // same endpoint as the same host with no port, because the scheme that
+        // would make them equal is not known here.
+        let no_port =
+            AzureChannelUrl::parse("az://azurite.local/devstoreaccount1/general").unwrap();
+        assert_ne!(channel, no_port);
+        assert_ne!(channel.host(), no_port.host());
+    }
+
+    #[test]
+    fn host_keeps_a_non_default_port() {
+        let emulator =
+            AzureChannelUrl::parse("az://127.0.0.1:10000/devstoreaccount1/general").unwrap();
+        assert_eq!(emulator.host().to_string(), "127.0.0.1:10000");
+        assert_eq!(
+            emulator.wire(AzureScheme::Http).as_str(),
+            "http://127.0.0.1:10000/devstoreaccount1/general"
+        );
+        assert_eq!(
+            emulator.canonical().as_str(),
+            "az://127.0.0.1:10000/devstoreaccount1/general"
+        );
+
+        let azure = AzureChannelUrl::parse("az://acct.blob.core.windows.net/general").unwrap();
+        assert_eq!(azure.host().to_string(), "acct.blob.core.windows.net");
+        assert_eq!(azure.host().port(), None);
+    }
+
+    #[test]
+    fn a_rewritten_path_is_rejected() {
+        for input in [
+            "az://acct.blob.core.windows.net/general/%2e%2e/%2e%2e/othercontainer/x",
+            "az://127.0.0.1:10000/devstoreaccount1/general/%2e%2e/%2e%2e/otheraccount/othercontainer",
+            "az://acct.blob.core.windows.net/general/../../othercontainer",
+            "az://acct.blob.core.windows.net/general/./noarch",
+            "az://acct.blob.core.windows.net/general/%2E%2E/othercontainer",
+        ] {
+            assert!(
+                matches!(
+                    AzureChannelUrl::parse(input),
+                    Err(AzureUrlError::DotSegmentInPath(_))
+                ),
+                "expected a rejection for {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_segment_is_rejected() {
+        for input in [
+            "az://acct.blob.core.windows.net//general/noarch",
+            "az://acct.blob.core.windows.net/general//noarch",
+            "az://127.0.0.1:10000//devstoreaccount1/general",
+        ] {
+            assert!(
+                matches!(
+                    AzureChannelUrl::parse(input),
+                    Err(AzureUrlError::EmptyPathSegment { .. })
+                ),
+                "expected a rejection for {input}"
+            );
+        }
+
+        assert_eq!(
+            channel("az://acct.blob.core.windows.net/general/")
+                .canonical()
+                .path(),
+            "/general/"
+        );
+    }
+
+    #[test]
+    fn a_malformed_percent_escape_is_rejected() {
+        for input in [
+            "az://acct.blob.core.windows.net/general/gen%eral",
+            "az://acct.blob.core.windows.net/general/100%",
+            "az://acct.blob.core.windows.net/general/%zz",
+        ] {
+            assert!(
+                matches!(
+                    AzureChannelUrl::parse(input),
+                    Err(AzureUrlError::MalformedPercentEscape { .. })
+                ),
+                "expected a rejection for {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn unrewritten_paths_still_parse() {
+        for (input, path) in [
+            (
+                "az://acct.blob.core.windows.net/general/prefix",
+                "/general/prefix",
+            ),
+            ("az://acct.blob.core.windows.net/general/", "/general/"),
+            ("az://acct.blob.core.windows.net/", "/"),
+            ("az://acct.blob.core.windows.net", "/"),
+            (
+                "az://acct.blob.core.windows.net/general/with%20space",
+                "/general/with%20space",
+            ),
+            (
+                "az://acct.blob.core.windows.net/general/p?sv=token#frag",
+                "/general/p",
+            ),
+            // A dot inside a segment is not a dot segment.
+            (
+                "az://acct.blob.core.windows.net/general/..hidden/...",
+                "/general/..hidden/...",
+            ),
+        ] {
+            assert_eq!(channel(input).canonical().path(), path, "{input}");
+        }
+    }
+
+    #[test]
+    fn segments_that_cannot_name_a_blob_are_rejected() {
+        assert!(matches!(
+            AzureChannelUrl::parse("az://acct.blob.core.windows.net/general/%ff"),
+            Err(AzureUrlError::NonUtf8Path { .. })
+        ));
+
+        // An encoded slash past the container is a blob name containing a slash,
+        // which Azure supports. It cannot move the container, which is read from a
+        // separate raw segment, and `ContainerName`'s charset admits neither `/`
+        // nor `%`, so the boundary is held by the type rather than by banning the
+        // escape everywhere.
+        for input in [
+            "az://acct.blob.core.windows.net/general/a%2Fb",
+            "az://acct.blob.core.windows.net/general/a%2fb",
+        ] {
+            assert_eq!(
+                located(input, &[]).container(),
+                Some(&container("general")),
+                "{input}"
+            );
+        }
+
+        for (input, path) in [
+            (
+                "az://acct.blob.core.windows.net/general/café",
+                "/general/caf%C3%A9",
+            ),
+            (
+                "az://acct.blob.core.windows.net/general/with space",
+                "/general/with%20space",
+            ),
+        ] {
+            assert_eq!(channel(input).canonical().path(), path, "{input}");
+        }
+
+        assert_eq!(
+            channel("az://acct.blob.core.windows.net/general/caf%C3%A9")
+                .canonical()
+                .path(),
+            "/general/caf%C3%A9"
+        );
+    }
+}
+
+#[cfg(test)]
+mod debug_redaction_tests {
+    use super::*;
+
+    #[test]
+    fn only_the_wire_spelling_carries_the_signature() {
+        let channel = AzureChannelUrl::parse(
+            "az://acct.blob.core.windows.net/general/p?sv=2024-11-04&sig=SECRETSIG&se=z",
+        )
+        .unwrap();
+
+        for shown in [
+            channel.canonical().to_string(),
+            channel.to_string(),
+            format!("{channel:?}"),
+        ] {
+            assert!(!shown.contains("SECRETSIG"), "signature leaked: {shown}");
+            assert!(shown.contains("sv=2024-11-04"), "over-redacted: {shown}");
+            assert!(shown.contains("se=z"), "over-redacted: {shown}");
+        }
+
+        let fragmented =
+            AzureChannelUrl::parse("az://acct.blob.core.windows.net/general/p?sv=1#sig=SECRETFRAG")
+                .unwrap();
+        for shown in [
+            fragmented.canonical().to_string(),
+            fragmented.to_string(),
+            format!("{fragmented:?}"),
+        ] {
+            assert!(!shown.contains("SECRETFRAG"), "signature leaked: {shown}");
+        }
+
+        assert!(
+            channel
+                .wire(AzureScheme::Https)
+                .to_string()
+                .contains("sig=SECRETSIG"),
+            "the wire spelling must keep the signature that authenticates the request"
+        );
+    }
+}

--- a/crates/rattler_azure/src/clap.rs
+++ b/crates/rattler_azure/src/clap.rs
@@ -1,0 +1,357 @@
+use std::time::Duration;
+
+use clap::Parser;
+
+use secrecy::{ExposeSecret, SecretString};
+
+use crate::{
+    AzureCliSasError, AzureCredentials, AzureLocation, AzureScheme, AzureUrlError,
+    mint_user_delegation_sas,
+};
+
+/// A SAS cannot be individually revoked, so a short lifetime bounds the damage if
+/// one leaks. Thirty minutes covers a typical index or upload run.
+const DEFAULT_AZURE_CLI_SAS_TTL_MINUTES: u64 = 30;
+
+/// Seven days, because Azure caps the lifetime of a user-delegation key there.
+const MAX_AZURE_CLI_SAS_TTL_MINUTES: u64 = 7 * 24 * 60;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AzureCredentialsError {
+    #[error("no Azure credentials supplied: pass --account-key, --sas-token, or --azure-cli")]
+    Missing,
+
+    #[error(transparent)]
+    Url(#[from] AzureUrlError),
+
+    #[error("failed to mint a user-delegation SAS from the Azure CLI")]
+    Cli(#[from] AzureCliSasError),
+}
+
+/// [`AzureCredentialsOpts`] can express several inputs at once. This enum is the
+/// single winner after precedence is applied, so downstream code never reasons
+/// about combinations.
+#[derive(Clone, Debug)]
+pub enum AzureAuthSource {
+    AccountKey(SecretString),
+
+    SasToken(SecretString),
+
+    AzureCli { ttl: Duration },
+}
+
+impl AzureAuthSource {
+    pub async fn resolve(
+        self,
+        permissions: &str,
+        location: &AzureLocation,
+        scheme: AzureScheme,
+    ) -> Result<AzureCredentials, AzureCredentialsError> {
+        match self {
+            AzureAuthSource::AccountKey(account_key) => {
+                Ok(AzureCredentials::AccountKey(account_key))
+            }
+            AzureAuthSource::SasToken(token) => Ok(AzureCredentials::SasToken(token)),
+            AzureAuthSource::AzureCli { ttl } => {
+                let (key, container) = location.addressed()?;
+                let token =
+                    mint_user_delegation_sas(key.account(), container, permissions, ttl, scheme)
+                        .await?;
+                Ok(AzureCredentials::SasToken(token))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct AzureCredentialsOpts {
+    /// The Azure Storage account key.
+    ///
+    /// Mutually exclusive with `--sas-token` and `--azure-cli`.
+    #[arg(
+        long,
+        env = "AZURE_STORAGE_KEY",
+        help_heading = "Azure Credentials",
+        value_parser = secret,
+        group = "credential"
+    )]
+    pub account_key: Option<SecretString>,
+
+    /// A shared access signature (SAS) token, with or without a leading `?`.
+    ///
+    /// Mutually exclusive with `--account-key` and `--azure-cli`.
+    #[arg(
+        long,
+        env = "AZURE_STORAGE_SAS_TOKEN",
+        help_heading = "Azure Credentials",
+        value_parser = secret,
+        group = "credential"
+    )]
+    pub sas_token: Option<SecretString>,
+
+    /// Mint a short-lived user-delegation SAS from the current `az login`
+    /// session (requires the Azure CLI).
+    ///
+    /// Mutually exclusive with `--account-key` and `--sas-token`.
+    #[allow(clippy::doc_markdown)]
+    #[arg(long, help_heading = "Azure Credentials", group = "credential")]
+    pub azure_cli: bool,
+
+    /// Lifetime, in minutes, of the SAS minted for `--azure-cli`.
+    ///
+    /// Raise it for very large index or upload runs. If the SAS expires mid-run,
+    /// later requests fail with a 403 and the run aborts, possibly leaving a
+    /// partial index behind.
+    #[arg(
+        long,
+        default_value_t = DEFAULT_AZURE_CLI_SAS_TTL_MINUTES,
+        value_parser = clap::value_parser!(u64).range(1..=MAX_AZURE_CLI_SAS_TTL_MINUTES),
+        help_heading = "Azure Credentials"
+    )]
+    pub azure_cli_sas_ttl_minutes: u64,
+}
+
+/// Take a command-line or environment value straight into a [`SecretString`], so
+/// it is never a plain `String` a `{:?}` could reach.
+fn secret(value: &str) -> Result<SecretString, std::convert::Infallible> {
+    Ok(value.into())
+}
+
+impl PartialEq for AzureCredentialsOpts {
+    /// Hand-written because [`SecretString`] withholds `PartialEq`: comparing
+    /// secrets is not constant-time. The containing `UploadOpts` tree derives
+    /// `PartialEq`, and comparing parsed command lines is not a secrets check.
+    fn eq(&self, other: &Self) -> bool {
+        fn same(left: Option<&SecretString>, right: Option<&SecretString>) -> bool {
+            match (left, right) {
+                (Some(left), Some(right)) => left.expose_secret() == right.expose_secret(),
+                (None, None) => true,
+                _ => false,
+            }
+        }
+
+        same(self.account_key.as_ref(), other.account_key.as_ref())
+            && same(self.sas_token.as_ref(), other.sas_token.as_ref())
+            && self.azure_cli == other.azure_cli
+            && self.azure_cli_sas_ttl_minutes == other.azure_cli_sas_ttl_minutes
+    }
+}
+
+impl AzureCredentialsOpts {
+    pub fn source(&self) -> Result<AzureAuthSource, AzureCredentialsError> {
+        if self.azure_cli {
+            Ok(AzureAuthSource::AzureCli {
+                ttl: Duration::from_secs(self.azure_cli_sas_ttl_minutes.saturating_mul(60)),
+            })
+        } else if let Some(sas_token) = &self.sas_token {
+            Ok(AzureAuthSource::SasToken(sas_token.clone()))
+        } else if let Some(account_key) = &self.account_key {
+            Ok(AzureAuthSource::AccountKey(account_key.clone()))
+        } else {
+            Err(AzureCredentialsError::Missing)
+        }
+    }
+
+    pub async fn resolve(
+        self,
+        permissions: &str,
+        location: &AzureLocation,
+        scheme: AzureScheme,
+    ) -> Result<AzureCredentials, AzureCredentialsError> {
+        self.source()?.resolve(permissions, location, scheme).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(flatten)]
+        creds: AzureCredentialsOpts,
+    }
+
+    fn opts(
+        account_key: Option<&str>,
+        sas_token: Option<&str>,
+        azure_cli: bool,
+    ) -> AzureCredentialsOpts {
+        AzureCredentialsOpts {
+            account_key: account_key.map(Into::into),
+            sas_token: sas_token.map(Into::into),
+            azure_cli,
+            azure_cli_sas_ttl_minutes: DEFAULT_AZURE_CLI_SAS_TTL_MINUTES,
+        }
+    }
+
+    fn unaddressable() -> AzureLocation {
+        let channel = crate::AzureChannelUrl::parse("az://acct.blob.core.windows.net").unwrap();
+        let location = crate::locate_as(&channel, crate::AzureAddressing::HostStyle).unwrap();
+        assert!(location.addressed().is_err());
+        location
+    }
+
+    #[tokio::test]
+    async fn account_key_resolves() {
+        assert!(matches!(
+            opts(Some("key"), None, false).resolve("cw", &unaddressable(), AzureScheme::Https).await,
+            Ok(AzureCredentials::AccountKey(k)) if k.expose_secret() == "key"
+        ));
+    }
+
+    #[tokio::test]
+    async fn sas_token_resolves() {
+        assert!(matches!(
+            opts(None, Some("sv=..."), false).resolve("cw", &unaddressable(), AzureScheme::Https).await,
+            Ok(AzureCredentials::SasToken(t)) if t.expose_secret() == "sv=..."
+        ));
+    }
+
+    #[tokio::test]
+    async fn none_is_rejected() {
+        assert!(matches!(
+            opts(None, None, false)
+                .resolve("cw", &unaddressable(), AzureScheme::Https)
+                .await,
+            Err(AzureCredentialsError::Missing)
+        ));
+    }
+
+    #[test]
+    fn azure_cli_ttl_is_carried_through() {
+        let mut opts = opts(None, None, true);
+        opts.azure_cli_sas_ttl_minutes = 45;
+        assert!(matches!(
+            opts.source().unwrap(),
+            AzureAuthSource::AzureCli { ttl } if ttl == Duration::from_secs(45 * 60)
+        ));
+    }
+
+    // The `--azure-cli` resolve path shells out to `az`, which isn't available in
+    // the test environment, so we only assert the flag and its TTL parse through
+    // clap and that precedence selects the CLI source; the mint itself is not
+    // exercised here.
+    #[test]
+    fn azure_cli_flag_and_ttl_parse() {
+        let cli = Cli::try_parse_from(["test", "--azure-cli", "--azure-cli-sas-ttl-minutes", "90"])
+            .expect("should parse");
+        assert!(cli.creds.azure_cli);
+        assert_eq!(cli.creds.azure_cli_sas_ttl_minutes, 90);
+
+        let default = Cli::try_parse_from(["test", "--azure-cli"]).expect("should parse");
+        assert_eq!(
+            default.creds.azure_cli_sas_ttl_minutes,
+            DEFAULT_AZURE_CLI_SAS_TTL_MINUTES
+        );
+    }
+
+    /// Serialised env-var swap, since the vars below are process-global and the
+    /// values under test are exactly the ones clap reads from the environment.
+    fn with_env<R>(vars: &[(&str, Option<&str>)], body: impl FnOnce() -> R) -> R {
+        use std::sync::Mutex;
+
+        // SAFETY: the tests that touch these variables are serialised by LOCK.
+        fn set(var: &str, value: Option<&str>) {
+            match value {
+                Some(value) => unsafe { std::env::set_var(var, value) },
+                None => unsafe { std::env::remove_var(var) },
+            }
+        }
+
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _guard = LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let previous: Vec<_> = vars
+            .iter()
+            .map(|(var, value)| {
+                let previous = std::env::var(var).ok();
+                set(var, *value);
+                (*var, previous)
+            })
+            .collect();
+        let out = body();
+        for (var, value) in previous {
+            set(var, value.as_deref());
+        }
+        out
+    }
+
+    fn parse(args: &[&str]) -> Result<AzureCredentialsOpts, clap::Error> {
+        Cli::try_parse_from(std::iter::once("test").chain(args.iter().copied()))
+            .map(|cli| cli.creds)
+    }
+
+    #[test]
+    fn account_key_and_sas_token_conflict_at_clap_level() {
+        assert!(parse(&["--account-key", "k", "--sas-token", "sv=..."]).is_err());
+    }
+
+    #[test]
+    fn azure_cli_conflicts_with_account_key_at_clap_level() {
+        assert!(parse(&["--azure-cli", "--account-key", "k"]).is_err());
+    }
+
+    #[test]
+    fn azure_cli_conflicts_with_sas_token_at_clap_level() {
+        assert!(parse(&["--azure-cli", "--sas-token", "sv=..."]).is_err());
+    }
+
+    #[test]
+    fn credentials_from_env_vars_alone_also_conflict() {
+        // clap's group conflict applies regardless of source, so exporting both
+        // AZURE_STORAGE_KEY and AZURE_STORAGE_SAS_TOKEN — what the `az`
+        // documentation tells you to do — is rejected too. That's a simple,
+        // deterministic outcome the user can resolve by unsetting one.
+        with_env(
+            &[
+                ("AZURE_STORAGE_KEY", Some("key")),
+                ("AZURE_STORAGE_SAS_TOKEN", Some("sv=env")),
+            ],
+            || {
+                assert!(parse(&[]).is_err());
+            },
+        );
+    }
+
+    #[test]
+    fn debug_never_prints_secrets() {
+        let sources = [
+            AzureAuthSource::AccountKey("supersecretkey".into()),
+            AzureAuthSource::SasToken("sig=deadbeef".into()),
+        ];
+        for source in &sources {
+            let out = format!("{source:?}");
+            assert!(out.contains("REDACTED"), "not redacted: {out}");
+            assert!(!out.contains("supersecret"), "leaked key: {out}");
+            assert!(!out.contains("deadbeef"), "leaked token: {out}");
+        }
+
+        let out = format!("{:?}", opts(Some("supersecretkey"), None, false));
+        assert!(out.contains("REDACTED"), "not redacted: {out}");
+        assert!(!out.contains("supersecret"), "leaked key: {out}");
+
+        let out = format!("{:?}", opts(None, Some("sig=deadbeef"), false));
+        assert!(out.contains("REDACTED"), "not redacted: {out}");
+        assert!(!out.contains("deadbeef"), "leaked token: {out}");
+    }
+
+    #[test]
+    fn ttl_range_is_enforced() {
+        assert!(
+            Cli::try_parse_from(["test", "--azure-cli", "--azure-cli-sas-ttl-minutes", "0"])
+                .is_err()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "test",
+                "--azure-cli",
+                "--azure-cli-sas-ttl-minutes",
+                &(MAX_AZURE_CLI_SAS_TTL_MINUTES + 1).to_string(),
+            ])
+            .is_err()
+        );
+    }
+}

--- a/crates/rattler_azure/src/credentials.rs
+++ b/crates/rattler_azure/src/credentials.rs
@@ -1,0 +1,25 @@
+use secrecy::SecretString;
+
+#[derive(Clone, Debug)]
+pub enum AzureCredentials {
+    AccountKey(SecretString),
+    SasToken(SecretString),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_never_prints_secret() {
+        for creds in [
+            AzureCredentials::AccountKey("supersecretkey".into()),
+            AzureCredentials::SasToken("sig=deadbeef".into()),
+        ] {
+            let out = format!("{creds:?}");
+            assert!(out.contains("REDACTED"), "not redacted: {out}");
+            assert!(!out.contains("supersecret"));
+            assert!(!out.contains("deadbeef"));
+        }
+    }
+}

--- a/crates/rattler_azure/src/endpoint_key.rs
+++ b/crates/rattler_azure/src/endpoint_key.rs
@@ -1,0 +1,330 @@
+use crate::{AccountName, AzureChannelUrl, AzureHost, AzureUrlError};
+
+/// Only [`new`](Self::new) builds one, so a host that carries no usable account
+/// label — an IP literal, a single-label name, a first label Azure would refuse —
+/// has no host-style spelling at all.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct AccountHost {
+    host: AzureHost,
+    account: AccountName,
+}
+
+impl AccountHost {
+    pub fn new(host: AzureHost) -> Result<Self, AzureUrlError> {
+        let account = AccountName::new(
+            host.account_label()
+                .ok_or_else(|| AzureUrlError::InvalidHost(host.to_string()))?,
+        )?;
+        Ok(Self { host, account })
+    }
+
+    pub fn host(&self) -> &AzureHost {
+        &self.host
+    }
+
+    pub fn account(&self) -> &AccountName {
+        &self.account
+    }
+}
+
+impl std::fmt::Display for AccountHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.host)
+    }
+}
+
+/// Only [`new`](Self::new) builds one, so the segment has passed Azure's naming
+/// rules wherever it came from — a written config key or a channel URL's path.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct AccountPath {
+    host: AzureHost,
+    account: AccountName,
+}
+
+impl AccountPath {
+    pub fn new(host: AzureHost, segment: &str) -> Result<Self, AzureUrlError> {
+        Ok(Self {
+            host,
+            account: AccountName::new(segment)?,
+        })
+    }
+
+    pub fn host(&self) -> &AzureHost {
+        &self.host
+    }
+
+    pub fn account(&self) -> &AccountName {
+        &self.account
+    }
+}
+
+impl std::fmt::Display for AccountPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.host, self.account)
+    }
+}
+
+/// The key of an `azure-options` entry: a channel URL prefix that runs up to, but
+/// not including, the container.
+///
+/// Its shape is what says where the storage account is, so nothing else has to.
+/// `acct.blob.core.windows.net` reads the account off the host;
+/// `proxy.internal/accta` reads it from the first path segment, which is the only
+/// spelling that works for an IP literal or a single-label host, and the only one
+/// that tells two accounts behind one proxy apart. Under both, the container is
+/// the segment right after the key.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(try_from = "String", into = "String")
+)]
+pub enum AzureEndpointKey {
+    HostStyle(AccountHost),
+    PathStyle(AccountPath),
+}
+
+impl AzureEndpointKey {
+    pub fn parse(key: &str) -> Result<Self, AzureUrlError> {
+        let channel = AzureChannelUrl::parse(&format!("az://{key}"))?;
+        if channel.query().is_some() || channel.fragment().is_some() {
+            return Err(AzureUrlError::InvalidKey(key.to_string()));
+        }
+
+        let segments = channel
+            .path_segments()
+            .filter(|segment| !segment.is_empty())
+            .collect::<Vec<_>>();
+        match segments.as_slice() {
+            [] => Self::host_style(channel.host()),
+            [account] => Self::path_style(channel.host().clone(), account),
+            _ => Err(AzureUrlError::InvalidKey(key.to_string())),
+        }
+    }
+
+    pub fn host_style(host: &AzureHost) -> Result<Self, AzureUrlError> {
+        AccountHost::new(host.clone()).map(Self::HostStyle)
+    }
+
+    pub fn path_style(host: AzureHost, segment: &str) -> Result<Self, AzureUrlError> {
+        AccountPath::new(host, segment).map(Self::PathStyle)
+    }
+
+    pub fn host(&self) -> &AzureHost {
+        match self {
+            Self::HostStyle(host) => host.host(),
+            Self::PathStyle(path) => path.host(),
+        }
+    }
+
+    pub fn account(&self) -> &AccountName {
+        match self {
+            Self::HostStyle(host) => host.account(),
+            Self::PathStyle(path) => path.account(),
+        }
+    }
+
+    pub(crate) fn container_segment(&self) -> usize {
+        match self {
+            Self::HostStyle(_) => 0,
+            Self::PathStyle(_) => 1,
+        }
+    }
+
+    #[cfg(feature = "opendal")]
+    pub(crate) fn segments_before_root(&self) -> usize {
+        self.container_segment() + 1
+    }
+}
+
+impl std::fmt::Display for AzureEndpointKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HostStyle(host) => write!(f, "{host}"),
+            Self::PathStyle(path) => write!(f, "{path}"),
+        }
+    }
+}
+
+impl std::str::FromStr for AzureEndpointKey {
+    type Err = AzureUrlError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for AzureEndpointKey {
+    type Error = AzureUrlError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(&value)
+    }
+}
+
+impl From<AzureEndpointKey> for String {
+    fn from(key: AzureEndpointKey) -> Self {
+        key.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{hash_of, key};
+
+    #[test]
+    fn a_written_key_round_trips() {
+        for (written, canonical) in [
+            ("acct.blob.core.windows.net", "acct.blob.core.windows.net"),
+            (
+                "MyCompany.blob.core.windows.net",
+                "mycompany.blob.core.windows.net",
+            ),
+            ("acct.blob.core.windows.net.", "acct.blob.core.windows.net"),
+            (
+                "acct.blob.core.windows.net:443",
+                "acct.blob.core.windows.net:443",
+            ),
+            ("proxy.internal/accta", "proxy.internal/accta"),
+            ("Proxy.Internal./accta", "proxy.internal/accta"),
+            ("ünï.blob.example/accta", "xn--n-nga1b.blob.example/accta"),
+            (
+                "[0:0:0:0:0:0:0:1]:10000/devstoreaccount1",
+                "[::1]:10000/devstoreaccount1",
+            ),
+            (
+                "127.0.0.1:10000/devstoreaccount1",
+                "127.0.0.1:10000/devstoreaccount1",
+            ),
+        ] {
+            let parsed = key(written);
+            assert_eq!(parsed.to_string(), canonical, "{written}");
+            assert_eq!(key(canonical), parsed, "{written}");
+            assert_eq!(hash_of(&key(canonical)), hash_of(&parsed), "{written}");
+        }
+    }
+
+    #[test]
+    fn a_key_past_the_account_is_rejected() {
+        for written in [
+            "proxy.internal/accta/general",
+            "acct.blob.core.windows.net/general/noarch",
+        ] {
+            assert!(
+                matches!(
+                    AzureEndpointKey::parse(written),
+                    Err(AzureUrlError::InvalidKey(_))
+                ),
+                "{written} names past the account"
+            );
+        }
+    }
+
+    #[test]
+    fn a_key_inherits_the_channel_url_rejections() {
+        for written in [
+            "acct.blob.core.windows.net@evil.example",
+            "acct.blob.core.windows.net/../accta",
+            "acct.blob.example//accta",
+            "acct.blob.example/acc%zz",
+            "proxy.internal/accta?sv=token",
+            "proxy.internal/accta#frag",
+            "acct.blob.core.windows.net:",
+            "acct..blob.core.windows.net",
+        ] {
+            assert!(
+                AzureEndpointKey::parse(written).is_err(),
+                "expected a rejection for {written}"
+            );
+        }
+    }
+
+    /// A key that names no account could not say which account a grant is for, so
+    /// there is no such key to write.
+    #[test]
+    fn a_key_must_name_an_account() {
+        for written in [
+            "127.0.0.1:10000",
+            "[::1]:10000",
+            "localhost",
+            "localhost.",
+            "azurite:10000",
+            "--as-user.blob.core.windows.net",
+            "acct-1.blob.example",
+        ] {
+            assert!(
+                AzureEndpointKey::parse(written).is_err(),
+                "expected a rejection for {written}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_backslash_spelled_dot_segment_is_rejected() {
+        for input in [
+            r"az://acct.blob.core.windows.net/general\..\..\evil/x",
+            r"az://127.0.0.1:10000/devstoreaccount1/general\..\..\otheracct\othercontainer",
+            r"az://acct.blob.core.windows.net\general\.\noarch",
+        ] {
+            assert!(
+                matches!(
+                    AzureChannelUrl::parse(input),
+                    Err(AzureUrlError::DotSegmentInPath(_))
+                ),
+                "expected a rejection for {input}"
+            );
+        }
+
+        for written in [
+            r"proxy.internal/x\..\..\accta",
+            "proxy.internal/x/../../accta",
+        ] {
+            assert!(
+                AzureEndpointKey::parse(written).is_err(),
+                "expected a rejection for {written}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_account_a_key_names_is_held_to_azures_rules() {
+        for written in [
+            "127.0.0.1:10000/devstore;evil",
+            "127.0.0.1:10000/DevStoreAccount1",
+            "127.0.0.1:10000/dev-store",
+            "127.0.0.1:10000/ab",
+            "127.0.0.1:10000/-o",
+            "127.0.0.1:10000/--as-user",
+        ] {
+            assert!(
+                matches!(
+                    AzureEndpointKey::parse(written),
+                    Err(AzureUrlError::InvalidAccountName(_))
+                ),
+                "expected a rejection for {written}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_style_key_rejects_undottable_hosts() {
+        for host in [
+            "127.0.0.1:10000",
+            "azurite:10000",
+            "localhost",
+            "[::1]:10000",
+            // A trailing dot is the DNS root label, not a second label: this host
+            // must not sneak past the dotted-domain gate.
+            "localhost.",
+            "LocalHost",
+            "azurite:443",
+            "azurite:80",
+        ] {
+            let err = AzureEndpointKey::host_style(&AzureHost::parse(host).unwrap())
+                .expect_err("a host-style key must not accept an undottable host");
+            assert!(matches!(err, AzureUrlError::InvalidHost(_)), "{err}");
+            assert!(err.to_string().contains("/<account>"), "{err}");
+        }
+    }
+}

--- a/crates/rattler_azure/src/error.rs
+++ b/crates/rattler_azure/src/error.rs
@@ -1,0 +1,88 @@
+#[derive(Debug, thiserror::Error)]
+pub enum AzureUrlError {
+    #[error("no host in Azure blob URL")]
+    NoHost,
+
+    #[error(
+        "Azure blob URL must not contain userinfo (`user:pass@host`): the `user@host` form is a \
+         host-spoofing vector that can disguise the real target host, and userinfo is invalid in \
+         blob URLs"
+    )]
+    UserInfoNotAllowed,
+
+    #[error("`{authority}` is not a valid Azure host: {reason}; expected `host` or `host:port`")]
+    InvalidHostAuthority { authority: String, reason: String },
+
+    #[error(
+        "Azure blob URL host `{0}` is not a dotted domain of the form `<account>.blob.<suffix>`, \
+         so its first label cannot be a storage account; read the account from the first path \
+         segment instead — with an `azure-options` key spelled `{0}/<account>` when fetching or \
+         indexing, or `--path-style` when uploading"
+    )]
+    InvalidHost(String),
+
+    #[error(
+        "`{0}` is not an `azure-options` key: a key is a channel URL prefix up to the container, \
+         so it is spelled `<host>` or `<host>/<account>` and nothing more"
+    )]
+    InvalidKey(String),
+
+    #[error("no container in Azure blob URL")]
+    NoContainer,
+
+    #[error(
+        "`{0}` is not a valid Azure storage account name: account names are 3-24 characters of \
+         lowercase letters and digits only"
+    )]
+    InvalidAccountName(String),
+
+    #[error(
+        "`{0}` is not a valid Azure blob container name: container names are 3-63 characters of \
+         lowercase letters, digits and hyphens, must start and end with a letter or digit, and \
+         must not contain consecutive hyphens"
+    )]
+    InvalidContainerName(String),
+
+    #[error("`{value}` is not a valid URL")]
+    InvalidUrl {
+        value: String,
+        #[source]
+        source: url::ParseError,
+    },
+
+    #[error(
+        "Azure blob channel URL segment `{0}` is a relative path segment; a channel URL must name \
+         the container it addresses directly, so write the path without `.` or `..`"
+    )]
+    DotSegmentInPath(String),
+
+    #[error(
+        "Azure blob channel URL path `{path}` has an empty segment; a doubled `/` names nothing, \
+         so write the path with single separators"
+    )]
+    EmptyPathSegment { path: String },
+
+    #[error(
+        "Azure blob channel URL segment `{segment}` contains `{escape}`, which is not a valid \
+         percent-escape; write a literal `%` as `%25`"
+    )]
+    MalformedPercentEscape { segment: String, escape: String },
+
+    /// Blob names are UTF-8. Decoding lossily would substitute U+FFFD and silently
+    /// address a different blob than the URL names.
+    #[error(
+        "Azure blob channel URL segment `{segment}` percent-decodes to bytes that are not UTF-8, \
+         so it cannot name a blob"
+    )]
+    NonUtf8Path {
+        segment: String,
+        #[source]
+        source: std::str::Utf8Error,
+    },
+
+    #[error(
+        "Azure blob channel URL must use the `az://` scheme, e.g. \
+         `az://<account>.blob.core.windows.net/<container>/...`: got `{0}`"
+    )]
+    InvalidScheme(String),
+}

--- a/crates/rattler_azure/src/host.rs
+++ b/crates/rattler_azure/src/host.rs
@@ -1,0 +1,358 @@
+use url::Url;
+
+use crate::AzureUrlError;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(try_from = "String", into = "String")
+)]
+pub struct AzureHost {
+    host: url::Host,
+    port: Option<u16>,
+}
+
+impl AzureHost {
+    pub fn parse(authority: &str) -> Result<Self, AzureUrlError> {
+        if authority.contains('@') {
+            return Err(AzureUrlError::UserInfoNotAllowed);
+        }
+        if authority.contains(['/', '\\', '?', '#']) {
+            return Err(AzureUrlError::InvalidHostAuthority {
+                authority: authority.to_string(),
+                reason: "it carries a path, query or fragment".to_string(),
+            });
+        }
+
+        // Two parses, each for the one thing it is authoritative about, because no
+        // single scheme gives both. `https` is a special scheme, so it runs the URL
+        // Standard's host parser: lowercasing, IDNA, and IP literals as typed
+        // `Ipv4`/`Ipv6` hosts — but it also drops `:443`. `az` is not special, so
+        // it has no default port to drop, but its opaque-host parsing leaves the
+        // host unnormalized (`MyCompany.X` stays mixed case, `127.0.0.1` arrives as
+        // a `Domain`). Host from the first, port from the second.
+        let normalized = Self::parse_as(authority, "https")?;
+        let verbatim = Self::parse_as(authority, "az")?;
+
+        // `url` reads a bare trailing colon as "no port at all", so `host:` would
+        // otherwise be accepted as `host` — a silent downgrade to a different
+        // endpoint, so a dangling colon is an explicit error rather than being
+        // read as "no port". Port 0 it keeps, and `wire()` then hands out
+        // `https://host:0/…`, which no connection can be made to.
+        let port_reason = match (Self::written_port(authority), verbatim.port()) {
+            (Some(""), _) => Some("its port is empty"),
+            (_, Some(0)) => Some("port 0 cannot be connected to"),
+            _ => None,
+        };
+        if let Some(reason) = port_reason {
+            return Err(AzureUrlError::InvalidHostAuthority {
+                authority: authority.to_string(),
+                reason: reason.to_string(),
+            });
+        }
+
+        let host = normalized.host().ok_or(AzureUrlError::NoHost)?.to_owned();
+        Self::normalized(host, verbatim.port(), authority)
+    }
+
+    /// The text after the authority's last `:`, unless that text ends with `]` —
+    /// the closing bracket of an IPv6 literal that spells no port.
+    fn written_port(authority: &str) -> Option<&str> {
+        let (_, port) = authority.rsplit_once(':')?;
+        (!port.ends_with(']')).then_some(port)
+    }
+
+    fn parse_as(authority: &str, scheme: &str) -> Result<Url, AzureUrlError> {
+        Url::parse(&format!("{scheme}://{authority}")).map_err(|err| {
+            AzureUrlError::InvalidHostAuthority {
+                authority: authority.to_string(),
+                reason: err.to_string(),
+            }
+        })
+    }
+
+    fn normalized(
+        host: url::Host,
+        port: Option<u16>,
+        authority: &str,
+    ) -> Result<Self, AzureUrlError> {
+        const DNS_NAME_LIMIT: usize = 253;
+
+        let url::Host::Domain(domain) = &host else {
+            return Ok(Self { host, port });
+        };
+
+        // Re-run the host parser on the trimmed name so there is exactly one
+        // normalization path rather than a second, hand-rolled one.
+        let host = url::Host::parse(domain.strip_suffix('.').unwrap_or(domain)).map_err(|err| {
+            AzureUrlError::InvalidHostAuthority {
+                authority: authority.to_string(),
+                reason: err.to_string(),
+            }
+        })?;
+        if let url::Host::Domain(domain) = &host {
+            // Only one trailing dot is stripped, so `acct.example..` still has an
+            // empty label here — as does `acct..example`. Rejecting both is what
+            // lets `Display` round-trip, and what stops account derivation from
+            // handing out an empty account name.
+            if domain.split('.').any(str::is_empty) {
+                return Err(AzureUrlError::InvalidHostAuthority {
+                    authority: authority.to_string(),
+                    reason: "one of its labels is empty".to_string(),
+                });
+            }
+            // Measured after IDNA, since the punycode form is what is resolved.
+            if domain.len() > DNS_NAME_LIMIT {
+                return Err(AzureUrlError::InvalidHostAuthority {
+                    authority: authority.to_string(),
+                    reason: format!(
+                        "it is {} characters long, over the {DNS_NAME_LIMIT}-character limit DNS \
+                         puts on a name",
+                        domain.len()
+                    ),
+                });
+            }
+        }
+        Ok(Self { host, port })
+    }
+
+    pub fn host(&self) -> &url::Host {
+        &self.host
+    }
+
+    pub fn port(&self) -> Option<u16> {
+        self.port
+    }
+
+    /// [`parse`](Self::parse) has already rejected empty labels and a trailing
+    /// dot, so those two labels are non-empty.
+    pub(crate) fn account_label(&self) -> Option<&str> {
+        match &self.host {
+            url::Host::Domain(domain) => {
+                let mut labels = domain.split('.');
+                let first = labels.next()?;
+                labels.next().is_some().then_some(first)
+            }
+            url::Host::Ipv4(_) | url::Host::Ipv6(_) => None,
+        }
+    }
+
+    /// A `true` is the only evidence that a host is really Azure, which is what
+    /// gates the ambient credential chain. A proxy or private endpoint in front of
+    /// real Azure answers `false`, so a `false` proves nothing.
+    pub fn is_known_azure_blob_endpoint(&self) -> bool {
+        const SUFFIXES: &[&str] = &[
+            "blob.core.windows.net",
+            "blob.core.usgovcloudapi.net",
+            "blob.core.chinacloudapi.cn",
+        ];
+
+        let url::Host::Domain(domain) = &self.host else {
+            return false;
+        };
+        SUFFIXES.iter().any(|suffix| {
+            // The dot has to be part of the match, or `notblob.core.windows.net`
+            // would pass as `blob.core.windows.net`.
+            domain
+                .strip_suffix(suffix)
+                .is_some_and(|prefix| prefix.ends_with('.'))
+        })
+    }
+}
+
+impl std::fmt::Display for AzureHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `url::Host`'s own `Display` brackets an IPv6 literal, which is what an
+        // authority needs.
+        write!(f, "{}", self.host)?;
+        if let Some(port) = self.port {
+            write!(f, ":{port}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for AzureHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AzureHost({:?})", self.to_string())
+    }
+}
+
+impl std::str::FromStr for AzureHost {
+    type Err = AzureUrlError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for AzureHost {
+    type Error = AzureUrlError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(&value)
+    }
+}
+
+impl From<AzureHost> for String {
+    fn from(host: AzureHost) -> Self {
+        host.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::hash_of;
+
+    #[test]
+    fn userinfo_is_rejected() {
+        assert!(matches!(
+            crate::AzureChannelUrl::parse("az://acct.blob.core.windows.net@evil.example/general"),
+            Err(AzureUrlError::UserInfoNotAllowed)
+        ));
+        assert!(matches!(
+            AzureHost::parse("acct.blob.core.windows.net@evil.example"),
+            Err(AzureUrlError::UserInfoNotAllowed)
+        ));
+    }
+
+    #[test]
+    fn known_azure_endpoints_are_matched_on_a_label_boundary() {
+        for host in [
+            "acct.blob.core.windows.net",
+            "acct.blob.core.usgovcloudapi.net",
+            "acct.blob.core.chinacloudapi.cn",
+        ] {
+            assert!(
+                AzureHost::parse(host)
+                    .unwrap()
+                    .is_known_azure_blob_endpoint(),
+                "{host}"
+            );
+        }
+
+        for host in [
+            "notblob.core.windows.net",             // no label boundary
+            "blob.core.windows.net",                // the suffix alone carries no account
+            "acct.blob.core.windows.net.evil.test", // suffix in the middle
+            "127.0.0.1:10000",
+            "azurite",
+        ] {
+            assert!(
+                !AzureHost::parse(host)
+                    .unwrap()
+                    .is_known_azure_blob_endpoint(),
+                "{host}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_host_labels_are_rejected() {
+        for host in [
+            "acct..blob.core.windows.net",
+            "acct.blob.example..",
+            ".example",
+        ] {
+            assert!(
+                matches!(
+                    AzureHost::parse(host),
+                    Err(AzureUrlError::InvalidHostAuthority { .. })
+                ),
+                "expected a rejection for {host}"
+            );
+            assert!(
+                matches!(
+                    crate::AzureChannelUrl::parse(&format!("az://{host}/general/noarch")),
+                    Err(AzureUrlError::InvalidHostAuthority { .. })
+                ),
+                "expected a rejection for {host}"
+            );
+        }
+    }
+
+    #[test]
+    fn host_normalization_collapses_equivalent_spellings() {
+        for (written, canonical) in [
+            (
+                "MyCompany.blob.core.windows.net",
+                "mycompany.blob.core.windows.net",
+            ),
+            (
+                "mycompany.blob.core.windows.net:443",
+                "mycompany.blob.core.windows.net:443",
+            ),
+            ("ünï.blob.example", "xn--n-nga1b.blob.example"),
+            ("[0:0:0:0:0:0:0:1]:10000", "[::1]:10000"),
+            ("0x7f.1", "127.0.0.1"),
+            ("acct.blob.core.windows.net.", "acct.blob.core.windows.net"),
+        ] {
+            let host = AzureHost::parse(written)
+                .unwrap_or_else(|err| panic!("{written} should parse: {err}"));
+            assert_eq!(host.to_string(), canonical, "{written}");
+
+            let reparsed = AzureHost::parse(canonical).unwrap();
+            assert_eq!(reparsed, host, "{written}");
+            // Equal hosts must also hash equally: they key the options map.
+            assert_eq!(hash_of(&host), hash_of(&reparsed), "{written}");
+        }
+    }
+
+    #[test]
+    fn host_equality_is_not_scheme_relative() {
+        let with_port = AzureHost::parse("azurite.local:443").unwrap();
+        let without = AzureHost::parse("azurite.local").unwrap();
+        assert_ne!(with_port, without);
+        assert_ne!(with_port, AzureHost::parse("azurite.local:80").unwrap());
+        assert_eq!(with_port.to_string(), "azurite.local:443");
+    }
+
+    #[test]
+    fn a_dangling_colon_is_rejected_rather_than_read_as_no_port() {
+        for authority in ["acct.blob.core.windows.net:", "[::1]:"] {
+            match AzureHost::parse(authority) {
+                Err(AzureUrlError::InvalidHostAuthority { reason, .. }) => {
+                    assert_eq!(reason, "its port is empty", "{authority}");
+                }
+                other => panic!("expected InvalidHostAuthority for {authority}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn host_rejects_anything_that_is_not_a_bare_authority() {
+        // Labels of 60, so length is the only rule under test.
+        let label = "a".repeat(60);
+        let too_long = format!("{}.blob.example", [label.as_str(); 8].join("."));
+        for authority in [
+            "acct.blob.core.windows.net/general",
+            "acct.blob.core.windows.net?sv=token",
+            "acct.blob.core.windows.net#frag",
+            "https://acct.blob.core.windows.net",
+            "",
+            "acct.blob.core.windows.net:notaport",
+            "acct.blob.core.windows.net:",
+            "acct.blob.core.windows.net:0",
+            "[::1]:",
+            "[::1]:0",
+            &too_long,
+        ] {
+            assert!(
+                AzureHost::parse(authority).is_err(),
+                "expected a rejection for {authority:?}"
+            );
+        }
+
+        // A name right at the limit still parses, so the check bounds the length
+        // rather than the number of labels.
+        let at_limit = format!(
+            "{}.{}.blob.example",
+            [label.as_str(); 3].join("."),
+            "a".repeat(57)
+        );
+        assert_eq!(at_limit.len(), 253);
+        assert!(AzureHost::parse(&at_limit).is_ok());
+    }
+}

--- a/crates/rattler_azure/src/lib.rs
+++ b/crates/rattler_azure/src/lib.rs
@@ -1,0 +1,43 @@
+//! Parsing Azure Blob channel URLs and minting short-lived credentials for them.
+//!
+//! # Endpoint model
+//!
+//! The default grant is [`Auth::Anonymous`], so naming an endpoint in a URL by
+//! itself sends nothing to it. Signing and sending live in `rattler_networking`,
+//! not here.
+//!
+//! Userinfo (`user:pass@host`) is rejected wherever a host is parsed:
+//! `az://real.host@evil.example/…` reads as the real host while addressing the
+//! attacker's and is an invalid blob endpoint.
+
+#[cfg(feature = "opendal")]
+mod azblob;
+mod channel_url;
+#[cfg(feature = "clap")]
+pub mod clap;
+mod credentials;
+mod endpoint_key;
+mod error;
+mod host;
+mod locate;
+mod names;
+pub mod options;
+#[cfg(feature = "clap")]
+mod sas;
+#[cfg(test)]
+mod test_support;
+
+#[cfg(feature = "opendal")]
+pub use azblob::azblob_config;
+pub use channel_url::AzureChannelUrl;
+pub use credentials::AzureCredentials;
+pub use endpoint_key::{AccountHost, AccountPath, AzureEndpointKey};
+pub use error::AzureUrlError;
+pub use host::AzureHost;
+pub use locate::{AzureAddressing, AzureLocation, locate, locate_as};
+pub use names::{AccountName, ContainerName};
+pub use options::{Auth, AzureEndpointOptions, AzureFetchOptions, AzureScheme};
+#[cfg(feature = "clap")]
+pub use sas::{AzureCliSasError, mint_user_delegation_sas};
+
+pub use secrecy::{ExposeSecret, SecretString};

--- a/crates/rattler_azure/src/locate.rs
+++ b/crates/rattler_azure/src/locate.rs
@@ -1,0 +1,317 @@
+use crate::{AzureChannelUrl, AzureEndpointKey, AzureUrlError, ContainerName};
+
+/// A channel URL bundled with the endpoint key and container derived from it, so
+/// the three can never be mixed and matched across different endpoints.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AzureLocation {
+    channel: AzureChannelUrl,
+    key: Option<AzureEndpointKey>,
+    container: Option<ContainerName>,
+}
+
+impl AzureLocation {
+    pub fn channel(&self) -> &AzureChannelUrl {
+        &self.channel
+    }
+
+    /// The key the URL matched, or the host-style key it falls back to.
+    ///
+    /// `None` when neither exists: an unconfigured IP literal names no account, so
+    /// there is nothing for a grant to hang off.
+    pub fn key(&self) -> Option<&AzureEndpointKey> {
+        self.key.as_ref()
+    }
+
+    pub fn container(&self) -> Option<&ContainerName> {
+        self.container.as_ref()
+    }
+
+    /// The key and container a request has to name, or the reason the URL names
+    /// neither.
+    ///
+    /// The fetch path can send anonymously without either; anything that writes,
+    /// signs or builds an endpoint needs both.
+    pub fn addressed(&self) -> Result<(&AzureEndpointKey, &ContainerName), AzureUrlError> {
+        let key = self
+            .key
+            .as_ref()
+            .ok_or_else(|| AzureUrlError::InvalidHost(self.channel.host().to_string()))?;
+        Ok((
+            key,
+            self.container.as_ref().ok_or(AzureUrlError::NoContainer)?,
+        ))
+    }
+}
+
+/// Match a channel URL against the configured entry keys.
+///
+/// Both candidates are tried, longest first, so `proxy.internal/accta` wins over
+/// `proxy.internal` where both are configured. A URL matching neither is read
+/// host-style, the shape of the default entry.
+pub fn locate(
+    channel: &AzureChannelUrl,
+    configured: impl Fn(&AzureEndpointKey) -> bool,
+) -> Result<AzureLocation, AzureUrlError> {
+    let host_style = AzureEndpointKey::host_style(channel.host()).ok();
+    let path_style = segment(channel, 0)
+        .and_then(|segment| AzureEndpointKey::path_style(channel.host().clone(), segment).ok());
+
+    let key = [path_style, host_style.clone()]
+        .into_iter()
+        .flatten()
+        .find(|key| configured(key))
+        .or(host_style);
+
+    located(channel, key)
+}
+
+/// Locate a channel under the addressing the caller states outright.
+///
+/// For a caller with no `azure-options` table to match against, where the account's
+/// whereabouts is the one thing the URL cannot say: `az://proxy.internal/accta/…`
+/// reads as account `proxy` or account `accta` with equal justification.
+pub fn locate_as(
+    channel: &AzureChannelUrl,
+    addressing: AzureAddressing,
+) -> Result<AzureLocation, AzureUrlError> {
+    let key = match addressing {
+        AzureAddressing::HostStyle => AzureEndpointKey::host_style(channel.host())?,
+        AzureAddressing::PathStyle => AzureEndpointKey::path_style(
+            channel.host().clone(),
+            segment(channel, 0).unwrap_or_default(),
+        )?,
+    };
+    located(channel, Some(key))
+}
+
+fn located(
+    channel: &AzureChannelUrl,
+    key: Option<AzureEndpointKey>,
+) -> Result<AzureLocation, AzureUrlError> {
+    let container = container_after(channel, key.as_ref())?;
+    Ok(AzureLocation {
+        channel: channel.clone(),
+        key,
+        container,
+    })
+}
+
+/// Deliberately just the missing bit, not the account itself: the account is
+/// already at path segment 0 of the URL, and a caller naming it separately could
+/// contradict the URL and sign for a different account than the one addressed.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AzureAddressing {
+    #[default]
+    HostStyle,
+
+    PathStyle,
+}
+
+impl From<bool> for AzureAddressing {
+    fn from(path_style: bool) -> Self {
+        if path_style {
+            Self::PathStyle
+        } else {
+            Self::HostStyle
+        }
+    }
+}
+
+/// `Ok(None)` means there is nothing to attribute a grant to: the URL has no
+/// container segment, or no key, in which case no segment is the container. `Err`
+/// means the segment is there but is not a name Azure allows, which is a malformed
+/// endpoint rather than an ungranted one — and only reportable when a key matched,
+/// since that is the only case where a grant could otherwise be missed.
+fn container_after(
+    channel: &AzureChannelUrl,
+    key: Option<&AzureEndpointKey>,
+) -> Result<Option<ContainerName>, AzureUrlError> {
+    let Some(key) = key else {
+        return Ok(None);
+    };
+    segment(channel, key.container_segment())
+        .map(ContainerName::new)
+        .transpose()
+}
+
+fn segment(channel: &AzureChannelUrl, index: usize) -> Option<&str> {
+    // The `is_empty` filter is only sound because `AzureChannelUrl::parse` rejects
+    // an empty segment anywhere but the end: the sole one that can reach here is a
+    // trailing slash, where "absent" is the right reading. Without that guarantee
+    // `az://host//general` would read as having no container and silently fetch a
+    // granted one anonymously.
+    channel
+        .path_segments()
+        .nth(index)
+        .filter(|segment| !segment.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{channel, container, key, located};
+
+    #[test]
+    fn the_container_follows_the_matched_key() {
+        for (url, configured) in [
+            ("az://acct.blob.core.windows.net/general/noarch", &[][..]),
+            (
+                "az://acct.blob.core.windows.net/general/noarch",
+                &["acct.blob.core.windows.net"],
+            ),
+            (
+                "az://proxy.internal/accta/general/noarch",
+                &["proxy.internal/accta"],
+            ),
+            ("az://proxy.internal/accta/general", &["proxy.internal"]),
+            (
+                "az://127.0.0.1:10000/devstoreaccount1/general",
+                &["127.0.0.1:10000/devstoreaccount1"],
+            ),
+        ] {
+            let located = located(url, configured);
+            let Some(container) = located.container() else {
+                panic!("{url} names a container");
+            };
+            let prefix = match located.key() {
+                Some(AzureEndpointKey::PathStyle(path)) => format!("/{}", path.account()),
+                Some(AzureEndpointKey::HostStyle(_)) | None => String::new(),
+            };
+            assert!(
+                channel(url)
+                    .canonical()
+                    .path()
+                    .starts_with(&format!("{prefix}/{container}")),
+                "{url}: `{container}` does not follow `{prefix}`"
+            );
+        }
+    }
+
+    #[test]
+    fn the_longest_configured_key_wins() {
+        let url = "az://proxy.internal/accta/general/noarch";
+
+        let both = located(url, &["proxy.internal", "proxy.internal/accta"]);
+        assert_eq!(both.key(), Some(&key("proxy.internal/accta")));
+        assert_eq!(both.container(), Some(&container("general")));
+
+        let host_only = located(url, &["proxy.internal"]);
+        assert_eq!(host_only.key(), Some(&key("proxy.internal")));
+        assert_eq!(host_only.container(), Some(&container("accta")));
+    }
+
+    /// An unconfigured IP literal is read host-style, which names no account — so
+    /// it has no key, and nothing a grant could hang off.
+    #[test]
+    fn an_unmatched_url_falls_back_to_host_style() {
+        let anonymous = located("az://127.0.0.1:10000/devstoreaccount1/general", &[]);
+        assert_eq!(anonymous.key(), None);
+        assert_eq!(anonymous.container(), None);
+
+        let azure = located("az://acct.blob.core.windows.net/general/noarch", &[]);
+        assert_eq!(azure.key(), Some(&key("acct.blob.core.windows.net")));
+        assert_eq!(azure.container(), Some(&container("general")));
+    }
+
+    #[test]
+    fn a_url_without_a_container_names_none() {
+        for (url, configured) in [
+            ("az://acct.blob.core.windows.net", &[][..]),
+            ("az://acct.blob.core.windows.net/", &[]),
+            (
+                "az://127.0.0.1:10000/devstoreaccount1",
+                &["127.0.0.1:10000/devstoreaccount1"],
+            ),
+            ("az://127.0.0.1:10000/", &[]),
+        ] {
+            assert_eq!(located(url, configured).container(), None, "{url}");
+        }
+    }
+
+    #[test]
+    fn a_url_with_an_unusable_container_is_an_error() {
+        for url in [
+            "az://acct.blob.core.windows.net/General/noarch",
+            "az://acct.blob.core.windows.net/ab/noarch",
+            "az://acct.blob.core.windows.net/a--b/noarch",
+            "az://acct.blob.core.windows.net/general;evil/noarch",
+            "az://acct.blob.core.windows.net/-o/noarch",
+        ] {
+            let err = locate(&channel(url), |_| false)
+                .expect_err("an illegal container name must be reported");
+            assert!(
+                matches!(err, AzureUrlError::InvalidContainerName(_)),
+                "{url}: {err}"
+            );
+        }
+    }
+
+    /// Without a key nothing is granted, so a segment Azure would refuse as a
+    /// container is not this parse's business: refusing it turns an anonymous fetch
+    /// a user had working into a hard error.
+    #[test]
+    fn an_unkeyed_url_reports_no_container_rather_than_a_bad_one() {
+        for url in [
+            "az://127.0.0.1:10000/Conda_Channel/noarch/repodata.json",
+            "az://azurite/Conda_Channel/noarch/repodata.json",
+            "az://mirror/ab/noarch/repodata.json",
+            "az://localhost:8080/My_Repo/noarch/repodata.json",
+        ] {
+            let located = located(url, &[]);
+            assert_eq!(located.key(), None, "{url}");
+            assert_eq!(located.container(), None, "{url}");
+        }
+    }
+
+    #[test]
+    fn a_path_style_key_takes_the_account_off_any_host() {
+        for host in [
+            "127.0.0.1:10000",
+            "[::1]:10000",
+            "azurite:10000",
+            "localhost:10000",
+            "azurite",
+            "localhost",
+        ] {
+            let key = key(&format!("{host}/devstoreaccount1"));
+            assert_eq!(key.account().as_str(), "devstoreaccount1", "{host}");
+
+            let located = locate_as(
+                &channel(&format!("az://{host}/devstoreaccount1/general/noarch")),
+                AzureAddressing::PathStyle,
+            )
+            .unwrap_or_else(|err| panic!("{host} should locate path-style: {err}"));
+            assert_eq!(located.addressed().unwrap(), (&key, &container("general")));
+        }
+    }
+
+    #[test]
+    fn a_url_short_of_the_container_has_none_to_address() {
+        for (url, addressing) in [
+            (
+                "az://127.0.0.1:10000/devstoreaccount1",
+                AzureAddressing::PathStyle,
+            ),
+            (
+                "az://acct.blob.core.windows.net",
+                AzureAddressing::HostStyle,
+            ),
+        ] {
+            let located =
+                locate_as(&channel(url), addressing).unwrap_or_else(|err| panic!("{err}"));
+            assert_eq!(located.container(), None, "{url}");
+            assert!(
+                matches!(located.addressed(), Err(AzureUrlError::NoContainer)),
+                "{url}"
+            );
+        }
+
+        assert!(matches!(
+            locate_as(
+                &channel("az://127.0.0.1:10000/"),
+                AzureAddressing::PathStyle
+            ),
+            Err(AzureUrlError::InvalidAccountName(_))
+        ));
+    }
+}

--- a/crates/rattler_azure/src/names.rs
+++ b/crates/rattler_azure/src/names.rs
@@ -1,0 +1,106 @@
+use crate::AzureUrlError;
+
+/// The charset admits no `-`, so an account name cannot be option-shaped
+/// (`--as-user`, `-o`) in the `az` argv the SAS mint builds, which is why the mint
+/// takes this type rather than a `&str`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AccountName(String);
+
+impl AccountName {
+    pub fn new(name: &str) -> Result<Self, AzureUrlError> {
+        let valid = (3..=24).contains(&name.len())
+            && name
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+
+        if valid {
+            Ok(Self(name.to_string()))
+        } else {
+            Err(AzureUrlError::InvalidAccountName(name.to_string()))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for AccountName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Exists for the same reason as [`AccountName`].
+///
+/// It is also the key of an `auth` table in `azure-options`, hence the hash and
+/// string serde bridge. Azure's rules make a container name lowercase by
+/// construction, so unlike a host there is only one spelling of one container.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(try_from = "String", into = "String")
+)]
+pub struct ContainerName(String);
+
+impl ContainerName {
+    pub fn new(name: &str) -> Result<Self, AzureUrlError> {
+        let valid = (3..=63).contains(&name.len())
+            && name
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            && !name.starts_with('-')
+            && !name.ends_with('-')
+            && !name.contains("--");
+
+        if valid {
+            Ok(Self(name.to_string()))
+        } else {
+            Err(AzureUrlError::InvalidContainerName(name.to_string()))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ContainerName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::str::FromStr for ContainerName {
+    type Err = AzureUrlError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for ContainerName {
+    type Error = AzureUrlError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(&value)
+    }
+}
+
+impl From<ContainerName> for String {
+    fn from(container: ContainerName) -> Self {
+        container.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_components_are_rejected() {
+        assert!(AccountName::new("").is_err());
+        assert!(ContainerName::new("").is_err());
+    }
+}

--- a/crates/rattler_azure/src/options.rs
+++ b/crates/rattler_azure/src/options.rs
@@ -1,0 +1,263 @@
+//! Custom endpoints and the Azurite emulator can be granted, but the ambient
+//! credential chain is gated on [`crate::AzureHost::is_known_azure_blob_endpoint`],
+//! so a grant on any other host resolves only `AZURE_STORAGE_*`.
+
+use crate::ContainerName;
+
+/// Whether credentials may attach to requests for a container.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(from = "bool", into = "bool")
+)]
+pub enum Auth {
+    /// Send requests unsigned. No credential is resolved, so nothing ambient can
+    /// leak to this host and nothing blocks on the managed-identity/IMDS probe.
+    #[default]
+    Anonymous,
+
+    /// Resolve a credential and sign with it. The full ambient chain is only
+    /// reached for a known Azure blob endpoint over TLS; anywhere else the signer
+    /// reads `AZURE_STORAGE_*` and nothing else. Since this is an explicit grant,
+    /// an unusable credential is a hard error rather than a silent downgrade to
+    /// anonymous.
+    DefaultChain,
+}
+
+impl From<bool> for Auth {
+    fn from(value: bool) -> Self {
+        if value {
+            Auth::DefaultChain
+        } else {
+            Auth::Anonymous
+        }
+    }
+}
+
+impl From<Auth> for bool {
+    fn from(value: Auth) -> Self {
+        matches!(value, Auth::DefaultChain)
+    }
+}
+
+impl Auth {
+    pub fn is_granted(self) -> bool {
+        matches!(self, Auth::DefaultChain)
+    }
+}
+
+/// The wire scheme an `az://` channel URL is rewritten to when a request is sent.
+///
+/// Prefixed rather than spelled bare `Scheme`, because `opendal::Scheme` names a
+/// storage service and is one import away.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(rename_all = "lowercase")
+)]
+pub enum AzureScheme {
+    #[default]
+    Https,
+
+    Http,
+}
+
+impl AzureScheme {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AzureScheme::Https => "https",
+            AzureScheme::Http => "http",
+        }
+    }
+}
+
+impl std::fmt::Display for AzureScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// What the fetch middleware needs to send one request.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AzureFetchOptions {
+    pub auth: Auth,
+
+    pub scheme: AzureScheme,
+}
+
+/// This is the serde surface. Each consumer takes the narrower view it can act
+/// on, via [`Self::scheme`] or [`Self::fetch`], and the fields are private so
+/// that view is the only way in. The default value is the no-entry behaviour, so
+/// callers can look an absent key up and fall back to `default()`.
+///
+/// There is no entry-level `auth` field at all. It is absent from the
+/// type rather than defaulted to false, so a grant always names a container — a
+/// container *under the key's reading of the URL*. A key whose shape does not
+/// match the endpoint reads the account segment as the container: on a host that
+/// really fronts its accounts path-style, a host-style key's `accta = true` grants
+/// every URL whose first segment is `accta`, which is the whole account.
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    // `deny_unknown_fields`, because a silently-missed grant is the worst failure
+    // this table has: Azure answers an anonymous read of a private container with
+    // 404, not 403, so a misspelled `[Auth]` surfaces as "channel not found" with
+    // nothing pointing at the typo. Container names are already held to Azure's
+    // rules for the same reason — a key that can never match is a config error.
+    serde(rename_all = "kebab-case", default, deny_unknown_fields)
+)]
+pub struct AzureEndpointOptions {
+    scheme: AzureScheme,
+
+    /// An explicit `false` is legal and redundant with omission, so a
+    /// higher-precedence config file can revoke rather than only add.
+    ///
+    /// Declared last, because the TOML serializer must emit an entry's scalars
+    /// before its tables.
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "indexmap::IndexMap::is_empty")
+    )]
+    auth: indexmap::IndexMap<ContainerName, Auth>,
+}
+
+impl AzureEndpointOptions {
+    pub fn new(auth: impl IntoIterator<Item = (ContainerName, Auth)>, scheme: AzureScheme) -> Self {
+        Self {
+            scheme,
+            auth: auth.into_iter().collect(),
+        }
+    }
+
+    pub fn scheme(&self) -> AzureScheme {
+        self.scheme
+    }
+
+    /// `container` is an `Option` because a URL need not name one. That case is
+    /// answered here rather than at the call site, and can only mean anonymous.
+    pub fn fetch(&self, container: Option<&ContainerName>) -> AzureFetchOptions {
+        AzureFetchOptions {
+            auth: container
+                .and_then(|container| self.auth.get(container))
+                .copied()
+                .unwrap_or_default(),
+            scheme: self.scheme,
+        }
+    }
+
+    /// Includes the explicit `false`s: a caller validating or listing the table
+    /// needs what the file says, not what it effectively means.
+    pub fn grants(&self) -> impl Iterator<Item = (&ContainerName, Auth)> {
+        self.auth.iter().map(|(container, auth)| (container, *auth))
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+
+    fn container(name: &str) -> ContainerName {
+        ContainerName::new(name).expect("test container name")
+    }
+
+    #[test]
+    fn toml_bools_map_to_enums() {
+        let opts: AzureEndpointOptions = toml::from_str(
+            r#"
+            scheme = "http"
+
+            [auth]
+            releases = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            opts,
+            AzureEndpointOptions::new(
+                [(container("releases"), Auth::DefaultChain)],
+                AzureScheme::Http,
+            )
+        );
+
+        let empty: AzureEndpointOptions = toml::from_str("").unwrap();
+        assert_eq!(empty, AzureEndpointOptions::default());
+        assert_eq!(
+            empty.fetch(Some(&container("releases"))),
+            AzureFetchOptions::default()
+        );
+        assert!(!empty.fetch(Some(&container("releases"))).auth.is_granted());
+        assert_eq!(empty.scheme(), AzureScheme::default());
+    }
+
+    #[test]
+    fn a_grant_applies_to_one_container_only() {
+        let opts: AzureEndpointOptions = toml::from_str(
+            r#"
+            [auth]
+            releases = true
+            public = false
+            "#,
+        )
+        .unwrap();
+
+        assert!(opts.fetch(Some(&container("releases"))).auth.is_granted());
+        assert!(!opts.fetch(Some(&container("public"))).auth.is_granted());
+        assert!(!opts.fetch(Some(&container("staging"))).auth.is_granted());
+
+        assert!(!opts.fetch(None).auth.is_granted());
+
+        // `grants` reports what the file says, explicit `false` included — in the
+        // order the document's table iterated (`toml::Table` is a `BTreeMap`, so
+        // that is byte order, not write order).
+        assert_eq!(
+            opts.grants().collect::<Vec<_>>(),
+            vec![
+                (&container("public"), Auth::Anonymous),
+                (&container("releases"), Auth::DefaultChain),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_unusable_container_key_is_rejected() {
+        let err = toml::from_str::<AzureEndpointOptions>("[auth]\nReleases = true\n")
+            .expect_err("uppercase is not a legal container name");
+        assert!(err.to_string().contains("Releases"), "{err}");
+    }
+
+    #[test]
+    fn an_unknown_field_is_rejected() {
+        for document in [
+            "[Auth]\nreleases = true\n",
+            "[authz]\nreleases = true\n",
+            "path-style = true\n",
+        ] {
+            assert!(
+                toml::from_str::<AzureEndpointOptions>(document).is_err(),
+                "silently ignored: {document}"
+            );
+        }
+    }
+
+    #[test]
+    fn enums_serialize_back_to_bools() {
+        let toml = toml::to_string(&AzureEndpointOptions::new(
+            [
+                (container("releases"), Auth::DefaultChain),
+                (container("public"), Auth::Anonymous),
+            ],
+            AzureScheme::Http,
+        ))
+        .unwrap();
+        assert!(toml.contains("releases = true"), "{toml}");
+        assert!(toml.contains("public = false"), "{toml}");
+        assert!(toml.contains(r#"scheme = "http""#), "{toml}");
+        assert!(!toml.contains("DefaultChain"), "{toml}");
+
+        let anonymous = toml::to_string(&AzureEndpointOptions::default()).unwrap();
+        assert!(!anonymous.contains("auth"), "{anonymous}");
+    }
+}

--- a/crates/rattler_azure/src/sas.rs
+++ b/crates/rattler_azure/src/sas.rs
@@ -1,0 +1,155 @@
+use secrecy::SecretString;
+
+use crate::{AccountName, AzureScheme, ContainerName};
+
+#[derive(Debug, thiserror::Error)]
+pub enum AzureCliSasError {
+    #[error("failed to compute the SAS expiry timestamp: {0}")]
+    Expiry(String),
+
+    #[error("could not resolve the Azure CLI (`az`) on PATH; install it and run `az login`")]
+    AzResolve(#[source] which::Error),
+
+    #[error("failed to run the Azure CLI (`az`)")]
+    Spawn(#[source] std::io::Error),
+
+    #[error("the Azure CLI failed to generate a user-delegation SAS (is `az login` current?): {0}")]
+    CommandFailed(String),
+
+    #[error("the Azure CLI returned an empty SAS token")]
+    EmptyOutput,
+}
+
+/// opendal's azblob backend accepts a shared account key or a SAS token, not an
+/// AAD bearer token, so an `az login` session has to be converted into a SAS:
+///
+/// ```text
+/// az storage container generate-sas --account-name <account> --name <container>
+///     --permissions <permissions> --expiry <expiry> --auth-mode login --as-user
+///     [--https-only] -o tsv
+/// ```
+///
+/// `permissions` is the Azure SAS permission string (e.g. `"cw"`). The returned
+/// token has no leading `?`. Requires `az` on `PATH` and a prior `az login`.
+/// `--https-only` is passed only when `scheme` is https, since it would otherwise
+/// make the SAS unusable against the host.
+///
+/// # Container-scope limitation
+///
+/// The minted SAS is container-scoped, not prefix-scoped, so a SAS for one channel
+/// also grants rights over sibling channels in the same container. Prefix-scoping
+/// would need a stored access policy, which this path does not create.
+pub async fn mint_user_delegation_sas(
+    account: &AccountName,
+    container: &ContainerName,
+    permissions: &str,
+    valid_for: std::time::Duration,
+    scheme: AzureScheme,
+) -> Result<SecretString, AzureCliSasError> {
+    let signed = jiff::SignedDuration::try_from(valid_for)
+        .map_err(|err| AzureCliSasError::Expiry(err.to_string()))?;
+    let expiry = jiff::Timestamp::now()
+        .checked_add(signed)
+        .map_err(|err| AzureCliSasError::Expiry(err.to_string()))?;
+    // `az` expects an ISO-8601 UTC timestamp; keep second precision so the window
+    // is not floored down to the enclosing whole minute.
+    let expiry = expiry.strftime("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+    let mut command = az_command()?;
+    let output = command
+        .args(generate_sas_args(
+            account,
+            container,
+            permissions,
+            &expiry,
+            scheme,
+        ))
+        .output()
+        .await
+        .map_err(AzureCliSasError::Spawn)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(AzureCliSasError::CommandFailed(stderr));
+    }
+
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if token.is_empty() {
+        return Err(AzureCliSasError::EmptyOutput);
+    }
+    Ok(token.into())
+}
+
+fn generate_sas_args<'a>(
+    account: &'a AccountName,
+    container: &'a ContainerName,
+    permissions: &'a str,
+    expiry: &'a str,
+    scheme: AzureScheme,
+) -> Vec<&'a str> {
+    let mut args = vec![
+        "storage",
+        "container",
+        "generate-sas",
+        "--account-name",
+        account.as_str(),
+        "--name",
+        container.as_str(),
+        "--permissions",
+        permissions,
+        "--expiry",
+        expiry,
+        "--auth-mode",
+        "login",
+        "--as-user",
+    ];
+    if let AzureScheme::Https = scheme {
+        args.push("--https-only");
+    }
+    args.extend(["-o", "tsv"]);
+    args
+}
+
+/// `which` resolves `az` up front, which matters on Windows: the CLI is an
+/// `az.cmd` batch shim and the process spawner does not honor `PATHEXT`. The
+/// resolved path is invoked directly rather than through `cmd /C`, which would be
+/// an argument-injection vector.
+fn az_command() -> Result<tokio::process::Command, AzureCliSasError> {
+    let path = which::which("az").map_err(AzureCliSasError::AzResolve)?;
+    Ok(tokio::process::Command::new(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{container, key};
+
+    #[test]
+    fn https_only_follows_the_configured_scheme() {
+        let key = key("acct.blob.core.windows.net");
+        let container = container("general");
+        let args = |scheme| {
+            generate_sas_args(
+                key.account(),
+                &container,
+                "cw",
+                "2030-01-01T00:00:00Z",
+                scheme,
+            )
+        };
+
+        assert!(args(AzureScheme::Https).contains(&"--https-only"));
+        assert!(!args(AzureScheme::Http).contains(&"--https-only"));
+
+        for scheme in [AzureScheme::Https, AzureScheme::Http] {
+            let args = args(scheme);
+            assert!(args.windows(2).any(|pair| pair == ["--permissions", "cw"]));
+            assert!(
+                args.windows(2)
+                    .any(|pair| pair == ["--expiry", "2030-01-01T00:00:00Z"])
+            );
+            assert!(args.contains(&"--as-user"));
+            assert!(args.windows(2).any(|pair| pair == ["--auth-mode", "login"]));
+        }
+    }
+}

--- a/crates/rattler_azure/src/test_support.rs
+++ b/crates/rattler_azure/src/test_support.rs
@@ -1,0 +1,35 @@
+//! Shared helpers for unit tests across this crate's modules.
+
+use crate::{AzureChannelUrl, AzureEndpointKey, AzureLocation, ContainerName, locate};
+
+pub(crate) fn channel(url: &str) -> AzureChannelUrl {
+    AzureChannelUrl::parse(url).unwrap_or_else(|err| panic!("{url} should parse: {err}"))
+}
+
+pub(crate) fn key(written: &str) -> AzureEndpointKey {
+    AzureEndpointKey::parse(written)
+        .unwrap_or_else(|err| panic!("{written} should parse as a key: {err}"))
+}
+
+pub(crate) fn located(url: &str, configured: &[&str]) -> AzureLocation {
+    let configured = configured.iter().copied().map(key).collect::<Vec<_>>();
+    locate(&channel(url), |candidate| configured.contains(candidate))
+        .unwrap_or_else(|err| panic!("{url} should locate: {err}"))
+}
+
+pub(crate) fn container(name: &str) -> ContainerName {
+    ContainerName::new(name).expect("test container name")
+}
+
+#[cfg(feature = "opendal")]
+pub(crate) fn path_style(url: &str) -> AzureLocation {
+    crate::locate_as(&channel(url), crate::AzureAddressing::PathStyle)
+        .unwrap_or_else(|err| panic!("{url} should locate path-style: {err}"))
+}
+
+pub(crate) fn hash_of(value: &impl std::hash::Hash) -> u64 {
+    use std::hash::Hasher;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude = ["**/snapshots/**", "test-data/**"]
 name = "rattler_config"
-version = "0.7.3"
+version = "0.8.0"
 edition.workspace = true
 authors = []
 description = "A crate to configure rattler and derived tools."
@@ -23,6 +23,9 @@ thiserror = { workspace = true }
 dirs = { workspace = true }
 fs-err = { workspace = true }
 indexmap = { workspace = true }
+rattler_azure = { workspace = true, default-features = false, features = [
+  "serde",
+] }
 rattler_conda_types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_ignored = { workspace = true }

--- a/crates/rattler_config/src/config.rs
+++ b/crates/rattler_config/src/config.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
 use url::Url;
 
+use crate::config::azure::AzureOptionsMap;
 use crate::config::s3::S3OptionsMap;
 use crate::config::{
     build::BuildConfig, concurrency::ConcurrencyConfig, index::IndexConfig, proxy::ProxyConfig,
@@ -27,6 +28,7 @@ use crate::config::{
 };
 use crate::locations::{ConfigLayer, ConfigLocation};
 
+pub mod azure;
 pub mod build;
 pub mod channel_config;
 pub mod concurrency;
@@ -195,6 +197,10 @@ pub struct CommonConfig {
     #[serde(skip_serializing_if = "S3OptionsMap::is_default")]
     pub s3_options: S3OptionsMap,
 
+    #[serde(default)]
+    #[serde(skip_serializing_if = "AzureOptionsMap::is_default")]
+    pub azure_options: AzureOptionsMap,
+
     /// Per-channel configuration for `rattler-index`.
     #[serde(default, skip_serializing_if = "IndexConfig::is_empty")]
     pub index_config: IndexConfig,
@@ -252,6 +258,7 @@ impl Default for CommonConfig {
             concurrency: ConcurrencyConfig::default(),
             proxy_config: ProxyConfig::default(),
             s3_options: S3OptionsMap::default(),
+            azure_options: AzureOptionsMap::default(),
             index_config: IndexConfig::default(),
             run_post_link_scripts: None,
             allow_symbolic_links: None,
@@ -306,6 +313,7 @@ impl Config for CommonConfig {
             concurrency: self.concurrency.merge_config(&other.concurrency)?,
             proxy_config: self.proxy_config.merge_config(&other.proxy_config)?,
             s3_options: self.s3_options.merge_config(&other.s3_options)?,
+            azure_options: self.azure_options.merge_config(&other.azure_options)?,
             index_config: self.index_config.merge_config(&other.index_config)?,
             run_post_link_scripts: other
                 .run_post_link_scripts
@@ -323,6 +331,7 @@ impl Config for CommonConfig {
         self.concurrency.validate()?;
         self.proxy_config.validate()?;
         self.s3_options.validate()?;
+        self.azure_options.validate()?;
         self.index_config.validate()?;
         Ok(())
     }
@@ -339,6 +348,7 @@ impl Config for CommonConfig {
             "allow-hard-links".to_string(),
             "allow-ref-links".to_string(),
             "s3-options".to_string(),
+            "azure-options".to_string(),
             "index-config".to_string(),
         ];
         keys.extend(prefixed_keys("build", self.build.keys()));
@@ -349,6 +359,7 @@ impl Config for CommonConfig {
         keys.extend(prefixed_keys("concurrency", self.concurrency.keys()));
         keys.extend(prefixed_keys("proxy-config", self.proxy_config.keys()));
         keys.extend(prefixed_keys("s3-options", self.s3_options.keys()));
+        keys.extend(prefixed_keys("azure-options", self.azure_options.keys()));
         keys
     }
 }
@@ -433,6 +444,9 @@ where
     /// should surface these to the user as warnings (they are typos or
     /// keys of other tools).
     pub fn from_toml_str(input: &str) -> Result<(Self, BTreeSet<String>), toml::de::Error> {
+        azure::ensure_no_colliding_keys(&input.parse()?)
+            .map_err(serde::de::Error::custom::<String>)?;
+
         // The document is deserialized twice: once into the common
         // configuration and once into the extension. Each pass records the
         // keys it did not recognize; only keys unknown to *both* passes are

--- a/crates/rattler_config/src/config/azure.rs
+++ b/crates/rattler_config/src/config/azure.rs
@@ -1,0 +1,322 @@
+use indexmap::IndexMap;
+use rattler_azure::{AzureEndpointKey, AzureEndpointOptions, AzureHost};
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
+
+/// Azure Blob channel options, keyed by [`AzureEndpointKey`] with
+/// [`AzureEndpointOptions`] as the entry.
+///
+/// Entries are **user-scoped by contract**. Read from a project manifest, a
+/// checked-out repository could name a host and be sent ambient credentials.
+#[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AzureOptionsMap(IndexMap<AzureEndpointKey, AzureEndpointOptions>);
+
+impl AzureOptionsMap {
+    pub fn get(&self, key: &AzureEndpointKey) -> AzureEndpointOptions {
+        self.0.get(key).cloned().unwrap_or_default()
+    }
+
+    pub fn contains(&self, key: &AzureEndpointKey) -> bool {
+        self.0.contains_key(key)
+    }
+}
+
+/// Both spellings reach serde, which silently keeps whichever the table iterated
+/// last — byte order of the raw keys, not the order they were written — so one
+/// entry's grants vanish and Azure reports the private container as a 404. TOML's
+/// own duplicate-key check runs on the raw text, so it cannot see the collision.
+///
+/// A host carrying both readings of its account is refused on the same terms: only
+/// one of `H` and `H/<account>` can describe an endpoint, and longest-match would
+/// pick the path-style one without saying so.
+pub(crate) fn ensure_no_colliding_keys(document: &toml::Table) -> Result<(), String> {
+    let Some(table) = document
+        .get("azure-options")
+        .and_then(toml::Value::as_table)
+    else {
+        return Ok(());
+    };
+
+    let mut seen: IndexMap<AzureEndpointKey, &String> = IndexMap::new();
+    let mut reading: IndexMap<AzureHost, (&String, bool)> = IndexMap::new();
+    for written in table.keys() {
+        // An unparsable key is serde's error to report, not ours.
+        let Ok(key) = AzureEndpointKey::parse(written) else {
+            continue;
+        };
+        if let Some(first) = seen.insert(key.clone(), written) {
+            return Err(format!(
+                "`azure-options` names one endpoint twice: \"{first}\" and \"{written}\" are both \
+                 `{key}`"
+            ));
+        }
+
+        let host_style = matches!(key, AzureEndpointKey::HostStyle(_));
+        if let Some((first, first_host_style)) =
+            reading.insert(key.host().clone(), (written, host_style))
+            && first_host_style != host_style
+        {
+            return Err(format!(
+                "`azure-options` reads `{}` both ways: \"{first}\" and \"{written}\" disagree on \
+                 whether the storage account is the host's first label or a path segment",
+                key.host()
+            ));
+        }
+    }
+    Ok(())
+}
+
+impl Config for AzureOptionsMap {
+    fn is_default(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn merge_config(self, other: &Self) -> Result<Self, super::MergeError> {
+        // An entry replaces wholesale rather than merging field by field. Merging
+        // let two individually-valid files produce a combination neither wrote: a
+        // system file granting a container over https, plus a user file setting
+        // only `scheme = "http"` on the same key, used to yield a cleartext grant.
+        // An entry is one unit — its scheme and grants describe one endpoint — so
+        // the layer that names a key owns it.
+        let mut merged = self.0;
+        merged.extend(
+            other
+                .0
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+        Ok(AzureOptionsMap(merged))
+    }
+
+    fn keys(&self) -> Vec<String> {
+        // Quoted, because a key can carry dots, a colon and a slash, none of which
+        // a bare TOML key holds — and the path is what the user passes to `config
+        // set`/`unset`.
+        //
+        // The per-container grants are listed as their own keys so each is
+        // separately unsettable. There is deliberately no `."<key>".auth` key: the
+        // path exists only as a table of containers, so `config set
+        // azure-options."<key>".auth true` has nowhere to land — which is the
+        // point, since that is the one edit whose blast radius would be the whole
+        // account.
+        self.0
+            .iter()
+            .flat_map(|(key, options)| {
+                let key = toml::Value::from(key.to_string()).to_string();
+                let grants = options
+                    .grants()
+                    .map(|(container, _)| {
+                        let container = toml::Value::from(container.to_string()).to_string();
+                        format!("{key}.auth.{container}")
+                    })
+                    .collect::<Vec<_>>();
+                std::iter::once(key).chain(grants)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rattler_azure::{Auth, AzureScheme, ContainerName};
+
+    use super::*;
+
+    fn key(written: &str) -> AzureEndpointKey {
+        AzureEndpointKey::parse(written).expect("test key should parse")
+    }
+
+    fn container(name: &str) -> ContainerName {
+        ContainerName::new(name).expect("test container name")
+    }
+
+    #[test]
+    fn table_parses_and_absent_keys_default() {
+        let map: AzureOptionsMap = toml::from_str(
+            r#"
+            ["mycompany.blob.core.windows.net".auth]
+            releases = true
+
+            ["127.0.0.1:10000/devstoreaccount1"]
+            scheme = "http"
+
+            ["127.0.0.1:10000/devstoreaccount1".auth]
+            general = true
+            "#,
+        )
+        .unwrap();
+
+        let real = map.get(&key("mycompany.blob.core.windows.net"));
+        assert_eq!(
+            real.fetch(Some(&container("releases"))).auth,
+            Auth::DefaultChain
+        );
+        assert_eq!(real.scheme(), AzureScheme::Https);
+
+        let azurite = map.get(&key("127.0.0.1:10000/devstoreaccount1"));
+        assert_eq!(
+            azurite.fetch(Some(&container("general"))).auth,
+            Auth::DefaultChain
+        );
+        assert_eq!(azurite.scheme(), AzureScheme::Http);
+
+        assert!(!real.fetch(Some(&container("public"))).auth.is_granted());
+        let unlisted = map.get(&key("someoneelse.blob.core.windows.net"));
+        assert!(
+            !unlisted
+                .fetch(Some(&container("releases")))
+                .auth
+                .is_granted()
+        );
+        assert_eq!(unlisted, AzureEndpointOptions::default());
+    }
+
+    #[test]
+    fn two_accounts_on_one_host_have_independent_grants() {
+        let map: AzureOptionsMap = toml::from_str(
+            r#"
+            ["proxy.internal/accta".auth]
+            general = true
+
+            ["proxy.internal/acctb".auth]
+            general = false
+            "#,
+        )
+        .unwrap();
+
+        assert!(
+            map.get(&key("proxy.internal/accta"))
+                .fetch(Some(&container("general")))
+                .auth
+                .is_granted()
+        );
+        assert!(
+            !map.get(&key("proxy.internal/acctb"))
+                .fetch(Some(&container("general")))
+                .auth
+                .is_granted()
+        );
+    }
+
+    #[test]
+    fn merge_replaces_the_endpoint_wholesale() {
+        let base: AzureOptionsMap =
+            toml::from_str("[\"host.example\"]\nscheme = \"http\"\n").unwrap();
+        let over: AzureOptionsMap =
+            toml::from_str("[\"host.example\".auth]\nreleases = true\n").unwrap();
+
+        let merged = base.merge_config(&over).unwrap();
+        let entry = merged.get(&key("host.example"));
+        assert_eq!(entry.scheme(), AzureScheme::Https);
+        assert!(entry.fetch(Some(&container("releases"))).auth.is_granted());
+    }
+
+    #[test]
+    fn merge_replaces_the_grant_table_wholesale() {
+        let system: AzureOptionsMap =
+            toml::from_str("[\"host.example\".auth]\nreleases = true\nstaging = true\n").unwrap();
+        let user: AzureOptionsMap =
+            toml::from_str("[\"host.example\".auth]\ninternal = true\n").unwrap();
+
+        let entry = system
+            .merge_config(&user)
+            .unwrap()
+            .get(&key("host.example"));
+        assert!(entry.fetch(Some(&container("internal"))).auth.is_granted());
+        assert!(
+            !entry.fetch(Some(&container("releases"))).auth.is_granted(),
+            "a grant the higher-precedence file omits must not survive the merge"
+        );
+    }
+
+    #[test]
+    fn keys_are_normalized_the_same_way_lookups_are() {
+        let written = "MyCompany.blob.core.windows.net";
+        let looked_up = "mycompany.blob.core.windows.net";
+        let map: AzureOptionsMap =
+            toml::from_str(&format!("[\"{written}\".auth]\nreleases = true\n")).unwrap();
+
+        assert!(
+            map.get(&key(looked_up))
+                .fetch(Some(&container("releases")))
+                .auth
+                .is_granted(),
+            "the grant written as `{written}` did not apply to `{looked_up}`"
+        );
+        assert_eq!(
+            map.keys(),
+            vec![
+                format!("\"{looked_up}\""),
+                format!("\"{looked_up}\".auth.\"releases\""),
+            ],
+        );
+        let written_back = toml::to_string(&map).unwrap();
+        assert!(
+            written_back.contains(&format!("[\"{looked_up}\"")),
+            "{written} was written back as {written_back}"
+        );
+    }
+
+    #[test]
+    fn a_document_naming_one_endpoint_twice_is_refused() {
+        for document in [
+            r#"
+[azure-options."acct.blob.example".auth]
+releases = false
+
+[azure-options."ACCT.blob.example.".auth]
+releases = true
+"#,
+            r#"
+[azure-options."proxy.internal/accta".auth]
+releases = false
+
+[azure-options."Proxy.Internal./accta".auth]
+releases = true
+"#,
+        ] {
+            let error = ensure_no_colliding_keys(&document.parse().unwrap())
+                .expect_err("a collision must be reported");
+            assert!(error.contains("names one endpoint twice"), "{error}");
+        }
+    }
+
+    #[test]
+    fn a_host_read_both_ways_is_refused() {
+        let document = r#"
+[azure-options."proxy.internal".auth]
+accta = true
+
+[azure-options."proxy.internal/accta".auth]
+general = true
+"#;
+        let error = ensure_no_colliding_keys(&document.parse().unwrap())
+            .expect_err("both readings of one host must be reported");
+        assert!(error.contains("proxy.internal"), "{error}");
+    }
+
+    #[test]
+    fn two_path_style_keys_on_one_host_are_allowed() {
+        let document = r#"
+[azure-options."proxy.internal/accta".auth]
+general = true
+
+[azure-options."proxy.internal/acctb".auth]
+general = true
+"#;
+        assert!(ensure_no_colliding_keys(&document.parse().unwrap()).is_ok());
+    }
+
+    #[test]
+    fn a_key_past_the_account_is_rejected() {
+        let err = toml::from_str::<AzureOptionsMap>(
+            "[\"acct.blob.example/general/noarch\".auth]\nreleases = true\n",
+        )
+        .expect_err("a key past the account must be rejected");
+        assert!(
+            err.to_string().contains("acct.blob.example/general/noarch"),
+            "{err}"
+        );
+    }
+}

--- a/crates/rattler_config/src/config/azure.rs
+++ b/crates/rattler_config/src/config/azure.rs
@@ -20,6 +20,18 @@ impl AzureOptionsMap {
     pub fn contains(&self, key: &AzureEndpointKey) -> bool {
         self.0.contains_key(key)
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&AzureEndpointKey, &AzureEndpointOptions)> {
+        self.0.iter()
+    }
+
+    pub fn insert(&mut self, key: AzureEndpointKey, options: AzureEndpointOptions) {
+        self.0.insert(key, options);
+    }
+
+    pub fn remove(&mut self, key: &AzureEndpointKey) -> bool {
+        self.0.shift_remove(key).is_some()
+    }
 }
 
 /// Both spellings reach serde, which silently keeps whichever the table iterated

--- a/crates/rattler_config/src/edit.rs
+++ b/crates/rattler_config/src/edit.rs
@@ -30,6 +30,9 @@ pub enum ConfigEditError {
 
     #[error("TOML serialization error: {0}")]
     TomlSerializeError(#[from] toml::ser::Error),
+
+    #[error(transparent)]
+    Invalid(#[from] crate::config::ValidationError),
 }
 
 /// Split a dotted key path into segments, honoring TOML-style quoting so
@@ -216,7 +219,10 @@ where
     }
 
     /// Save the config to the given path.
+    /// Refuses to write a configuration that would be rejected on load, so a
+    /// tool cannot leave the user with a file it will not start from.
     pub fn save(&self, to: &Path) -> Result<(), ConfigEditError> {
+        self.validate()?;
         let contents = self.to_toml()?;
         tracing::debug!("Saving config to: {}", to.display());
 

--- a/crates/rattler_config/test-data/compat/kitchen-sink.toml
+++ b/crates/rattler_config/test-data/compat/kitchen-sink.toml
@@ -39,6 +39,16 @@ endpoint-url = "https://s3.example.com"
 region = "eu-central-1"
 force-path-style = true
 
+[azure-options."mycompany.blob.core.windows.net".auth]
+releases = true
+public = false
+
+[azure-options."127.0.0.1:10000/devstoreaccount1"]
+scheme = "http"
+
+[azure-options."127.0.0.1:10000/devstoreaccount1".auth]
+general = true
+
 [index-config]
 write-zst = true
 write-shards = false

--- a/crates/rattler_config/test-data/compat/override-layer.toml
+++ b/crates/rattler_config/test-data/compat/override-layer.toml
@@ -18,3 +18,7 @@ solves = 9
 endpoint-url = "https://minio.example.com"
 region = "auto"
 force-path-style = false
+
+[azure-options."mycompany.blob.core.windows.net".auth]
+staging = true
+public = false

--- a/crates/rattler_config/tests/compat.rs
+++ b/crates/rattler_config/tests/compat.rs
@@ -185,6 +185,10 @@ const EDIT_MATRIX: &[(&str, &str)] = &[
         "s3-options.some-bucket",
         r#"{"endpoint-url": "https://s3.example.com", "region": "auto", "force-path-style": true}"#,
     ),
+    (
+        r#"azure-options."acct.blob.core.windows.net""#,
+        r#"{"auth": {"releases": true}}"#,
+    ),
 ];
 
 /// Every key in the matrix can be set on a fully populated config, the
@@ -229,6 +233,45 @@ fn edit_matrix_set_roundtrip_unset() {
             "{key}: unset must restore the default without collateral changes"
         );
     }
+}
+
+#[test]
+fn edit_grants_one_container_at_a_time() {
+    let key = rattler_azure::AzureEndpointKey::parse("acct.blob.core.windows.net").unwrap();
+    let releases = rattler_azure::ContainerName::new("releases").unwrap();
+    let public = rattler_azure::ContainerName::new("public").unwrap();
+
+    let mut config = Config::default();
+    for (container, value) in [("releases", "true"), ("public", "false")] {
+        let path = format!(r#"azure-options."acct.blob.core.windows.net".auth."{container}""#);
+        config
+            .set(&path, Some(value.to_string()))
+            .unwrap_or_else(|e| panic!("{path} must be settable: {e}"));
+    }
+
+    let entry = config.azure_options.get(&key);
+    assert!(entry.fetch(Some(&releases)).auth.is_granted());
+    assert!(!entry.fetch(Some(&public)).auth.is_granted());
+
+    assert!(
+        config
+            .set(
+                r#"azure-options."acct.blob.core.windows.net".auth"#,
+                Some("true".to_string())
+            )
+            .is_err(),
+        "an endpoint-wide grant must not be settable"
+    );
+
+    config
+        .set(
+            r#"azure-options."acct.blob.core.windows.net".auth."releases""#,
+            None,
+        )
+        .unwrap();
+    let entry = config.azure_options.get(&key);
+    assert!(!entry.fetch(Some(&releases)).auth.is_granted());
+    assert_eq!(entry.grants().count(), 1, "`public` must survive");
 }
 
 /// Unknown keys must be rejected by `set` (both set and unset direction).
@@ -276,6 +319,17 @@ fn merge_semantics() {
     let per_channel = &merged.repodata_config.per_channel[&prefix_dev];
     assert_eq!(per_channel.disable_sharded, Some(true)); // from layer 1
     assert_eq!(per_channel.disable_zstd, Some(true)); // from layer 2
+    let mycompany = merged
+        .azure_options
+        .get(&rattler_azure::AzureEndpointKey::parse("mycompany.blob.core.windows.net").unwrap());
+    for (container, granted) in [("releases", false), ("staging", true), ("public", false)] {
+        let container = rattler_azure::ContainerName::new(container).unwrap();
+        assert_eq!(
+            mycompany.fetch(Some(&container)).auth.is_granted(),
+            granted,
+            "{container}"
+        );
+    }
     // concurrency: explicitly set values win over the lower layer.
     assert_eq!(merged.concurrency.solves, 9);
     assert_eq!(merged.concurrency.downloads, 12);

--- a/crates/rattler_config/tests/snapshots/compat__merge__kitchen_sink_plus_override.snap
+++ b/crates/rattler_config/tests/snapshots/compat__merge__kitchen_sink_plus_override.snap
@@ -52,6 +52,19 @@ endpoint-url = "https://minio.example.com/"
 region = "auto"
 force-path-style = false
 
+[azure-options."127.0.0.1:10000/devstoreaccount1"]
+scheme = "http"
+
+[azure-options."127.0.0.1:10000/devstoreaccount1".auth]
+general = true
+
+[azure-options."mycompany.blob.core.windows.net"]
+scheme = "https"
+
+[azure-options."mycompany.blob.core.windows.net".auth]
+public = false
+staging = true
+
 [index-config]
 write-zst = true
 write-shards = false

--- a/crates/rattler_config/tests/snapshots/compat__parse__deprecated-and-unknown.toml.snap
+++ b/crates/rattler_config/tests/snapshots/compat__parse__deprecated-and-unknown.toml.snap
@@ -88,6 +88,9 @@ expression: "(unused, normalized(config))"
             s3_options: S3OptionsMap(
                 {},
             ),
+            azure_options: AzureOptionsMap(
+                {},
+            ),
             index_config: IndexConfig {
                 default: IndexChannelConfig {
                     write_zst: None,

--- a/crates/rattler_config/tests/snapshots/compat__parse__kitchen-sink.toml.snap
+++ b/crates/rattler_config/tests/snapshots/compat__parse__kitchen-sink.toml.snap
@@ -206,6 +206,43 @@ expression: "(unused, normalized(config))"
                     },
                 },
             ),
+            azure_options: AzureOptionsMap(
+                {
+                    PathStyle(
+                        AccountPath {
+                            host: AzureHost("127.0.0.1:10000"),
+                            account: AccountName(
+                                "devstoreaccount1",
+                            ),
+                        },
+                    ): AzureEndpointOptions {
+                        scheme: Http,
+                        auth: {
+                            ContainerName(
+                                "general",
+                            ): DefaultChain,
+                        },
+                    },
+                    HostStyle(
+                        AccountHost {
+                            host: AzureHost("mycompany.blob.core.windows.net"),
+                            account: AccountName(
+                                "mycompany",
+                            ),
+                        },
+                    ): AzureEndpointOptions {
+                        scheme: Https,
+                        auth: {
+                            ContainerName(
+                                "public",
+                            ): Anonymous,
+                            ContainerName(
+                                "releases",
+                            ): DefaultChain,
+                        },
+                    },
+                },
+            ),
             index_config: IndexConfig {
                 default: IndexChannelConfig {
                     write_zst: Some(

--- a/crates/rattler_config/tests/snapshots/compat__parse__override-layer.toml.snap
+++ b/crates/rattler_config/tests/snapshots/compat__parse__override-layer.toml.snap
@@ -136,6 +136,28 @@ expression: "(unused, normalized(config))"
                     },
                 },
             ),
+            azure_options: AzureOptionsMap(
+                {
+                    HostStyle(
+                        AccountHost {
+                            host: AzureHost("mycompany.blob.core.windows.net"),
+                            account: AccountName(
+                                "mycompany",
+                            ),
+                        },
+                    ): AzureEndpointOptions {
+                        scheme: Https,
+                        auth: {
+                            ContainerName(
+                                "public",
+                            ): Anonymous,
+                            ContainerName(
+                                "staging",
+                            ): DefaultChain,
+                        },
+                    },
+                },
+            ),
             index_config: IndexConfig {
                 default: IndexChannelConfig {
                     write_zst: None,

--- a/crates/rattler_config/tests/snapshots/compat__parse__snake-case-aliases.toml.snap
+++ b/crates/rattler_config/tests/snapshots/compat__parse__snake-case-aliases.toml.snap
@@ -68,6 +68,9 @@ expression: "(unused, normalized(config))"
             s3_options: S3OptionsMap(
                 {},
             ),
+            azure_options: AzureOptionsMap(
+                {},
+            ),
             index_config: IndexConfig {
                 default: IndexChannelConfig {
                     write_zst: None,

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1701,7 +1701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2853,7 +2853,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3853,7 +3853,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4025,6 +4025,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rattler_azure"
+version = "0.1.0"
+dependencies = [
+ "indexmap 2.14.0",
+ "percent-encoding",
+ "secrecy",
+ "serde",
+ "thiserror 2.0.20",
+ "url",
+]
+
+[[package]]
 name = "rattler_cache"
 version = "0.10.8"
 dependencies = [
@@ -4111,11 +4123,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "dirs",
  "fs-err",
  "indexmap 2.14.0",
+ "rattler_azure",
  "rattler_conda_types",
  "serde",
  "serde_ignored",
@@ -4822,7 +4835,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4880,7 +4893,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5529,7 +5542,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6206,7 +6219,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/test-data/sparse/generate.py
+++ b/test-data/sparse/generate.py
@@ -34,9 +34,7 @@ def tar_zst(entries, level=3):
 
 
 def index_json(name):
-    return json.dumps(
-        {"name": name, "version": "1.0.0", "build": "0", "build_number": 0}
-    ).encode()
+    return json.dumps({"name": name, "version": "1.0.0", "build": "0", "build_number": 0}).encode()
 
 
 def write_conda(stem, pkg_entries, info_entries, force_zip64=False):
@@ -73,9 +71,21 @@ write_conda(
                 {
                     "paths_version": 1,
                     "paths": [
-                        {"_path": "bin/first-file.txt", "path_type": "hardlink", "size_in_bytes": 19},
-                        {"_path": "lib/blob.bin", "path_type": "hardlink", "size_in_bytes": 150000},
-                        {"_path": "share/last-file.txt", "path_type": "hardlink", "size_in_bytes": 18},
+                        {
+                            "_path": "bin/first-file.txt",
+                            "path_type": "hardlink",
+                            "size_in_bytes": 19,
+                        },
+                        {
+                            "_path": "lib/blob.bin",
+                            "path_type": "hardlink",
+                            "size_in_bytes": 150000,
+                        },
+                        {
+                            "_path": "share/last-file.txt",
+                            "path_type": "hardlink",
+                            "size_in_bytes": 18,
+                        },
                     ],
                 }
             ).encode(),

--- a/test-data/test-server/reposerver.py
+++ b/test-data/test-server/reposerver.py
@@ -124,9 +124,7 @@ class RepoSigner:
             fout.write(root_md_serialized_unsigned)
 
         # This overwrites the file with a signed version of the file.
-        cct_root_signing.sign_root_metadata_via_gpg(
-            root_filepath, root_keys[0]["fingerprint"]
-        )
+        cct_root_signing.sign_root_metadata_via_gpg(root_filepath, root_keys[0]["fingerprint"])
 
         # Load untrusted signed root metadata.
         signed_root_md = cct_common.load_metadata_from_file(root_filepath)
@@ -136,9 +134,7 @@ class RepoSigner:
         print("[reposigner] Root metadata signed & verified!")
 
     def create_key_mgr(self, keys):
-        private_key_key_mgr = cct_common.PrivateKey.from_hex(
-            keys["key_mgr"][0]["private"]
-        )
+        private_key_key_mgr = cct_common.PrivateKey.from_hex(keys["key_mgr"][0]["private"])
         pkg_mgr_pub_keys = [k["public"] for k in keys["pkg_mgr"]]
         key_mgr = cct_metadata_construction.build_delegating_metadata(
             metadata_type="key_mgr",  # 'root' or 'key_mgr'
@@ -159,9 +155,7 @@ class RepoSigner:
 
         # let's run a verification
         root_metadata = cct_common.load_metadata_from_file(self.folder / "1.root.json")
-        key_mgr_metadata = cct_common.load_metadata_from_file(
-            self.folder / "key_mgr.json"
-        )
+        key_mgr_metadata = cct_common.load_metadata_from_file(self.folder / "key_mgr.json")
 
         cct_common.checkformat_signable(root_metadata)
 
@@ -171,9 +165,7 @@ class RepoSigner:
         root_delegations = root_metadata["signed"]["delegations"]  # for brevity
         cct_common.checkformat_delegations(root_delegations)
         if "key_mgr" not in root_delegations:
-            raise ValueError(
-                'Missing expected delegation to "key_mgr" in root metadata.'
-            )
+            raise ValueError('Missing expected delegation to "key_mgr" in root metadata.')
         cct_common.checkformat_delegation(root_delegations["key_mgr"])
 
         # Doing delegation processing.
@@ -286,14 +278,10 @@ class ChannelHandler(SimpleHTTPRequestHandler):
         self.wfile.write(b"no valid api key received")
 
 
-global_parser = argparse.ArgumentParser(
-    description="Start a multi-channel conda package server."
-)
+global_parser = argparse.ArgumentParser(description="Start a multi-channel conda package server.")
 global_parser.add_argument("-p", "--port", type=int, default=8000, help="Port to use.")
 
-channel_parser = argparse.ArgumentParser(
-    description="Start a simple conda package server."
-)
+channel_parser = argparse.ArgumentParser(description="Start a simple conda package server.")
 channel_parser.add_argument(
     "-d",
     "--directory",


### PR DESCRIPTION
### Description

Second PR in the series splitting up #2615 (Azure Blob Storage channel support). **Stacked on #2727** — the diff includes that PR's commit until it merges; review only the `rattler_config` changes here.

This adds the `azure-options` table to `rattler_config`, letting users configure Azure endpoints and per-container auth grants:

```toml
[azure-options."mycompany.blob.core.windows.net"]
scheme = "https"

[azure-options."mycompany.blob.core.windows.net".auth]
releases = true
public = false

# Path-style addressing (Azurite, proxies): account as first path segment
[azure-options."127.0.0.1:10000/devstoreaccount1"]
scheme = "http"
```

- Entries are keyed by `rattler_azure::AzureEndpointKey` — a host (host-style, real Azure) or `host[:port]/account` (path-style). A document naming the same host both ways is rejected at parse time, since the two readings would silently shadow each other.
- Each entry carries an optional `scheme` and an `auth` table of per-container grants (`<container> = true/false`); an unlisted container is not granted.
- Across config layers the endpoint map extends, but each endpoint's entry is replaced wholesale — so a higher layer can revoke a grant by omission.
- `azure_options` is wired into `CommonConfig` (defaults, merge, validate, keys), and `edit::save()` now validates before writing.

### How Has This Been Tested?

- `cargo nextest run -p rattler_config --all-features` — 90/90 pass, including e2e fixture parsing (`kitchen-sink.toml`, `override-layer.toml`), layer-merge semantics, edit round-trips, and insta snapshots
- `cargo clippy -p rattler_config --all-features -- -D warnings` and `cargo fmt --check` — clean

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
