### PR TITLE
feat: default `__glibc` to 2.39 on `linux-riscv64`

### DIFF
--- a/crates/rattler_virtual_packages/src/defaults.rs
+++ b/crates/rattler_virtual_packages/src/defaults.rs
@@ -7,9 +7,15 @@ use rattler_conda_types::{Platform, Version};
 
 /// The default `glibc` version to use when the version cannot be detected.
 ///
-/// This is the `glibc` version that ships with RHEL 8 and Debian 10.
-pub fn default_glibc_version() -> Version {
-    "2.28".parse().unwrap()
+/// This is the `glibc` version that ships with RHEL 8 and Debian 10, except for
+/// platforms that never had a `glibc` that old: `riscv64` support only landed in
+/// `glibc` 2.27 upstream, and conda-forge builds for `linux-riscv64` against
+/// 2.39, so assuming 2.28 there makes every package look uninstallable.
+pub fn default_glibc_version(platform: Platform) -> Version {
+    match platform {
+        Platform::LinuxRiscv64 => "2.39".parse().unwrap(),
+        _ => "2.28".parse().unwrap(),
+    }
 }
 
 /// The default Linux kernel version to use when the version cannot be

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -529,7 +529,7 @@ impl VirtualPackages {
             }),
             libc: platform.is_linux().then(|| LibC {
                 family: "glibc".into(),
-                version: defaults::default_glibc_version(),
+                version: defaults::default_glibc_version(platform),
             }),
             cuda: None,
             cuda_arch: None,
@@ -1643,7 +1643,10 @@ mod test {
         );
         let libc = linux.libc.unwrap();
         assert_eq!(libc.family, "glibc");
-        assert_eq!(libc.version, defaults::default_glibc_version());
+        assert_eq!(
+            libc.version,
+            defaults::default_glibc_version(Platform::Linux64)
+        );
 
         let osx = VirtualPackages::baseline_for_platform(Platform::OsxArm64);
         assert_eq!(
@@ -1660,6 +1663,26 @@ mod test {
         assert_eq!(
             VirtualPackages::baseline_for_platform(Platform::Linux64).archspec,
             Archspec::from_platform(Platform::Linux64)
+        );
+    }
+
+    /// conda-forge builds `linux-riscv64` against a much newer `glibc` than the
+    /// RHEL 8 baseline the other Linux platforms use, so assuming 2.28 there
+    /// would make every package look uninstallable.
+    #[test]
+    fn baseline_assumes_a_newer_glibc_on_riscv64() {
+        let riscv = VirtualPackages::baseline_for_platform(Platform::LinuxRiscv64);
+        let libc = riscv.libc.expect("__glibc should be present");
+        assert_eq!(libc.family, "glibc");
+        assert_eq!(libc.version, Version::from_str("2.39").unwrap());
+
+        // Other Linux platforms keep the RHEL 8 baseline.
+        assert_eq!(
+            VirtualPackages::baseline_for_platform(Platform::Linux64)
+                .libc
+                .expect("__glibc should be present")
+                .version,
+            Version::from_str("2.28").unwrap()
         );
     }
 
@@ -1705,7 +1728,10 @@ mod test {
             );
             let libc = packages.libc.expect("__glibc should be present");
             assert_eq!(libc.family, "glibc");
-            assert_eq!(libc.version, defaults::default_glibc_version());
+            assert_eq!(
+                libc.version,
+                defaults::default_glibc_version(Platform::Linux64)
+            );
         }
 
         if !current.is_osx() {


### PR DESCRIPTION
xref https://github.com/conda-forge/conda-forge.github.io/issues/1744#issuecomment-5439335369

### Description

When cross-compiling, `__glibc` falls back to 2.28 (the RHEL 8 / Debian 10 baseline). That baseline is wrong for `linux-riscv64`: `riscv64` support only landed in glibc 2.27 upstream, and conda-forge builds `linux-riscv64` packages against 2.39. The result is that solving for `linux-riscv64` from any other platform fails on essentially everything:

```
❯ rattler solve nushell --platform linux-riscv64
Virtual packages:
  - __glibc=2.28=0

Error:   × Cannot solve the request because of: nushell * cannot be installed because there are no viable options:
  │ └─ nushell 0.115.1 would require
  │    └─ __glibc >=2.39,<3.0.a0, for which no candidates were found.
```

`default_glibc_version` now takes a `Platform` and returns 2.39 for `Platform::LinuxRiscv64`, keeping 2.28 for every other Linux platform. This mirrors how `default_mac_os_version` is already platform-aware.

Note this is a breaking change to the signature of the public `defaults::default_glibc_version`, which gained a `Platform` argument.

### How Has This Been Tested?

`cargo test -p rattler_virtual_packages` (44 passed). Added `baseline_assumes_a_newer_glibc_on_riscv64`, which asserts the riscv64 baseline is 2.39 and that `linux-64` still gets 2.28.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

```plaintext
❯ rattler solve nushell --platform linux-riscv64
Solving for platform: linux-riscv64
Loaded 70 records in 375ms
⠁ determining virtual packages
 INFO rattler_virtual_packages: cannot detect the version of the virtual package '__linux' when targeting 'linux-riscv64', assuming version 4.18; set the CONDA_OVERRIDE_LINUX environment variable to override
 INFO rattler_virtual_packages: cannot detect the version of the virtual package '__glibc' when targeting 'linux-riscv64', assuming version 2.28; set the CONDA_OVERRIDE_GLIBC environment variable to override
Virtual packages:
  - __unix=0=0
  - __linux=4.18=0
  - __glibc=2.28=0
  - __archspec=1=riscv64

Error:   × Cannot solve the request because of: nushell * cannot be installed because there are no viable options:
  │ └─ nushell 0.115.1 would require
  │    └─ __glibc >=2.39,<3.0.a0, for which no candidates were found.
  │

make the default glibc version be 2.39 for linux-riscv64

create a draft pr
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.