### PR TITLE
feat: mask SAS signatures in rattler_redaction

### DIFF
--- a/crates/rattler_redaction/src/lib.rs
+++ b/crates/rattler_redaction/src/lib.rs
@@ -1,12 +1,74 @@
+use std::borrow::Cow;
+use std::ops::Range;
+
 use url::Url;
 
 /// A default string to use for redaction.
 pub const DEFAULT_REDACTION_STR: &str = "********";
 
+/// The signature is the credential itself; the rest of such a URL is inert without
+/// it and stays readable.
+const SIGNATURE_PARAM: &str = "sig";
+
+/// The byte range of a `sig` parameter's value, starting right after the
+/// `=` at `equals` (an offset into `pair = &text[separator + 1..]`) and
+/// ending at the first character that cannot be part of the value.
+///
+/// Returns `None` for an empty value, since there is nothing to redact.
+fn signature_value_span(text: &str, separator: usize, equals: usize) -> Option<Range<usize>> {
+    let value = separator + 1 + equals + 1;
+    let end = value
+        + text[value..]
+            .find(|c: char| c.is_whitespace() || "&\"',)]}".contains(c))
+            .unwrap_or(text.len() - value);
+    if end == value {
+        return None;
+    }
+    Some(value..end)
+}
+
+/// Mask the signature of a pre-signed URL wherever one appears in `text`.
+///
+/// Takes text rather than a [`Url`] because that is the shape the leak has:
+/// storage backends quote the request URL inside error messages.
+pub fn redact_signatures_in_text<'a>(text: &'a str, redaction: &str) -> Cow<'a, str> {
+    let mut out = String::new();
+    let mut written = 0;
+
+    for (separator, _) in text.char_indices().filter(|(_, c)| *c == '?' || *c == '&') {
+        let pair = &text[separator + 1..];
+        let Some(equals) = pair.find('=') else {
+            continue;
+        };
+        if !pair[..equals].eq_ignore_ascii_case(SIGNATURE_PARAM) {
+            continue;
+        }
+
+        let Some(Range { start: value, end }) = signature_value_span(text, separator, equals)
+        else {
+            continue;
+        };
+        if value < written {
+            continue;
+        }
+
+        out.push_str(&text[written..value]);
+        out.push_str(redaction);
+        written = end;
+    }
+
+    if written == 0 {
+        return Cow::Borrowed(text);
+    }
+    out.push_str(&text[written..]);
+    Cow::Owned(out)
+}
+
 /// Masks the known secret patterns in a URL for display in logs and error
-/// messages: the password in the userinfo (the username stays) and the token
-/// in a `/t/<token>/` path. Query strings and fragments are left untouched,
-/// so the URL stays recognizable for debugging.
+/// messages: the password in the userinfo (the username stays), the token in
+/// a `/t/<token>/` path, and a `sig` query parameter such as an Azure SAS
+/// signature. Other query parameters and the fragment are left untouched, so
+/// the URL stays recognizable for debugging.
 ///
 /// Use [`strip_url_for_serialization`] instead when the URL is written into
 /// durable output.
@@ -31,28 +93,43 @@ pub fn redact_url_for_display(url: &Url, redaction: &str) -> Option<Url> {
         url.set_password(Some(redaction)).ok()?;
     }
 
-    let mut segments = url.path_segments()?;
-    match (segments.next(), segments.next()) {
-        (Some("t"), Some(_)) => {
-            let remainder = segments.collect::<Vec<_>>();
-            let mut redacted_path = format!(
-                "t/{redaction}{separator}",
-                separator = if remainder.is_empty() { "" } else { "/" },
-            );
-
-            for (idx, segment) in remainder.iter().enumerate() {
-                redacted_path.push_str(segment);
-                // if the original url ends with a slash, we need to add it to the redacted path
-                if idx < remainder.len() - 1 {
-                    redacted_path.push('/');
-                }
-            }
-
-            url.set_path(&redacted_path);
-            Some(url)
-        }
-        _ => Some(url),
+    if let Some(query) = url.query()
+        && let Cow::Owned(masked) = redact_signatures_in_text(&format!("?{query}"), redaction)
+    {
+        url.set_query(Some(&masked[1..]));
     }
+
+    // A URL that cannot be a base has no `/t/<token>/` to mask but may still
+    // have had a signature masked above; returning `None` here would throw
+    // that masking away, since callers fall back to the unredacted URL.
+    let token_prefixed = url.path_segments().is_some_and(|mut segments| {
+        matches!((segments.next(), segments.next()), (Some("t"), Some(_)))
+    });
+
+    if token_prefixed {
+        let remainder = url
+            .path_segments()
+            .into_iter()
+            .flatten()
+            .skip(2)
+            .collect::<Vec<_>>();
+        let mut redacted_path = format!(
+            "t/{redaction}{separator}",
+            separator = if remainder.is_empty() { "" } else { "/" },
+        );
+
+        for (idx, segment) in remainder.iter().enumerate() {
+            redacted_path.push_str(segment);
+            // if the original url ends with a slash, we need to add it to the redacted path
+            if idx < remainder.len() - 1 {
+                redacted_path.push('/');
+            }
+        }
+
+        url.set_path(&redacted_path);
+    }
+
+    Some(url)
 }
 
 /// Deprecated name of [`redact_url_for_display`].
@@ -161,6 +238,48 @@ impl Redact for Url {
 mod test {
     use super::*;
     use std::str::FromStr;
+
+    #[test]
+    fn test_redact_signatures_in_text() {
+        let message = "unexpected status code 403, url=https://acct.blob.core.windows.net/c/p?sv=2025-01-05&se=2026-08-05T00%3A00Z&sig=aBcD%2Fefg%3D, op=stat";
+        assert_eq!(
+            redact_signatures_in_text(message, DEFAULT_REDACTION_STR),
+            format!(
+                "unexpected status code 403, url=https://acct.blob.core.windows.net/c/p?sv=2025-01-05&se=2026-08-05T00%3A00Z&sig={DEFAULT_REDACTION_STR}, op=stat"
+            )
+        );
+
+        assert!(matches!(
+            redact_signatures_in_text("https://prefix.dev/conda-forge?a=b", "X"),
+            Cow::Borrowed(_)
+        ));
+
+        assert_eq!(
+            redact_signatures_in_text("https://h/p?design=keep&sig=drop", "X"),
+            "https://h/p?design=keep&sig=X"
+        );
+
+        assert_eq!(
+            Url::from_str("https://acct.blob.core.windows.net/c/p?sv=2025-01-05&sig=secret")
+                .unwrap()
+                .redact()
+                .to_string(),
+            format!(
+                "https://acct.blob.core.windows.net/c/p?sv=2025-01-05&sig={DEFAULT_REDACTION_STR}"
+            )
+        );
+    }
+
+    #[test]
+    fn a_url_that_cannot_be_a_base_still_has_its_signature_masked() {
+        let redacted = redact_url_for_display(
+            &Url::from_str("az:container/repodata.json?sig=secret").unwrap(),
+            DEFAULT_REDACTION_STR,
+        )
+        .expect("a signature must be masked even with no path segments to inspect");
+
+        assert!(!redacted.to_string().contains("secret"), "{redacted}");
+    }
 
     #[test]
     fn test_redact_url_for_display() {


### PR DESCRIPTION
### Description

Third PR in the series splitting up #2615 (Azure Blob Storage channel support). Unlike #2727/#2728 this one is independent and goes directly against `main`.

Azure SAS tokens carry their authorization in the `sig` query parameter, and storage-backend errors (e.g. opendal's) quote the full request URL in their message text — so a failed request can leak a live credential into logs and terminal output. This teaches `rattler_redaction` to mask them:

- New: `redact_signatures_in_text(text, redaction) -> Cow<str>` — masks the value of a `sig` query parameter (case-insensitive) wherever it appears in arbitrary text. Text-based rather than `Url`-based because the input is prose with URLs embedded mid-sentence, including URLs that `Url` cannot represent:

  ```text
  before: unexpected status code 403, url=https://acct.blob.core.windows.net/c/p?sv=2025-01-05&se=2026-08-05T00%3A00Z&sig=aBcD%2Fefg%3D, op=stat
  after:  unexpected status code 403, url=https://acct.blob.core.windows.net/c/p?sv=2025-01-05&se=2026-08-05T00%3A00Z&sig=********, op=stat
  ```

- `redact_url_for_display` now also masks a `sig` query parameter, alongside its existing password/token masking.

Later PRs in the series (the Azure networking middleware, `rattler_index`, `rattler_upload`) consume the new function when surfacing storage errors.

### How Has This Been Tested?

- `cargo nextest run -p rattler_redaction --all-features` — 4/4 pass, including a cannot-be-a-base URL that justifies the text-based approach, plus the doctest
- `cargo clippy -p rattler_redaction --all-features -- -D warnings` and `cargo fmt --check` — clean

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
