### PR TITLE
feat: configure repodata cache freshness

### DIFF
--- a/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
@@ -29,6 +29,16 @@ pub struct RepoDataState {
     )]
     pub cache_last_modified: SystemTime,
 
+    /// When the cached response was last downloaded or successfully revalidated.
+    #[serde(
+        default,
+        deserialize_with = "option_duration_from_nanos",
+        serialize_with = "option_duration_to_nanos",
+        rename = "refresh_ns",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cache_last_validated: Option<SystemTime>,
+
     /// The size of the repodata.json file on disk.
     #[serde(rename = "size")]
     pub cache_size: u64,
@@ -116,6 +126,34 @@ fn duration_to_nanos<S: Serializer>(time: &SystemTime, s: S) -> Result<S::Ok, S:
         .map_err(|_err| S::Error::custom("duration cannot be computed for file time"))?
         .as_nanos()
         .serialize(s)
+}
+
+fn option_duration_from_nanos<'de, D>(deserializer: D) -> Result<Option<SystemTime>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    Option::<u64>::deserialize(deserializer)?
+        .map(|nanos| {
+            SystemTime::UNIX_EPOCH
+                .checked_add(std::time::Duration::from_nanos(nanos))
+                .ok_or_else(|| D::Error::custom("the time cannot be represented internally"))
+        })
+        .transpose()
+}
+
+fn option_duration_to_nanos<S: Serializer>(
+    time: &Option<SystemTime>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::ser::Error;
+    time.map(|time| {
+        time.duration_since(SystemTime::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .map_err(|_error| S::Error::custom("duration cannot be computed for validation time"))
+    })
+    .transpose()?
+    .serialize(serializer)
 }
 
 fn deserialize_blake2_hash<'de, D>(

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -1,7 +1,7 @@
 //! This module provides functionality to download and cache `repodata.json`
 //! from a remote location.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use cfg_if::cfg_if;
 use rattler_redaction::Redact;
@@ -145,6 +145,20 @@ impl Variant {
             Variant::Current => "current_repodata.json",
         }
     }
+}
+
+/// Controls how long cached repodata is considered fresh.
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+pub enum CacheFreshness {
+    /// Follow the response's HTTP cache-control headers.
+    #[default]
+    HttpCacheControl,
+
+    /// Always conditionally revalidate cached repodata.
+    AlwaysRevalidate,
+
+    /// Override the response's freshness lifetime with the given duration.
+    Override(Duration),
 }
 
 /// Defines how to use the repodata cache.

--- a/crates/rattler_repodata_gateway/src/fetch/with_cache.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/with_cache.rs
@@ -24,7 +24,7 @@ use url::Url;
 use crate::{
     Reporter,
     fetch::{
-        CacheAction, FetchRepoDataError, RepoDataNotFoundError, Variant,
+        CacheAction, CacheFreshness, FetchRepoDataError, RepoDataNotFoundError, Variant,
         cache::{CacheHeaders, Expiring, RepoDataState},
     },
     reporter::{DownloadReporter, ResponseReporterExt},
@@ -38,6 +38,9 @@ pub struct FetchRepoDataOptions {
     /// How to use the cache. By default it will cache and reuse downloaded
     /// repodata.json (if the server allows it).
     pub cache_action: CacheAction,
+
+    /// Controls how long cached repodata is considered fresh.
+    pub cache_freshness: CacheFreshness,
 
     /// Determines which variant to download. See [`Variant`] for more
     /// information.
@@ -58,6 +61,7 @@ impl Default for FetchRepoDataOptions {
     fn default() -> Self {
         Self {
             cache_action: CacheAction::default(),
+            cache_freshness: CacheFreshness::default(),
             variant: Variant::default(),
             zstd_enabled: true,
             bz2_enabled: true,
@@ -131,6 +135,7 @@ async fn repodata_from_file(
             cache_control: None,
         },
         cache_last_modified: SystemTime::now(),
+        cache_last_validated: Some(SystemTime::now()),
         blake2_hash: None,
         has_zst: None,
         has_bz2: None,
@@ -220,7 +225,12 @@ pub async fn fetch_repo_data(
         let owned_cache_path = cache_path.clone();
         let owned_cache_key = cache_key.clone();
         let cache_state = tokio::task::spawn_blocking(move || {
-            validate_cached_state(&owned_cache_path, &owned_subdir_url, &owned_cache_key)
+            validate_cached_state(
+                &owned_cache_path,
+                &owned_subdir_url,
+                &owned_cache_key,
+                options.cache_freshness,
+            )
         })
         .await?;
         match (cache_state, options.cache_action) {
@@ -386,6 +396,7 @@ pub async fn fetch_repo_data(
                 // Update the cache on disk with any new findings.
                 let cache_state = RepoDataState {
                     url: repo_data_url,
+                    cache_last_validated: Some(SystemTime::now()),
                     has_zst: variant_availability.has_zst,
                     has_bz2: variant_availability.has_bz2,
                     ..cache_state.expect("we must have had a cache, otherwise we wouldn't know the previous state of the cache")
@@ -498,6 +509,7 @@ pub async fn fetch_repo_data(
             .modified()
             .map_err(FetchRepoDataError::FailedToGetMetadata)?,
         cache_size: repo_data_json_metadata.len(),
+        cache_last_validated: Some(SystemTime::now()),
         blake2_hash: Some(blake2_hash),
         has_zst: variant_availability.has_zst,
         has_bz2: variant_availability.has_bz2,
@@ -771,6 +783,7 @@ fn validate_cached_state(
     cache_path: &Path,
     subdir_url: &Url,
     cache_key: &str,
+    cache_freshness: CacheFreshness,
 ) -> ValidatedCacheState {
     let repo_data_json_path = cache_path.join(format!("{cache_key}.json"));
     let cache_state_path = cache_path.join(format!("{cache_key}.info.json"));
@@ -870,13 +883,31 @@ fn validate_cached_state(
     }
 
     // Determine the age of the cache
-    let cache_age = match SystemTime::now().duration_since(cache_last_modified) {
+    let cache_age = match SystemTime::now().duration_since(
+        cache_state
+            .cache_last_validated
+            .unwrap_or(cache_last_modified),
+    ) {
         Ok(duration) => duration,
         Err(e) => {
             tracing::warn!("failed to determine cache age: {e}. Ignoring cached files...");
             return ValidatedCacheState::Mismatched(cache_state);
         }
     };
+
+    match cache_freshness {
+        CacheFreshness::AlwaysRevalidate => {
+            return ValidatedCacheState::OutOfDate(cache_state);
+        }
+        CacheFreshness::Override(max_age) => {
+            return if cache_age < max_age {
+                ValidatedCacheState::UpToDate(cache_state)
+            } else {
+                ValidatedCacheState::OutOfDate(cache_state)
+            };
+        }
+        CacheFreshness::HttpCacheControl => {}
+    }
 
     // Parse the cache control header, and determine if the cache is out of date or
     // not.
@@ -940,6 +971,7 @@ mod test {
             Arc,
             atomic::{AtomicUsize, Ordering},
         },
+        time::Duration,
     };
 
     use assert_matches::assert_matches;
@@ -967,7 +999,7 @@ mod test {
     use crate::{
         DownloadReporter, Reporter,
         fetch::{
-            FetchRepoDataError, RepoDataNotFoundError,
+            CacheFreshness, FetchRepoDataError, RepoDataNotFoundError,
             cache::{CacheHeaders, RepoDataState},
             with_cache::{
                 CacheResult, CachedRepoData, FetchRepoDataOptions, ValidatedCacheState,
@@ -1022,6 +1054,10 @@ mod test {
     }
 
     fn validate_cache_with_cache_control(cache_control: &str) -> ValidatedCacheState {
+        validate_cache(cache_control, CacheFreshness::HttpCacheControl)
+    }
+
+    fn validate_cache(cache_control: &str, cache_freshness: CacheFreshness) -> ValidatedCacheState {
         let cache_dir = TempDir::new().unwrap();
         let cache_key = "test-cache";
         let repo_data_path = cache_dir.path().join(format!("{cache_key}.json"));
@@ -1037,6 +1073,7 @@ mod test {
                 cache_control: Some(cache_control.to_string()),
             },
             cache_last_modified: metadata.modified().unwrap(),
+            cache_last_validated: Some(metadata.modified().unwrap()),
             cache_size: metadata.len(),
             blake2_hash: None,
             has_zst: None,
@@ -1045,7 +1082,7 @@ mod test {
         .to_path(&cache_dir.path().join(format!("{cache_key}.info.json")))
         .unwrap();
 
-        validate_cached_state(cache_dir.path(), &subdir_url, cache_key)
+        validate_cached_state(cache_dir.path(), &subdir_url, cache_key, cache_freshness)
     }
 
     #[test]
@@ -1057,6 +1094,25 @@ mod test {
         assert_matches!(
             validate_cache_with_cache_control("private, max-age=30"),
             ValidatedCacheState::UpToDate(_)
+        );
+    }
+
+    #[test]
+    fn test_cache_freshness_overrides_http_headers() {
+        assert_matches!(
+            validate_cache(
+                "no-cache",
+                CacheFreshness::Override(Duration::from_secs(30))
+            ),
+            ValidatedCacheState::UpToDate(_)
+        );
+        assert_matches!(
+            validate_cache("max-age=3600", CacheFreshness::AlwaysRevalidate),
+            ValidatedCacheState::OutOfDate(_)
+        );
+        assert_matches!(
+            validate_cache("max-age=3600", CacheFreshness::Override(Duration::ZERO)),
+            ValidatedCacheState::OutOfDate(_)
         );
     }
 
@@ -1191,6 +1247,53 @@ mod test {
         .unwrap();
 
         assert_matches!(cache_result, CacheResult::CacheOutdated);
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn revalidation_refreshes_the_override_ttl() {
+        let subdir_path = TempDir::new().unwrap();
+        std::fs::write(subdir_path.path().join("repodata.json"), FAKE_REPO_DATA).unwrap();
+        let server = SimpleChannelServer::new(subdir_path.path()).await;
+        let cache_dir = TempDir::new().unwrap();
+
+        fetch_repo_data(
+            server.url(),
+            LazyClient::default(),
+            cache_dir.path().to_owned(),
+            FetchRepoDataOptions::default(),
+            None,
+        )
+        .await
+        .unwrap();
+        let revalidated = fetch_repo_data(
+            server.url(),
+            LazyClient::default(),
+            cache_dir.path().to_owned(),
+            FetchRepoDataOptions {
+                cache_freshness: CacheFreshness::AlwaysRevalidate,
+                ..FetchRepoDataOptions::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        assert_matches!(revalidated.cache_result, CacheResult::CacheHitAfterFetch);
+        drop(revalidated);
+
+        let cached = fetch_repo_data(
+            server.url(),
+            LazyClient::default(),
+            cache_dir.path().to_owned(),
+            FetchRepoDataOptions {
+                cache_freshness: CacheFreshness::Override(Duration::from_secs(3600)),
+                ..FetchRepoDataOptions::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        assert_matches!(cached.cache_result, CacheResult::CacheHit);
     }
 
     #[tracing_test::traced_test]

--- a/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rattler_conda_types::ChannelUrl;
 use url::Url;
 
-use crate::fetch::CacheAction;
+use crate::fetch::{CacheAction, CacheFreshness};
 
 /// Describes additional properties that influence how the gateway fetches
 /// repodata for a specific channel.
@@ -20,9 +20,11 @@ pub struct SourceConfig {
     /// When enabled, sharded repodata will be used if available.
     pub sharded_enabled: bool,
 
-    /// Describes fetching repodata from a channel should interact with any
-    /// caches.
+    /// Describes how fetching repodata from a channel should interact with caches.
     pub cache_action: CacheAction,
+
+    /// Controls how long cached repodata is considered fresh.
+    pub cache_freshness: CacheFreshness,
 
     /// When the gateway may only read from the cache, report a package whose
     /// shard is absent as having no records instead of failing the query.
@@ -47,6 +49,7 @@ impl Default for SourceConfig {
             bz2_enabled: true,
             sharded_enabled: true,
             cache_action: CacheAction::default(),
+            cache_freshness: CacheFreshness::default(),
             missing_shards_are_empty: false,
         }
     }
@@ -60,6 +63,7 @@ impl From<rattler_config::config::repodata_config::RepodataChannelConfig> for So
             bz2_enabled: !value.disable_bzip2.unwrap_or(false),
             sharded_enabled: !value.disable_sharded.unwrap_or(false),
             cache_action: CacheAction::default(),
+            cache_freshness: CacheFreshness::default(),
             missing_shards_are_empty: false,
         }
     }

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/tokio.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/tokio.rs
@@ -35,6 +35,7 @@ impl RemoteSubdirClient {
             cache_dir,
             FetchRepoDataOptions {
                 cache_action: source_config.cache_action,
+                cache_freshness: source_config.cache_freshness,
                 zstd_enabled: source_config.zstd_enabled,
                 bz2_enabled: source_config.bz2_enabled,
                 ..FetchRepoDataOptions::default()

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -173,7 +173,7 @@ async fn parse_records<R: AsRef<[u8]> + Send + 'static>(
 // Tests are only run on non-wasm targets since they use tokio and axum
 #[cfg(test)]
 mod tests {
-    use crate::fetch::CacheAction;
+    use crate::fetch::{CacheAction, CacheFreshness};
     use crate::gateway::error::GatewayError;
     use crate::gateway::subdir::SubdirClient;
     use axum::{
@@ -200,6 +200,7 @@ mod tests {
     /// configurable responses for shard requests.
     struct MockShardedServer {
         local_addr: SocketAddr,
+        index_requests: Arc<AtomicUsize>,
         shard_requests: Arc<AtomicUsize>,
         _shutdown_sender: oneshot::Sender<()>,
     }
@@ -231,19 +232,28 @@ mod tests {
             let index_bytes = rmp_serde::to_vec_named(&sharded_index).unwrap();
             let compressed_index = zstd::encode_all(index_bytes.as_slice(), 3).unwrap();
 
+            let index_requests = Arc::new(AtomicUsize::new(0));
             let shard_requests = Arc::new(AtomicUsize::new(0));
             let app = Router::new()
                 .route(
                     "/linux-64/repodata_shards.msgpack.zst",
-                    get(move || async move {
-                        Response::builder()
-                            .status(StatusCode::OK)
-                            .header("Content-Type", "application/octet-stream")
-                            // Keep the cached copy fresh, so `UseCacheOnly`
-                            // accepts it in the cold-shard tests.
-                            .header("Cache-Control", "max-age=3600")
-                            .body(Body::from(compressed_index.clone()))
-                            .unwrap()
+                    get({
+                        let index_requests = Arc::clone(&index_requests);
+                        move || {
+                            let compressed_index = compressed_index.clone();
+                            let index_requests = Arc::clone(&index_requests);
+                            async move {
+                                index_requests.fetch_add(1, Ordering::SeqCst);
+                                Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header("Content-Type", "application/octet-stream")
+                                    // Keep the cached copy fresh, so `UseCacheOnly`
+                                    // accepts it in the cold-shard tests.
+                                    .header("Cache-Control", "max-age=3600")
+                                    .body(Body::from(compressed_index))
+                                    .unwrap()
+                            }
+                        }
                     }),
                 )
                 .route(
@@ -284,6 +294,7 @@ mod tests {
 
             Self {
                 local_addr,
+                index_requests,
                 shard_requests,
                 _shutdown_sender: tx,
             }
@@ -297,6 +308,10 @@ mod tests {
             Channel::from_url(self.url())
         }
 
+        fn index_request_count(&self) -> usize {
+            self.index_requests.load(Ordering::SeqCst)
+        }
+
         /// How many shard downloads the server has answered so far. The index
         /// request is not counted.
         fn shard_request_count(&self) -> usize {
@@ -308,6 +323,36 @@ mod tests {
     enum MockShardResponse {
         Empty,
         Truncated,
+    }
+
+    #[tokio::test]
+    async fn shard_index_freshness_can_force_revalidation() {
+        let server = MockShardedServer::new(MockShardResponse::Empty).await;
+        let cache_dir = tempfile::tempdir().unwrap();
+
+        for freshness in [
+            CacheFreshness::HttpCacheControl,
+            CacheFreshness::AlwaysRevalidate,
+        ] {
+            ShardedSubdir::new(
+                server.channel(),
+                "linux-64".to_string(),
+                rattler_networking::LazyClient::default(),
+                cache_dir.path().to_path_buf(),
+                ShardCachePolicy {
+                    action: CacheAction::CacheOrFetch,
+                    freshness,
+                    missing_shards_are_empty: false,
+                },
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        assert_eq!(server.index_request_count(), 2);
     }
 
     #[tokio::test]
@@ -325,6 +370,7 @@ mod tests {
             cache_dir.path().to_path_buf(),
             ShardCachePolicy {
                 action: CacheAction::NoCache,
+                freshness: CacheFreshness::default(),
                 missing_shards_are_empty: false,
             },
             None,
@@ -394,6 +440,7 @@ mod tests {
             cache_dir.path().to_path_buf(),
             ShardCachePolicy {
                 action: CacheAction::NoCache,
+                freshness: CacheFreshness::default(),
                 missing_shards_are_empty: false,
             },
             None,
@@ -436,6 +483,7 @@ mod tests {
             cache_dir.path().to_path_buf(),
             ShardCachePolicy {
                 action: CacheAction::NoCache,
+                freshness: CacheFreshness::default(),
                 missing_shards_are_empty: false,
             },
             None,
@@ -479,6 +527,7 @@ mod tests {
             cache_dir.to_path_buf(),
             ShardCachePolicy {
                 action: CacheAction::CacheOrFetch,
+                freshness: CacheFreshness::default(),
                 missing_shards_are_empty: false,
             },
             None,
@@ -495,6 +544,7 @@ mod tests {
             cache_dir.to_path_buf(),
             ShardCachePolicy {
                 action: cache_only_action,
+                freshness: CacheFreshness::default(),
                 missing_shards_are_empty,
             },
             None,
@@ -525,6 +575,7 @@ mod tests {
             cache_dir.path().to_path_buf(),
             ShardCachePolicy {
                 action: CacheAction::ForceCacheOnly,
+                freshness: CacheFreshness::default(),
                 missing_shards_are_empty: true,
             },
             None,

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/index.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/index.rs
@@ -3,7 +3,7 @@ use std::{path::Path, str::FromStr, sync::Arc, time::SystemTime};
 use super::{REPODATA_SHARDS_FILENAME, SHARDS_CACHE_SUFFIX, ShardedRepodata};
 use crate::{
     GatewayError, Reporter,
-    fetch::CacheAction,
+    fetch::{CacheAction, CacheFreshness},
     gateway::{
         error::SubdirNotFoundError,
         sharded_subdir::{decode_zst_bytes_async, is_missing_sharded_repodata_status},
@@ -49,6 +49,7 @@ pub async fn fetch_index(
     channel_base_url: &Url,
     cache_dir: &Path,
     cache_action: CacheAction,
+    cache_freshness: CacheFreshness,
     concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
     reporter: Option<&dyn Reporter>,
 ) -> Result<ShardedRepodata, GatewayError> {
@@ -167,36 +168,57 @@ pub async fn fetch_index(
     if cache_action != CacheAction::NoCache
         && let Ok(cache_header) = read_cached_index(&mut cache_reader).await
     {
-        // Check if the cache indicates the resource was unavailable
-        // (404 or 501)
-        if cache_header.not_found {
-            tracing::debug!(
-                "cached not-available response for sharded index at {channel_base_url}"
-            );
-            return Err(create_subdir_not_found_error(channel_base_url));
-        }
-
         // If we are in cache-only mode we can't fetch the index from the server
         if cache_action == CacheAction::ForceCacheOnly {
+            if cache_header.not_found {
+                return Err(create_subdir_not_found_error(channel_base_url));
+            }
             if let Ok(shard_index) = read_shard_index_from_reader(&mut cache_reader).await {
                 tracing::debug!("using locally cached shard index for {channel_base_url}");
                 return Ok(shard_index);
             }
         } else {
-            match cache_header
-                .policy
-                .before_request(&canonical_request, SystemTime::now())
-            {
-                BeforeRequest::Fresh(_) => {
+            let now = SystemTime::now();
+            let override_is_fresh = match cache_freshness {
+                CacheFreshness::Override(max_age) => cache_header.policy.age(now) < max_age,
+                CacheFreshness::AlwaysRevalidate | CacheFreshness::HttpCacheControl => false,
+            };
+            let mut revalidation_request = SimpleRequest::get(&canonical_shards_url);
+            if matches!(
+                cache_freshness,
+                CacheFreshness::AlwaysRevalidate | CacheFreshness::Override(_)
+            ) {
+                revalidation_request.headers.insert(
+                    http::header::CACHE_CONTROL,
+                    http::HeaderValue::from_static("no-cache"),
+                );
+            }
+            let before_request = if override_is_fresh {
+                None
+            } else {
+                Some(
+                    cache_header
+                        .policy
+                        .before_request(&revalidation_request, now),
+                )
+            };
+            match before_request {
+                None | Some(BeforeRequest::Fresh(_)) => {
+                    if cache_header.not_found {
+                        tracing::debug!(
+                            "cached not-available response for sharded index at {channel_base_url}"
+                        );
+                        return Err(create_subdir_not_found_error(channel_base_url));
+                    }
                     if let Ok(shard_index) = read_shard_index_from_reader(&mut cache_reader).await {
                         tracing::debug!("shard index cache hit");
                         return Ok(shard_index);
                     }
                 }
-                BeforeRequest::Stale {
+                Some(BeforeRequest::Stale {
                     request: state_request,
                     ..
-                } => {
+                }) => {
                     if cache_action == CacheAction::UseCacheOnly {
                         // Cache-only and what we have may not be used, so this
                         // subdir has no sharded index we can read. The caller
@@ -272,26 +294,62 @@ pub async fn fetch_index(
                         &response,
                         SystemTime::now(),
                     ) {
-                        AfterResponse::NotModified(_policy, _) => {
-                            // The cached file is still valid
-                            match read_shard_index_from_reader(&mut cache_reader).await {
-                                Ok(shard_index) => {
-                                    tracing::debug!("shard index cache was not modified");
-                                    if let Some((reporter, index)) = download_reporter {
-                                        reporter.on_download_complete(response.url(), index);
+                        AfterResponse::NotModified(policy, _) => {
+                            // Persist the refreshed policy so a TTL starts again after a 304.
+                            if cache_header.not_found {
+                                write_not_found_cache(
+                                    cache_reader.into_inner().inner_mut(),
+                                    policy,
+                                )
+                                .await
+                                .map_err(|e| {
+                                    GatewayError::IoError(
+                                        format!(
+                                            "failed to refresh not-found cache for shard index at {}",
+                                            cache_path.display()
+                                        ),
+                                        e,
+                                    )
+                                })?;
+                                return Err(create_subdir_not_found_error(channel_base_url));
+                            }
+                            let mut bytes = Vec::new();
+                            match cache_reader.read_to_end(&mut bytes).await {
+                                Ok(_) => match parse_shard_index(bytes.clone()).await {
+                                    Ok(shard_index) => {
+                                        write_shard_index_cache(
+                                            cache_reader.into_inner().inner_mut(),
+                                            policy,
+                                            Bytes::from(bytes),
+                                        )
+                                        .await
+                                        .map_err(|e| {
+                                            GatewayError::IoError(
+                                                format!(
+                                                    "failed to refresh shard index cache at {}",
+                                                    cache_path.display()
+                                                ),
+                                                e,
+                                            )
+                                        })?;
+                                        tracing::debug!("shard index cache was not modified");
+                                        if let Some((reporter, index)) = download_reporter {
+                                            reporter.on_download_complete(response.url(), index);
+                                        }
+                                        return Ok(shard_index);
                                     }
-                                    // If reading the file failed for some reason we'll just
-                                    // fetch it again.
-                                    return Ok(shard_index);
-                                }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "the cached shard index has been corrupted: {e}"
+                                        );
+                                    }
+                                },
                                 Err(e) => {
-                                    tracing::warn!(
-                                        "the cached shard index has been corrupted: {e}"
-                                    );
-                                    if let Some((reporter, index)) = download_reporter {
-                                        reporter.on_download_complete(response.url(), index);
-                                    }
+                                    tracing::warn!("failed to read the cached shard index: {e}");
                                 }
+                            }
+                            if let Some((reporter, index)) = download_reporter {
+                                reporter.on_download_complete(response.url(), index);
                             }
                         }
                         AfterResponse::Modified(policy, _) => {
@@ -467,14 +525,15 @@ async fn write_not_found_cache(cache_file: &mut File, policy: CachePolicy) -> st
 pub async fn read_shard_index_from_reader<R: AsyncRead + Unpin>(
     reader: &mut BufReader<R>,
 ) -> Result<ShardedRepodata, GatewayError> {
-    // Read the file to memory
     let mut bytes = Vec::new();
     reader
         .read_to_end(&mut bytes)
         .await
         .map_err(|e| GatewayError::IoError("failed to read shard index buffer".to_string(), e))?;
+    parse_shard_index(bytes).await
+}
 
-    // Deserialize the bytes
+async fn parse_shard_index(bytes: Vec<u8>) -> Result<ShardedRepodata, GatewayError> {
     run_blocking_task(move || {
         rmp_serde::from_slice(&bytes)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     GatewayError, Reporter,
-    fetch::{CacheAction, FetchRepoDataError},
+    fetch::{CacheAction, CacheFreshness, FetchRepoDataError},
     gateway::{
         error::SubdirNotFoundError,
         subdir::{PackageRecords, SubdirClient},
@@ -38,6 +38,9 @@ pub(crate) const SHARDS_CACHE_SUFFIX: &str = ".shards-cache-v1";
 pub struct ShardCachePolicy {
     /// How fetching shards should interact with the cache.
     pub action: CacheAction,
+
+    /// Controls how long the cached shard index is considered fresh.
+    pub freshness: CacheFreshness,
 
     /// See [`crate::SourceConfig::missing_shards_are_empty`].
     pub missing_shards_are_empty: bool,
@@ -90,6 +93,7 @@ impl ShardedSubdir {
             &index_base_url,
             &cache_dir,
             cache_policy.action,
+            cache_policy.freshness,
             concurrent_requests_semaphore.clone(),
             reporter,
         )

--- a/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
@@ -157,6 +157,7 @@ impl<'g> SubdirBuilder<'g> {
             #[cfg(not(target_arch = "wasm32"))]
             sharded_subdir::ShardCachePolicy {
                 action: _source_config.cache_action,
+                freshness: _source_config.cache_freshness,
                 missing_shards_are_empty: _source_config.missing_shards_are_empty,
             },
             self.gateway.concurrent_requests_semaphore.clone(),

--- a/py-rattler/src/repo_data/gateway.rs
+++ b/py-rattler/src/repo_data/gateway.rs
@@ -555,6 +555,7 @@ impl PyFetchRepoDataOptions {
                 zstd_enabled,
                 bz2_enabled,
                 retry_policy: None,
+                ..FetchRepoDataOptions::default()
             },
         }
     }


### PR DESCRIPTION
### Description

Add a per-source `CacheFreshness` policy to `rattler_repodata_gateway`:

- `HttpCacheControl` preserves the current default
- `AlwaysRevalidate` keeps cached metadata and performs conditional requests
- `Override(Duration)` replaces the server-provided freshness lifetime

The policy applies to regular compressed/uncompressed repodata and sharded repodata indexes. Content-addressed individual shards continue to follow their index hashes.

Successful HTTP 304 responses now refresh the persisted validation timestamp/policy, so an overridden TTL starts again instead of causing revalidation on every subsequent request. Existing cache state files remain readable; the new `refresh_ns` field is optional.

Fixes #2734

### How Has This Been Tested?

- cache-state tests verify HTTP-header, forced-revalidation, zero-TTL, and overridden-TTL behavior
- a local HTTP test verifies a 304 refresh starts a new override TTL
- a sharded server test verifies `AlwaysRevalidate` bypasses a fresh server max-age
- `cargo test -p rattler_repodata_gateway --features gateway --lib` (207 passed, 1 ignored)
- `cargo clippy -p rattler_repodata_gateway --features gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: OpenAI Codex

Prompt: Implement the `rattler_repodata_gateway` cache-freshness API requested in #2734, including Conda-compatible revalidation/TTL modes and tests for normal and sharded repodata.

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented hard-to-understand cache revalidation paths
- [x] I have documented the public API
- [x] I have added sufficient tests
