### PR TITLE
fix: handle empty channel specifiers

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1023,6 +1023,13 @@ impl NamelessMatchSpec {
 fn parse_channel_and_subdir(
     input: &str,
 ) -> Result<(Option<Channel>, Option<String>), ParseMatchSpecError> {
+    // An empty matchspec (such as caused by ::some-package)
+    // does not have channel or namespace. See https://github.com/conda/rattler/issues/2736
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok((None, None));
+    }
+
     // The root directory only resolves relative path channels. With an
     // empty-root fallback those fail with a parse error instead of panicking
     // when the current directory is unavailable.
@@ -1737,6 +1744,27 @@ mod tests {
     fn test_empty_namespace() {
         let spec = MatchSpec::from_str("conda-forge::foo", Strict).unwrap();
         assert!(spec.namespace.is_none());
+    }
+
+    /// An empty channel component (e.g. the leading `::` in `::foo`) means no
+    /// channel was specified at all, mirroring how an empty namespace
+    /// component is handled above. Regression tests for <https://github.com/conda/rattler/issues/2736>
+    #[test]
+    fn test_empty_channel() {
+        let spec = MatchSpec::from_str("::foo", Strict).unwrap();
+        assert!(spec.channel.is_none());
+        assert!(spec.namespace.is_none());
+
+        let spec = MatchSpec::from_str(":ns:foo", Strict).unwrap();
+        assert!(spec.channel.is_none());
+        assert_eq!(spec.namespace.as_deref(), Some("ns"));
+
+        let nameless = NamelessMatchSpec::from_str("::", Strict).unwrap();
+        assert!(nameless.channel.is_none());
+
+        // The bracket form `[channel=""]` must behave the same way.
+        let spec = MatchSpec::from_str("foo[channel=\"\"]", Strict).unwrap();
+        assert!(spec.channel.is_none());
     }
 
     #[test]


### PR DESCRIPTION
### Description

This changes `::mypackage` to be parsed as no channel, no namespace, rather than hardcoding it to conda.anaconda.org. The prior existing behavior appears to have been unintended

Fixes #2736

### How Has This Been Tested?

Unit tests, running the script in the original bug report:
> spec.channel = None
> channel = None (correct: "::numpy" specifies no channel)
> round-tripped spec = numpy


### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Kilo code

```plaintext
Parsing a matchspec with a an empty channel - aka ::numpy causes rattler to default to conda.anaconda.org as the url. This is incorrect, per my understanding of CEP-29, as well as this analysis: But the CEP's own cited reference implementation does specify it — and it disagrees with rattler
CEP-29's frontmatter lists conda's models/match_spec.py as reference implementation #1 (alongside rattler as #4). In conda itself (confirmed unchanged from 24.5.0 through the CEP-cited 25.7.0):
def _parse_channel(channel_val):
    if not channel_val:          # empty string is falsy
        return None, None
    ...
...
channel, subdir = _parse_channel(channel_str)   # channel_str == "" for "::conda"
...
if channel is not None:
    components["channel"] = channel   # never set, since channel is None 

Instead, this should parse as no url, no name for the channel. Double check that my interpretation of the spec and reference implementation is correct. Double check any previous work in the codebase and whether anyone has commented about this behavior in a PR. Stop with your analysis, and then we'll design a fix afterwards
```

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

