### PR TITLE
feat: add rattler_azure URL parsing core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4981,6 +4981,7 @@ name = "rattler_azure"
 version = "0.1.0"
 dependencies = [
  "indexmap 2.14.0",
+ "insta",
  "percent-encoding",
  "secrecy",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,9 +1051,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake2"
-version = "0.11.0"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
  "digest 0.11.3",
 ]
@@ -2554,18 +2554,18 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff461519b1a948200f163574be072753bcfb462a323f0eb426629d89872dd685"
+checksum = "f54aab44c16b8463ae11b165a87c3d484780231f157bb1ed65843d591beb5abd"
 dependencies = [
  "async-trait",
- "base64 0.23.1",
+ "base64 0.22.1",
  "bytes",
+ "chrono",
  "google-cloud-gax",
  "hex",
  "hmac 0.13.0",
  "http 1.5.0",
- "jiff",
  "reqwest",
  "rustc_version",
  "rustls",
@@ -2581,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.14.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5615cff28ee59cfe52fbb4c11b8b1e77f650296e2ea4f4c2b7757ac6b19e752"
+checksum = "b9a46dd0fd026bbc4a5d84e6ab0c941cee6e3b057976a0bb107fdb5238ce598f"
 dependencies = [
  "bytes",
  "futures",
@@ -2596,7 +2596,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -4974,6 +4973,20 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "rattler_azure"
+version = "0.1.0"
+dependencies = [
+ "indexmap 2.14.0",
+ "percent-encoding",
+ "secrecy",
+ "serde",
+ "thiserror 2.0.20",
+ "tokio",
+ "toml",
  "url",
 ]
 
@@ -7727,9 +7740,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.26.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -7948,9 +7961,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.6"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ rstest = { version = "0.26" }
 rstest_reuse = "0.7"
 rustix = { version = "1.1", default-features = false }
 simd-json = { version = "0.17", features = ["serde_impl"] }
+secrecy = "0.10"
 self_cell = "1"
 semver = "1"
 send_wrapper = "0.6"
@@ -217,6 +218,7 @@ coalesced_map = { path = "crates/coalesced_map", version = "=0.1.4", default-fea
 file_url = { path = "crates/file_url", version = "=0.3.2", default-features = false }
 path_resolver = { path = "crates/path_resolver", version = "=0.2.13", default-features = false }
 rattler = { path = "crates/rattler", version = "=0.48.6", default-features = false }
+rattler_azure = { path = "crates/rattler_azure", version = "=0.1.0", default-features = false }
 rattler_cache = { path = "crates/rattler_cache", version = "=0.10.9", default-features = false }
 rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.52.1", default-features = false }
 rattler_conda_version = { path = "crates/rattler_conda_version", version = "=0.1.1", default-features = false }

--- a/crates/rattler_azure/Cargo.toml
+++ b/crates/rattler_azure/Cargo.toml
@@ -11,14 +11,9 @@ readme.workspace = true
 
 [features]
 default = []
-# Serde derives for the types of the `azure-options` config table. Pulls in
-# `serde` and `indexmap/serde` only, so config crates can depend on this crate
-# with default features off.
 serde = ["dep:serde", "indexmap/serde"]
 
 [dependencies]
-# The per-container grant table. Order is kept for tables built in memory;
-# deserialized TOML arrives in byte order, since `toml::Table` is a `BTreeMap`.
 indexmap = { workspace = true }
 percent-encoding = { workspace = true }
 secrecy = { workspace = true }

--- a/crates/rattler_azure/Cargo.toml
+++ b/crates/rattler_azure/Cargo.toml
@@ -22,5 +22,7 @@ thiserror = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+indexmap = { workspace = true, features = ["serde"] }
+insta = { workspace = true, features = ["yaml"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 toml = { workspace = true }

--- a/crates/rattler_azure/Cargo.toml
+++ b/crates/rattler_azure/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "rattler_azure"
+version = "0.1.0"
+description = "A crate to streamline interaction with Azure Blob storage for rattler"
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+readme.workspace = true
+
+[features]
+default = []
+# Serde derives for the types of the `azure-options` config table. Pulls in
+# `serde` and `indexmap/serde` only, so config crates can depend on this crate
+# with default features off.
+serde = ["dep:serde", "indexmap/serde"]
+
+[dependencies]
+# The per-container grant table. Order is kept for tables built in memory;
+# deserialized TOML arrives in byte order, since `toml::Table` is a `BTreeMap`.
+indexmap = { workspace = true }
+percent-encoding = { workspace = true }
+secrecy = { workspace = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+thiserror = { workspace = true }
+url = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+toml = { workspace = true }

--- a/crates/rattler_azure/src/channel_url.rs
+++ b/crates/rattler_azure/src/channel_url.rs
@@ -1,0 +1,517 @@
+use std::borrow::Cow;
+
+use url::Url;
+
+use crate::{AzureHost, AzureScheme, AzureUrlError};
+
+/// `Display` and `Debug` mask any SAS signature, so the value is log-safe;
+/// only [`Self::wire`] reproduces the signed form.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct AzureChannelUrl {
+    host: AzureHost,
+
+    path: EncodedPath,
+
+    /// A SAS token may be written inline.
+    query: Option<String>,
+
+    fragment: Option<String>,
+}
+
+const PATH_SEPARATORS: [char; 2] = ['/', '\\'];
+
+const QUERY_OR_FRAGMENT_MARKERS: [char; 2] = ['?', '#'];
+
+const AUTHORITY_TERMINATORS: [char; 4] = ['/', '\\', '?', '#'];
+
+impl AzureChannelUrl {
+    /// Parse and validate an `az://` channel URL.
+    pub fn parse(value: &str) -> Result<Self, AzureUrlError> {
+        let rest = strip_az_scheme(value)
+            .ok_or_else(|| AzureUrlError::InvalidScheme(value.to_string()))?;
+
+        let (authority, tail) = split_authority(rest);
+        let host = AzureHost::parse(authority)?;
+        let url = parse_wire_url(value, authority, tail)?;
+
+        let written_segments = decode_written_path_segments(tail)?;
+        if let Some(segment) = written_segments.iter().find(|s| s.is_dot_segment()) {
+            return Err(AzureUrlError::DotSegmentInPath(segment.raw.to_string()));
+        }
+
+        let segments = url
+            .path_segments()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        if has_empty_segments(&segments) {
+            return Err(AzureUrlError::EmptyPathSegment {
+                path: url.path().to_string(),
+            });
+        }
+        if let Some((segment, escape)) = malformed_percent_escape_in(&segments) {
+            return Err(AzureUrlError::MalformedPercentEscape { segment, escape });
+        }
+
+        Ok(Self {
+            host,
+            path: EncodedPath(url.path().to_string()),
+            query: url.query().map(str::to_string),
+            fragment: url.fragment().map(str::to_string),
+        })
+    }
+
+    /// The `az://` spelling with any SAS signature masked: for display,
+    /// config and comparison, not for sending.
+    pub fn canonical(&self) -> Url {
+        self.spelled("az", Sas::Masked)
+    }
+
+    /// The URL a request is sent to: `scheme://…` with the SAS signature
+    /// intact.
+    pub fn wire(&self, scheme: AzureScheme) -> Url {
+        self.spelled(scheme.as_str(), Sas::Exposed)
+    }
+
+    fn spelled(&self, scheme: &str, sas: Sas) -> Url {
+        let mut text = format!("{scheme}://{}{}", self.host, self.path);
+        if let Some(query) = &self.query {
+            text.push('?');
+            text.push_str(&sas.spell(query));
+        }
+        if let Some(fragment) = &self.fragment {
+            text.push('#');
+            text.push_str(&sas.spell(fragment));
+        }
+
+        Url::parse(&text).expect("a normalized authority, path and query is a valid URL")
+    }
+
+    pub fn host(&self) -> &AzureHost {
+        &self.host
+    }
+}
+
+/// A URL's path in wire form with a leading `/` and percent-encoded
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) struct EncodedPath(String);
+
+impl std::fmt::Display for EncodedPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::fmt::Display for AzureChannelUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.canonical())
+    }
+}
+
+impl std::fmt::Debug for AzureChannelUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("AzureChannelUrl")
+            .field(&self.canonical().as_str())
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Sas {
+    Exposed,
+    Masked,
+}
+
+impl Sas {
+    fn spell<'a>(self, text: &'a str) -> Cow<'a, str> {
+        match self {
+            Self::Exposed => Cow::Borrowed(text),
+            Self::Masked => Cow::Owned(mask_sas_signature(text)),
+        }
+    }
+}
+
+fn mask_sas_signature(query: &str) -> String {
+    query
+        .split('&')
+        .map(|parameter| match parameter.split_once('=') {
+            Some((name, _)) if name.eq_ignore_ascii_case("sig") => format!("{name}=REDACTED"),
+            _ => parameter.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+impl std::str::FromStr for AzureChannelUrl {
+    type Err = AzureUrlError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+fn strip_az_scheme(value: &str) -> Option<&str> {
+    let (scheme, rest) = value.split_once("://")?;
+    scheme.eq_ignore_ascii_case("az").then_some(rest)
+}
+
+fn split_authority(rest: &str) -> (&str, &str) {
+    let authority_end = rest.find(AUTHORITY_TERMINATORS).unwrap_or(rest.len());
+    rest.split_at(authority_end)
+}
+
+/// Parses `<authority><tail>` as an `https` URL
+fn parse_wire_url(value: &str, authority: &str, tail: &str) -> Result<Url, AzureUrlError> {
+    Url::parse(&format!("https://{authority}{tail}")).map_err(|source| AzureUrlError::InvalidUrl {
+        value: value.to_string(),
+        source,
+    })
+}
+
+/// One segment of a url path
+struct WrittenSegment<'a> {
+    raw: &'a str,
+    decoded: String,
+}
+
+impl WrittenSegment<'_> {
+    fn is_dot_segment(&self) -> bool {
+        self.decoded == "." || self.decoded == ".."
+    }
+}
+
+/// Percent-decodes and UTF-8-validates every segment of the url tail
+fn decode_written_path_segments(tail: &str) -> Result<Vec<WrittenSegment<'_>>, AzureUrlError> {
+    let written = match tail
+        .split(QUERY_OR_FRAGMENT_MARKERS)
+        .next()
+        .unwrap_or_default()
+    {
+        "" => "/",
+        path => path,
+    };
+
+    written
+        .trim_start_matches(PATH_SEPARATORS)
+        .split(PATH_SEPARATORS)
+        .map(|segment| {
+            let decoded = percent_encoding::percent_decode_str(segment)
+                .decode_utf8()
+                .map_err(|source| AzureUrlError::NonUtf8Path {
+                    segment: segment.to_string(),
+                    source,
+                })?;
+            Ok(WrittenSegment {
+                raw: segment,
+                decoded: decoded.into_owned(),
+            })
+        })
+        .collect()
+}
+
+/// Whether an empty segment appears anywhere but at the end of the path
+fn has_empty_segments(segments: &[&str]) -> bool {
+    let last = segments.len().saturating_sub(1);
+    segments[..last].iter().any(|segment| segment.is_empty())
+}
+
+/// The first `%` that does not start a valid escape, and the malformed escape
+/// itself
+fn malformed_percent_escape_in(segments: &[&str]) -> Option<(String, String)> {
+    segments.iter().find_map(|segment| {
+        malformed_percent_escape(segment).map(|escape| (segment.to_string(), escape))
+    })
+}
+
+/// The first `%` in `segment` that does not begin a valid escape, with up to
+/// two following characters
+fn malformed_percent_escape(segment: &str) -> Option<String> {
+    let bytes = segment.as_bytes();
+    bytes.iter().enumerate().find_map(|(index, byte)| {
+        if *byte != b'%' {
+            return None;
+        }
+        let escape = bytes
+            .get(index..index + 3)
+            .filter(|escape| escape[1..].iter().all(u8::is_ascii_hexdigit));
+        escape
+            .is_none()
+            .then(|| segment[index..].chars().take(3).collect())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::channel;
+
+    #[track_caller]
+    fn assert_rejects(inputs: &[&str], expected: fn(&AzureUrlError) -> bool) {
+        for input in inputs {
+            match AzureChannelUrl::parse(input) {
+                Ok(_) => panic!("expected a rejection for {input}"),
+                Err(err) => assert!(expected(&err), "wrong error for {input}: {err:?}"),
+            }
+        }
+    }
+
+    #[track_caller]
+    fn assert_canonical_paths(cases: &[(&str, &str)]) {
+        for (input, path) in cases {
+            assert_eq!(channel(input).canonical().path(), *path, "{input}");
+        }
+    }
+
+    #[test]
+    fn parse_requires_the_az_scheme() {
+        assert_rejects(
+            &[
+                "https://acct.blob.core.windows.net/general",
+                "http://acct.blob.core.windows.net/general",
+                "ftp://acct.blob.core.windows.net/general",
+                "acct.blob.core.windows.net/general",
+            ],
+            |err| matches!(err, AzureUrlError::InvalidScheme(_)),
+        );
+    }
+
+    #[test]
+    fn canonical_and_wire_round_trip() {
+        let channel =
+            AzureChannelUrl::parse("az://acct.blob.core.windows.net/general/noarch").unwrap();
+
+        assert_eq!(
+            channel.canonical().as_str(),
+            "az://acct.blob.core.windows.net/general/noarch"
+        );
+        assert_eq!(
+            channel.wire(AzureScheme::Https).as_str(),
+            "https://acct.blob.core.windows.net/general/noarch"
+        );
+        assert_eq!(
+            channel.wire(AzureScheme::Http).as_str(),
+            "http://acct.blob.core.windows.net/general/noarch"
+        );
+        assert_eq!(channel.to_string(), channel.canonical().to_string());
+        assert_eq!(
+            channel,
+            channel
+                .canonical()
+                .as_str()
+                .parse::<AzureChannelUrl>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn spellings_cannot_disagree() {
+        for input in [
+            "az://acct.blob.core.windows.net/general/noarch",
+            "az://127.0.0.1:10000/devstoreaccount1/general",
+            "az://acct.blob.core.windows.net/general/with%20space?sv=token",
+            "az://[::1]:10000/devstoreaccount1/general",
+            "az://azurite.local:443/devstoreaccount1/general",
+            "az://azurite.local:80/devstoreaccount1/general",
+        ] {
+            let channel = AzureChannelUrl::parse(input).unwrap();
+            let canonical = channel.canonical();
+            for scheme in [AzureScheme::Https, AzureScheme::Http] {
+                let wire = channel.wire(scheme);
+                assert_eq!(wire.scheme(), scheme.as_str());
+                assert_eq!(canonical.host_str(), wire.host_str(), "{input}");
+                assert_eq!(canonical.path(), wire.path(), "{input}");
+                assert_eq!(canonical.query(), wire.query(), "{input}");
+
+                let default = match scheme {
+                    AzureScheme::Https => 443,
+                    AzureScheme::Http => 80,
+                };
+                assert_eq!(
+                    wire.port_or_known_default(),
+                    Some(canonical.port().unwrap_or(default)),
+                    "{input} over {scheme}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_written_default_port_survives() {
+        let channel =
+            AzureChannelUrl::parse("az://azurite.local:443/devstoreaccount1/general").unwrap();
+
+        assert_eq!(channel.host().to_string(), "azurite.local:443");
+        assert_eq!(channel.host().port(), Some(443));
+        assert_eq!(
+            channel.canonical().as_str(),
+            "az://azurite.local:443/devstoreaccount1/general"
+        );
+        assert_eq!(
+            channel.wire(AzureScheme::Http).as_str(),
+            "http://azurite.local:443/devstoreaccount1/general"
+        );
+        assert_eq!(
+            channel.wire(AzureScheme::Https).as_str(),
+            "https://azurite.local/devstoreaccount1/general"
+        );
+
+        // a host on 443 is not the same endpoint as the same host with
+        // no port, because the scheme that would make them equal is not known here.
+        let no_port =
+            AzureChannelUrl::parse("az://azurite.local/devstoreaccount1/general").unwrap();
+        assert_ne!(channel, no_port);
+        assert_ne!(channel.host(), no_port.host());
+    }
+
+    #[test]
+    fn host_keeps_a_non_default_port() {
+        let emulator =
+            AzureChannelUrl::parse("az://127.0.0.1:10000/devstoreaccount1/general").unwrap();
+        assert_eq!(emulator.host().to_string(), "127.0.0.1:10000");
+        assert_eq!(
+            emulator.wire(AzureScheme::Http).as_str(),
+            "http://127.0.0.1:10000/devstoreaccount1/general"
+        );
+        assert_eq!(
+            emulator.canonical().as_str(),
+            "az://127.0.0.1:10000/devstoreaccount1/general"
+        );
+
+        let azure = AzureChannelUrl::parse("az://acct.blob.core.windows.net/general").unwrap();
+        assert_eq!(azure.host().to_string(), "acct.blob.core.windows.net");
+        assert_eq!(azure.host().port(), None);
+    }
+
+    #[test]
+    fn a_rewritten_path_is_rejected() {
+        assert_rejects(
+            &[
+                "az://acct.blob.core.windows.net/general/%2e%2e/%2e%2e/othercontainer/x",
+                "az://127.0.0.1:10000/devstoreaccount1/general/%2e%2e/%2e%2e/otheraccount/othercontainer",
+                "az://acct.blob.core.windows.net/general/../../othercontainer",
+                "az://acct.blob.core.windows.net/general/./noarch",
+                "az://acct.blob.core.windows.net/general/%2E%2E/othercontainer",
+            ],
+            |err| matches!(err, AzureUrlError::DotSegmentInPath(_)),
+        );
+    }
+
+    #[test]
+    fn an_empty_segment_is_rejected() {
+        assert_rejects(
+            &[
+                "az://acct.blob.core.windows.net//general/noarch",
+                "az://acct.blob.core.windows.net/general//noarch",
+                "az://127.0.0.1:10000//devstoreaccount1/general",
+            ],
+            |err| matches!(err, AzureUrlError::EmptyPathSegment { .. }),
+        );
+
+        assert_canonical_paths(&[("az://acct.blob.core.windows.net/general/", "/general/")]);
+    }
+
+    #[test]
+    fn a_malformed_percent_escape_is_rejected() {
+        assert_rejects(
+            &[
+                "az://acct.blob.core.windows.net/general/gen%eral",
+                "az://acct.blob.core.windows.net/general/100%",
+                "az://acct.blob.core.windows.net/general/%zz",
+            ],
+            |err| matches!(err, AzureUrlError::MalformedPercentEscape { .. }),
+        );
+    }
+
+    #[test]
+    fn unrewritten_paths_still_parse() {
+        assert_canonical_paths(&[
+            (
+                "az://acct.blob.core.windows.net/general/prefix",
+                "/general/prefix",
+            ),
+            ("az://acct.blob.core.windows.net/general/", "/general/"),
+            ("az://acct.blob.core.windows.net/", "/"),
+            ("az://acct.blob.core.windows.net", "/"),
+            (
+                "az://acct.blob.core.windows.net/general/with%20space",
+                "/general/with%20space",
+            ),
+            (
+                "az://acct.blob.core.windows.net/general/p?sv=token#frag",
+                "/general/p",
+            ),
+            // A dot inside a segment is not a dot segment.
+            (
+                "az://acct.blob.core.windows.net/general/..hidden/...",
+                "/general/..hidden/...",
+            ),
+        ]);
+    }
+
+    #[test]
+    fn segments_that_cannot_name_a_blob_are_rejected() {
+        assert_rejects(
+            &[
+                "az://acct.blob.core.windows.net/general/%ff",
+                // only becomes invalid UTF-8 once the parser encodes the raw character
+                "az://acct.blob.core.windows.net/general/caf%C3é",
+                "az://acct.blob.core.windows.net/general/%C3é",
+            ],
+            |err| matches!(err, AzureUrlError::NonUtf8Path { .. }),
+        );
+
+        assert_canonical_paths(&[
+            (
+                "az://acct.blob.core.windows.net/general/café",
+                "/general/caf%C3%A9",
+            ),
+            (
+                "az://acct.blob.core.windows.net/general/with space",
+                "/general/with%20space",
+            ),
+            (
+                "az://acct.blob.core.windows.net/general/caf%C3%A9",
+                "/general/caf%C3%A9",
+            ),
+        ]);
+    }
+}
+
+#[cfg(test)]
+mod debug_redaction_tests {
+    use super::*;
+    use crate::test_support::channel;
+
+    fn masked_spellings(channel: &AzureChannelUrl) -> [String; 3] {
+        [
+            channel.canonical().to_string(),
+            channel.to_string(),
+            format!("{channel:?}"),
+        ]
+    }
+
+    #[test]
+    fn only_the_wire_spelling_carries_the_signature() {
+        let signed =
+            channel("az://acct.blob.core.windows.net/general/p?sv=2024-11-04&sig=SECRETSIG&se=z");
+
+        for shown in masked_spellings(&signed) {
+            assert!(!shown.contains("SECRETSIG"), "signature leaked: {shown}");
+            assert!(shown.contains("sv=2024-11-04"), "over-redacted: {shown}");
+            assert!(shown.contains("se=z"), "over-redacted: {shown}");
+        }
+
+        let fragmented = channel("az://acct.blob.core.windows.net/general/p?sv=1#sig=SECRETFRAG");
+        for shown in masked_spellings(&fragmented) {
+            assert!(!shown.contains("SECRETFRAG"), "signature leaked: {shown}");
+        }
+
+        assert!(
+            signed
+                .wire(AzureScheme::Https)
+                .to_string()
+                .contains("sig=SECRETSIG"),
+            "the wire spelling must keep the signature that authenticates the request"
+        );
+    }
+}

--- a/crates/rattler_azure/src/channel_url.rs
+++ b/crates/rattler_azure/src/channel_url.rs
@@ -4,8 +4,7 @@ use url::Url;
 
 use crate::{AzureHost, AzureScheme, AzureUrlError};
 
-/// `Display` and `Debug` mask any SAS signature, so the value is log-safe;
-/// only [`Self::wire`] reproduces the signed form.
+/// `Display` and `Debug` mask any SAS signature, so the value is log-safe.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AzureChannelUrl {
     host: AzureHost,

--- a/crates/rattler_azure/src/channel_url.rs
+++ b/crates/rattler_azure/src/channel_url.rs
@@ -244,34 +244,67 @@ mod tests {
     use super::*;
     use crate::test_support::channel;
 
-    #[track_caller]
-    fn assert_rejects(inputs: &[&str], expected: fn(&AzureUrlError) -> bool) {
-        for input in inputs {
-            match AzureChannelUrl::parse(input) {
-                Ok(_) => panic!("expected a rejection for {input}"),
-                Err(err) => assert!(expected(&err), "wrong error for {input}: {err:?}"),
-            }
-        }
-    }
+    #[test]
+    fn rejected_urls() {
+        let inputs = [
+            // not the az scheme
+            "https://acct.blob.core.windows.net/general",
+            "http://acct.blob.core.windows.net/general",
+            "ftp://acct.blob.core.windows.net/general",
+            "acct.blob.core.windows.net/general",
+            // dot segments rewrite the path
+            "az://acct.blob.core.windows.net/general/%2e%2e/%2e%2e/othercontainer/x",
+            "az://127.0.0.1:10000/devstoreaccount1/general/%2e%2e/%2e%2e/otheraccount/othercontainer",
+            "az://acct.blob.core.windows.net/general/../../othercontainer",
+            "az://acct.blob.core.windows.net/general/./noarch",
+            "az://acct.blob.core.windows.net/general/%2E%2E/othercontainer",
+            // empty segments
+            "az://acct.blob.core.windows.net//general/noarch",
+            "az://acct.blob.core.windows.net/general//noarch",
+            "az://127.0.0.1:10000//devstoreaccount1/general",
+            // malformed percent escapes
+            "az://acct.blob.core.windows.net/general/gen%eral",
+            "az://acct.blob.core.windows.net/general/100%",
+            "az://acct.blob.core.windows.net/general/%zz",
+            // segments that decode to invalid UTF-8; the second only becomes
+            // invalid once the parser encodes the raw character
+            "az://acct.blob.core.windows.net/general/%ff",
+            "az://acct.blob.core.windows.net/general/caf%C3é",
+            "az://acct.blob.core.windows.net/general/%C3é",
+        ];
 
-    #[track_caller]
-    fn assert_canonical_paths(cases: &[(&str, &str)]) {
-        for (input, path) in cases {
-            assert_eq!(channel(input).canonical().path(), *path, "{input}");
-        }
+        let rejections: indexmap::IndexMap<&str, String> = inputs
+            .iter()
+            .map(|input| match AzureChannelUrl::parse(input) {
+                Ok(_) => panic!("expected a rejection for {input}"),
+                Err(err) => (*input, err.to_string()),
+            })
+            .collect();
+        insta::assert_yaml_snapshot!(rejections);
     }
 
     #[test]
-    fn parse_requires_the_az_scheme() {
-        assert_rejects(
-            &[
-                "https://acct.blob.core.windows.net/general",
-                "http://acct.blob.core.windows.net/general",
-                "ftp://acct.blob.core.windows.net/general",
-                "acct.blob.core.windows.net/general",
-            ],
-            |err| matches!(err, AzureUrlError::InvalidScheme(_)),
-        );
+    fn accepted_urls_canonicalize() {
+        let inputs = [
+            "az://acct.blob.core.windows.net/general/prefix",
+            "az://acct.blob.core.windows.net/general/",
+            "az://acct.blob.core.windows.net/",
+            "az://acct.blob.core.windows.net",
+            "az://acct.blob.core.windows.net/general/p?sv=token#frag",
+            // a dot inside a segment is not a dot segment
+            "az://acct.blob.core.windows.net/general/..hidden/...",
+            // spellings normalize to percent-encoded UTF-8
+            "az://acct.blob.core.windows.net/general/café",
+            "az://acct.blob.core.windows.net/general/with space",
+            "az://acct.blob.core.windows.net/general/with%20space",
+            "az://acct.blob.core.windows.net/general/caf%C3%A9",
+        ];
+
+        let canonical: indexmap::IndexMap<&str, String> = inputs
+            .iter()
+            .map(|input| (*input, channel(input).canonical().to_string()))
+            .collect();
+        insta::assert_yaml_snapshot!(canonical);
     }
 
     #[test]
@@ -379,100 +412,6 @@ mod tests {
         let azure = AzureChannelUrl::parse("az://acct.blob.core.windows.net/general").unwrap();
         assert_eq!(azure.host().to_string(), "acct.blob.core.windows.net");
         assert_eq!(azure.host().port(), None);
-    }
-
-    #[test]
-    fn a_rewritten_path_is_rejected() {
-        assert_rejects(
-            &[
-                "az://acct.blob.core.windows.net/general/%2e%2e/%2e%2e/othercontainer/x",
-                "az://127.0.0.1:10000/devstoreaccount1/general/%2e%2e/%2e%2e/otheraccount/othercontainer",
-                "az://acct.blob.core.windows.net/general/../../othercontainer",
-                "az://acct.blob.core.windows.net/general/./noarch",
-                "az://acct.blob.core.windows.net/general/%2E%2E/othercontainer",
-            ],
-            |err| matches!(err, AzureUrlError::DotSegmentInPath(_)),
-        );
-    }
-
-    #[test]
-    fn an_empty_segment_is_rejected() {
-        assert_rejects(
-            &[
-                "az://acct.blob.core.windows.net//general/noarch",
-                "az://acct.blob.core.windows.net/general//noarch",
-                "az://127.0.0.1:10000//devstoreaccount1/general",
-            ],
-            |err| matches!(err, AzureUrlError::EmptyPathSegment { .. }),
-        );
-
-        assert_canonical_paths(&[("az://acct.blob.core.windows.net/general/", "/general/")]);
-    }
-
-    #[test]
-    fn a_malformed_percent_escape_is_rejected() {
-        assert_rejects(
-            &[
-                "az://acct.blob.core.windows.net/general/gen%eral",
-                "az://acct.blob.core.windows.net/general/100%",
-                "az://acct.blob.core.windows.net/general/%zz",
-            ],
-            |err| matches!(err, AzureUrlError::MalformedPercentEscape { .. }),
-        );
-    }
-
-    #[test]
-    fn unrewritten_paths_still_parse() {
-        assert_canonical_paths(&[
-            (
-                "az://acct.blob.core.windows.net/general/prefix",
-                "/general/prefix",
-            ),
-            ("az://acct.blob.core.windows.net/general/", "/general/"),
-            ("az://acct.blob.core.windows.net/", "/"),
-            ("az://acct.blob.core.windows.net", "/"),
-            (
-                "az://acct.blob.core.windows.net/general/with%20space",
-                "/general/with%20space",
-            ),
-            (
-                "az://acct.blob.core.windows.net/general/p?sv=token#frag",
-                "/general/p",
-            ),
-            // A dot inside a segment is not a dot segment.
-            (
-                "az://acct.blob.core.windows.net/general/..hidden/...",
-                "/general/..hidden/...",
-            ),
-        ]);
-    }
-
-    #[test]
-    fn segments_that_cannot_name_a_blob_are_rejected() {
-        assert_rejects(
-            &[
-                "az://acct.blob.core.windows.net/general/%ff",
-                // only becomes invalid UTF-8 once the parser encodes the raw character
-                "az://acct.blob.core.windows.net/general/caf%C3é",
-                "az://acct.blob.core.windows.net/general/%C3é",
-            ],
-            |err| matches!(err, AzureUrlError::NonUtf8Path { .. }),
-        );
-
-        assert_canonical_paths(&[
-            (
-                "az://acct.blob.core.windows.net/general/café",
-                "/general/caf%C3%A9",
-            ),
-            (
-                "az://acct.blob.core.windows.net/general/with space",
-                "/general/with%20space",
-            ),
-            (
-                "az://acct.blob.core.windows.net/general/caf%C3%A9",
-                "/general/caf%C3%A9",
-            ),
-        ]);
     }
 }
 

--- a/crates/rattler_azure/src/credentials.rs
+++ b/crates/rattler_azure/src/credentials.rs
@@ -1,0 +1,25 @@
+use secrecy::SecretString;
+
+#[derive(Clone, Debug)]
+pub enum AzureCredentials {
+    AccountKey(SecretString),
+    SasToken(SecretString),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_never_prints_secret() {
+        for creds in [
+            AzureCredentials::AccountKey("supersecretkey".into()),
+            AzureCredentials::SasToken("sig=deadbeef".into()),
+        ] {
+            let out = format!("{creds:?}");
+            assert!(out.contains("REDACTED"), "not redacted: {out}");
+            assert!(!out.contains("supersecret"));
+            assert!(!out.contains("deadbeef"));
+        }
+    }
+}

--- a/crates/rattler_azure/src/credentials.rs
+++ b/crates/rattler_azure/src/credentials.rs
@@ -1,5 +1,7 @@
 use secrecy::SecretString;
 
+/// A credential for authenticating blob requests. `Debug` redacts the
+/// secret, so the value is log-safe.
 #[derive(Clone, Debug)]
 pub enum AzureCredentials {
     AccountKey(SecretString),

--- a/crates/rattler_azure/src/error.rs
+++ b/crates/rattler_azure/src/error.rs
@@ -1,3 +1,4 @@
+/// Why a channel URL, host, name or endpoint key failed to parse.
 #[derive(Debug, thiserror::Error)]
 pub enum AzureUrlError {
     #[error("no host in Azure blob URL")]

--- a/crates/rattler_azure/src/error.rs
+++ b/crates/rattler_azure/src/error.rs
@@ -77,8 +77,6 @@ pub enum AzureUrlError {
         source: std::str::Utf8Error,
     },
 
-    #[error(
-        "Azure blob channel URL must use the `az://` scheme, got `{0}`"
-    )]
+    #[error("Azure blob channel URL must use the `az://` scheme, got `{0}`")]
     InvalidScheme(String),
 }

--- a/crates/rattler_azure/src/error.rs
+++ b/crates/rattler_azure/src/error.rs
@@ -1,0 +1,84 @@
+#[derive(Debug, thiserror::Error)]
+pub enum AzureUrlError {
+    #[error("no host in Azure blob URL")]
+    NoHost,
+
+    #[error(
+        "Azure blob URL must not contain userinfo (`user:pass@host`), userinfo is invalid in blob URLs"
+    )]
+    UserInfoNotAllowed,
+
+    #[error("`{authority}` is not a valid Azure host: {reason}; expected `host` or `host:port`")]
+    InvalidHostAuthority { authority: String, reason: String },
+
+    #[error(
+        "Azure blob URL host `{0}` is not a dotted domain of the form `<account>.blob.<suffix>`, \
+         so its first label cannot be a storage account; such a host can only be addressed \
+         path-style, with the account as the first path segment"
+    )]
+    InvalidHost(String),
+
+    #[error(
+        "`{0}` is not a valid Azure endpoint key: a key is a channel URL prefix up to the \
+         container, so it is spelled `<host>` or `<host>/<account>` and nothing more"
+    )]
+    InvalidKey(String),
+
+    #[error("no container in Azure blob URL")]
+    NoContainer,
+
+    #[error(
+        "`{0}` is not a valid Azure storage account name: account names are 3-24 characters of \
+         lowercase letters and digits only"
+    )]
+    InvalidAccountName(String),
+
+    #[error(
+        "`{0}` is not a valid Azure blob container name: container names are 3-63 characters of \
+         lowercase letters, digits and hyphens, must start and end with a letter or digit, and \
+         must not contain consecutive hyphens"
+    )]
+    InvalidContainerName(String),
+
+    #[error("`{value}` is not a valid URL")]
+    InvalidUrl {
+        value: String,
+        #[source]
+        source: url::ParseError,
+    },
+
+    #[error(
+        "Azure blob channel URL segment `{0}` is a relative path segment; a channel URL must name \
+         the container it addresses directly, so write the path without `.` or `..`"
+    )]
+    DotSegmentInPath(String),
+
+    #[error(
+        "Azure blob channel URL path `{path}` has an empty segment; a doubled `/` names nothing, \
+         so write the path with single separators"
+    )]
+    EmptyPathSegment { path: String },
+
+    #[error(
+        "Azure blob channel URL segment `{segment}` contains `{escape}`, which is not a valid \
+         percent-escape; write a literal `%` as `%25`"
+    )]
+    MalformedPercentEscape { segment: String, escape: String },
+
+    /// Blob names are UTF-8. Decoding lossily would substitute U+FFFD and silently
+    /// address a different blob than the URL names.
+    #[error(
+        "Azure blob channel URL segment `{segment}` percent-decodes to bytes that are not UTF-8, \
+         so it cannot name a blob"
+    )]
+    NonUtf8Path {
+        segment: String,
+        #[source]
+        source: std::str::Utf8Error,
+    },
+
+    #[error(
+        "Azure blob channel URL must use the `az://` scheme, got `{0}`"
+    )]
+    InvalidScheme(String),
+}

--- a/crates/rattler_azure/src/host.rs
+++ b/crates/rattler_azure/src/host.rs
@@ -109,10 +109,10 @@ impl AzureHost {
         self.port
     }
 
-    /// Whether the host is Azure's own blob endpoint in some cloud.
+    /// Whether the host is one of Azure's own blob endpoints.
     ///
-    /// Only a `true` proves anything: a proxy or private endpoint in front of
-    /// real Azure answers `false`, so a `false` proves nothing.
+    /// A proxy or private endpoint in front of real Azure returns `false`,
+    /// so `false` does not mean the host is not Azure.
     pub fn is_known_azure_blob_endpoint(&self) -> bool {
         // `blob.` + each cloud's `StorageEndpointSuffix`:
         // https://learn.microsoft.com/en-us/azure/storage/common/storage-powershell-independent-clouds#endpoint-suffix

--- a/crates/rattler_azure/src/host.rs
+++ b/crates/rattler_azure/src/host.rs
@@ -2,6 +2,7 @@ use url::Url;
 
 use crate::AzureUrlError;
 
+/// A validated and normalized `host[:port]` authority.
 #[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "serde",

--- a/crates/rattler_azure/src/host.rs
+++ b/crates/rattler_azure/src/host.rs
@@ -223,28 +223,8 @@ mod tests {
     }
 
     #[test]
-    fn empty_host_labels_are_rejected() {
-        for host in [
-            "acct..blob.core.windows.net",
-            "acct.blob.example..",
-            ".example",
-        ] {
-            assert!(
-                matches!(
-                    AzureHost::parse(host),
-                    Err(AzureUrlError::InvalidHostAuthority { .. })
-                ),
-                "expected a rejection for {host}"
-            );
-        }
-    }
-
-    #[test]
     fn host_rejects_anything_that_is_not_a_bare_authority() {
-        // Labels of 60, so length is the only rule under test.
-        let label = "a".repeat(60);
-        let too_long = format!("{}.blob.example", [label.as_str(); 8].join("."));
-        for authority in [
+        let inputs = [
             "acct.blob.core.windows.net/general",
             "acct.blob.core.windows.net?sv=token",
             "acct.blob.core.windows.net#frag",
@@ -255,13 +235,28 @@ mod tests {
             "acct.blob.core.windows.net:0",
             "[::1]:",
             "[::1]:0",
-            &too_long,
-        ] {
-            assert!(
-                AzureHost::parse(authority).is_err(),
-                "expected a rejection for {authority:?}"
-            );
-        }
+            // empty labels
+            "acct..blob.core.windows.net",
+            "acct.blob.example..",
+            ".example",
+        ];
+
+        let rejections: indexmap::IndexMap<&str, String> = inputs
+            .iter()
+            .map(|authority| match AzureHost::parse(authority) {
+                Ok(_) => panic!("expected a rejection for {authority:?}"),
+                Err(err) => (*authority, err.to_string()),
+            })
+            .collect();
+        insta::assert_yaml_snapshot!(rejections);
+    }
+
+    #[test]
+    fn host_length_is_bounded() {
+        // Labels of 60, so length is the only rule under test.
+        let label = "a".repeat(60);
+        let too_long = format!("{}.blob.example", [label.as_str(); 8].join("."));
+        assert!(AzureHost::parse(&too_long).is_err());
 
         // A name right at the limit still parses, so the check bounds the length
         // rather than the number of labels.

--- a/crates/rattler_azure/src/host.rs
+++ b/crates/rattler_azure/src/host.rs
@@ -1,0 +1,276 @@
+use url::Url;
+
+use crate::AzureUrlError;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(try_from = "String", into = "String")
+)]
+pub struct AzureHost {
+    host: url::Host,
+    port: Option<u16>,
+}
+
+impl AzureHost {
+    pub fn parse(authority: &str) -> Result<Self, AzureUrlError> {
+        if authority.contains('@') {
+            return Err(AzureUrlError::UserInfoNotAllowed);
+        }
+        if authority.contains(['/', '\\', '?', '#']) {
+            return Err(AzureUrlError::InvalidHostAuthority {
+                authority: authority.to_string(),
+                reason: "it carries a path, query or fragment".to_string(),
+            });
+        }
+
+        // parse as https to properly handle hosts but this drops `:443`, so parse as `az` for port
+        let normalized = Self::parse_as(authority, "https")?;
+        let verbatim = Self::parse_as(authority, "az")?;
+
+        let port_reason = match (Self::written_port(authority), verbatim.port()) {
+            (Some(""), _) => Some("its port is empty"),
+            (_, Some(0)) => Some("port 0 cannot be connected to"),
+            _ => None,
+        };
+
+        if let Some(reason) = port_reason {
+            return Err(AzureUrlError::InvalidHostAuthority {
+                authority: authority.to_string(),
+                reason: reason.to_string(),
+            });
+        }
+
+        let host = normalized.host().ok_or(AzureUrlError::NoHost)?.to_owned();
+        Self::normalized(host, verbatim.port(), authority)
+    }
+
+    /// The text after the authority's last `:`, unless that text is an IPv6 literal
+    fn written_port(authority: &str) -> Option<&str> {
+        let (_, port) = authority.rsplit_once(':')?;
+        (!port.ends_with(']')).then_some(port)
+    }
+
+    fn parse_as(authority: &str, scheme: &str) -> Result<Url, AzureUrlError> {
+        Url::parse(&format!("{scheme}://{authority}")).map_err(|err| {
+            AzureUrlError::InvalidHostAuthority {
+                authority: authority.to_string(),
+                reason: err.to_string(),
+            }
+        })
+    }
+
+    fn normalized(
+        host: url::Host,
+        port: Option<u16>,
+        authority: &str,
+    ) -> Result<Self, AzureUrlError> {
+        const DNS_NAME_LIMIT: usize = 253;
+
+        let url::Host::Domain(domain) = &host else {
+            return Ok(Self { host, port });
+        };
+
+        let host = url::Host::parse(domain.strip_suffix('.').unwrap_or(domain)).map_err(|err| {
+            AzureUrlError::InvalidHostAuthority {
+                authority: authority.to_string(),
+                reason: err.to_string(),
+            }
+        })?;
+
+        if let url::Host::Domain(domain) = &host {
+            if domain.split('.').any(str::is_empty) {
+                return Err(AzureUrlError::InvalidHostAuthority {
+                    authority: authority.to_string(),
+                    reason: "one of its labels is empty".to_string(),
+                });
+            }
+
+            if domain.len() > DNS_NAME_LIMIT {
+                return Err(AzureUrlError::InvalidHostAuthority {
+                    authority: authority.to_string(),
+                    reason: format!(
+                        "it is {} characters long, over the {DNS_NAME_LIMIT}-character limit DNS \
+                         puts on a name",
+                        domain.len()
+                    ),
+                });
+            }
+        }
+        Ok(Self { host, port })
+    }
+
+    pub fn host(&self) -> &url::Host {
+        &self.host
+    }
+
+    pub fn port(&self) -> Option<u16> {
+        self.port
+    }
+
+    /// Whether the host is Azure's own blob endpoint in some cloud.
+    ///
+    /// Only a `true` proves anything: a proxy or private endpoint in front of
+    /// real Azure answers `false`, so a `false` proves nothing.
+    pub fn is_known_azure_blob_endpoint(&self) -> bool {
+        // `blob.` + each cloud's `StorageEndpointSuffix`:
+        // https://learn.microsoft.com/en-us/azure/storage/common/storage-powershell-independent-clouds#endpoint-suffix
+        // The German cloud's `core.cloudapi.de` is left out because that cloud closed in 2021:
+        // https://learn.microsoft.com/en-us/previous-versions/azure/germany/germany-welcome
+        const SUFFIXES: &[&str] = &[
+            "blob.core.windows.net",
+            "blob.core.usgovcloudapi.net",
+            "blob.core.chinacloudapi.cn",
+        ];
+
+        let url::Host::Domain(domain) = &self.host else {
+            return false;
+        };
+
+        SUFFIXES.iter().any(|suffix| {
+            domain
+                .strip_suffix(suffix)
+                // otherwise we could match `notblob.core.windows.net`.
+                .is_some_and(|prefix| prefix.ends_with('.'))
+        })
+    }
+}
+
+impl std::fmt::Display for AzureHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.host)?;
+        if let Some(port) = self.port {
+            write!(f, ":{port}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for AzureHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AzureHost({:?})", self.to_string())
+    }
+}
+
+impl std::str::FromStr for AzureHost {
+    type Err = AzureUrlError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for AzureHost {
+    type Error = AzureUrlError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(&value)
+    }
+}
+
+impl From<AzureHost> for String {
+    fn from(host: AzureHost) -> Self {
+        host.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn userinfo_is_rejected() {
+        assert!(matches!(
+            crate::AzureChannelUrl::parse("az://acct.blob.core.windows.net@evil.example/general"),
+            Err(AzureUrlError::UserInfoNotAllowed)
+        ));
+        assert!(matches!(
+            AzureHost::parse("acct.blob.core.windows.net@evil.example"),
+            Err(AzureUrlError::UserInfoNotAllowed)
+        ));
+    }
+
+    #[test]
+    fn known_azure_endpoints_are_matched_on_a_label_boundary() {
+        for host in [
+            "acct.blob.core.windows.net",
+            "acct.blob.core.usgovcloudapi.net",
+            "acct.blob.core.chinacloudapi.cn",
+        ] {
+            assert!(
+                AzureHost::parse(host)
+                    .unwrap()
+                    .is_known_azure_blob_endpoint(),
+                "{host}"
+            );
+        }
+
+        for host in [
+            "notblob.core.windows.net",             // no label boundary
+            "blob.core.windows.net",                // the suffix alone carries no account
+            "acct.blob.core.windows.net.evil.test", // suffix in the middle
+            "127.0.0.1:10000",
+            "azurite",
+        ] {
+            assert!(
+                !AzureHost::parse(host)
+                    .unwrap()
+                    .is_known_azure_blob_endpoint(),
+                "{host}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_host_labels_are_rejected() {
+        for host in [
+            "acct..blob.core.windows.net",
+            "acct.blob.example..",
+            ".example",
+        ] {
+            assert!(
+                matches!(
+                    AzureHost::parse(host),
+                    Err(AzureUrlError::InvalidHostAuthority { .. })
+                ),
+                "expected a rejection for {host}"
+            );
+        }
+    }
+
+    #[test]
+    fn host_rejects_anything_that_is_not_a_bare_authority() {
+        // Labels of 60, so length is the only rule under test.
+        let label = "a".repeat(60);
+        let too_long = format!("{}.blob.example", [label.as_str(); 8].join("."));
+        for authority in [
+            "acct.blob.core.windows.net/general",
+            "acct.blob.core.windows.net?sv=token",
+            "acct.blob.core.windows.net#frag",
+            "https://acct.blob.core.windows.net",
+            "",
+            "acct.blob.core.windows.net:notaport",
+            "acct.blob.core.windows.net:",
+            "acct.blob.core.windows.net:0",
+            "[::1]:",
+            "[::1]:0",
+            &too_long,
+        ] {
+            assert!(
+                AzureHost::parse(authority).is_err(),
+                "expected a rejection for {authority:?}"
+            );
+        }
+
+        // A name right at the limit still parses, so the check bounds the length
+        // rather than the number of labels.
+        let at_limit = format!(
+            "{}.{}.blob.example",
+            [label.as_str(); 3].join("."),
+            "a".repeat(57)
+        );
+        assert_eq!(at_limit.len(), 253);
+        assert!(AzureHost::parse(&at_limit).is_ok());
+    }
+}

--- a/crates/rattler_azure/src/lib.rs
+++ b/crates/rattler_azure/src/lib.rs
@@ -1,0 +1,25 @@
+//! Parsing Azure Blob channel URLs and minting short-lived credentials for them.
+//!
+//! # Channel URLs
+//!
+//! A channel is written `az://host[:port]/…` and parsed into an
+//! [`AzureChannelUrl`], which validates and normalizes the spelling so
+//! equivalent URLs compare equal.
+
+mod channel_url;
+mod credentials;
+mod error;
+mod host;
+mod names;
+pub mod options;
+#[cfg(test)]
+mod test_support;
+
+pub use channel_url::AzureChannelUrl;
+pub use credentials::AzureCredentials;
+pub use error::AzureUrlError;
+pub use host::AzureHost;
+pub use names::{AccountName, ContainerName};
+pub use options::{Auth, AzureEndpointOptions, AzureFetchOptions, AzureScheme};
+
+pub use secrecy::{ExposeSecret, SecretString};

--- a/crates/rattler_azure/src/names.rs
+++ b/crates/rattler_azure/src/names.rs
@@ -1,0 +1,102 @@
+use crate::AzureUrlError;
+
+/// A name that satisfies Azure's storage-account rules: 3-24 characters,
+/// lowercase letters and digits only.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AccountName(String);
+
+impl AccountName {
+    pub fn new(name: &str) -> Result<Self, AzureUrlError> {
+        let valid = (3..=24).contains(&name.len())
+            && name
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+
+        if valid {
+            Ok(Self(name.to_string()))
+        } else {
+            Err(AzureUrlError::InvalidAccountName(name.to_string()))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for AccountName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A name that satisfies Azure's container rules: 3-63 characters of
+/// lowercase letters, digits and non-consecutive interior hyphens.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(try_from = "String", into = "String")
+)]
+pub struct ContainerName(String);
+
+impl ContainerName {
+    pub fn new(name: &str) -> Result<Self, AzureUrlError> {
+        let valid = (3..=63).contains(&name.len())
+            && name
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            && !name.starts_with('-')
+            && !name.ends_with('-')
+            && !name.contains("--");
+
+        if valid {
+            Ok(Self(name.to_string()))
+        } else {
+            Err(AzureUrlError::InvalidContainerName(name.to_string()))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ContainerName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::str::FromStr for ContainerName {
+    type Err = AzureUrlError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for ContainerName {
+    type Error = AzureUrlError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(&value)
+    }
+}
+
+impl From<ContainerName> for String {
+    fn from(container: ContainerName) -> Self {
+        container.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_components_are_rejected() {
+        assert!(AccountName::new("").is_err());
+        assert!(ContainerName::new("").is_err());
+    }
+}

--- a/crates/rattler_azure/src/options.rs
+++ b/crates/rattler_azure/src/options.rs
@@ -1,0 +1,213 @@
+//! Per-endpoint options: which containers a credential may attach to, and the
+//! wire scheme.
+
+use crate::ContainerName;
+
+/// Whether credentials may attach to requests for a container.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(from = "bool", into = "bool")
+)]
+pub enum Auth {
+    /// Send requests unsigned
+    #[default]
+    Anonymous,
+
+    /// Resolve a credential and sign with it
+    DefaultChain,
+}
+
+impl From<bool> for Auth {
+    fn from(value: bool) -> Self {
+        if value {
+            Auth::DefaultChain
+        } else {
+            Auth::Anonymous
+        }
+    }
+}
+
+impl From<Auth> for bool {
+    fn from(value: Auth) -> Self {
+        matches!(value, Auth::DefaultChain)
+    }
+}
+
+impl Auth {
+    pub fn is_granted(self) -> bool {
+        matches!(self, Auth::DefaultChain)
+    }
+}
+
+/// The wire scheme an `az://` channel URL is rewritten to when a request is sent.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(rename_all = "lowercase")
+)]
+pub enum AzureScheme {
+    #[default]
+    Https,
+
+    Http,
+}
+
+impl AzureScheme {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AzureScheme::Https => "https",
+            AzureScheme::Http => "http",
+        }
+    }
+}
+
+impl std::fmt::Display for AzureScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// What the fetch middleware needs to send a request.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AzureFetchOptions {
+    pub auth: Auth,
+
+    pub scheme: AzureScheme,
+}
+
+/// The options of one endpoint entry.
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(rename_all = "kebab-case", default, deny_unknown_fields)
+)]
+pub struct AzureEndpointOptions {
+    scheme: AzureScheme,
+
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "indexmap::IndexMap::is_empty")
+    )]
+    auth: indexmap::IndexMap<ContainerName, Auth>,
+}
+
+impl AzureEndpointOptions {
+    pub fn new(auth: impl IntoIterator<Item = (ContainerName, Auth)>, scheme: AzureScheme) -> Self {
+        Self {
+            scheme,
+            auth: auth.into_iter().collect(),
+        }
+    }
+
+    pub fn scheme(&self) -> AzureScheme {
+        self.scheme
+    }
+
+    pub fn fetch(&self, container: Option<&ContainerName>) -> AzureFetchOptions {
+        AzureFetchOptions {
+            auth: container
+                .and_then(|container| self.auth.get(container))
+                .copied()
+                .unwrap_or_default(),
+            scheme: self.scheme,
+        }
+    }
+
+    pub fn grants(&self) -> impl Iterator<Item = (&ContainerName, Auth)> {
+        self.auth.iter().map(|(container, auth)| (container, *auth))
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn container(name: &str) -> ContainerName {
+        ContainerName::new(name).expect("test container name")
+    }
+
+    #[test]
+    fn enums_round_trip_as_toml_bools() {
+        let opts = AzureEndpointOptions::new(
+            [
+                (container("releases"), Auth::DefaultChain),
+                (container("public"), Auth::Anonymous),
+            ],
+            AzureScheme::Http,
+        );
+
+        let written = toml::to_string(&opts).unwrap();
+        assert!(written.contains("releases = true"), "{written}");
+        assert!(written.contains("public = false"), "{written}");
+        assert!(written.contains(r#"scheme = "http""#), "{written}");
+        assert!(!written.contains("DefaultChain"), "{written}");
+
+        assert_eq!(toml::from_str::<AzureEndpointOptions>(&written), Ok(opts));
+
+        // The default writes no `auth` table, and an empty document reads back
+        // as the default, which grants no container.
+        let default = toml::to_string(&AzureEndpointOptions::default()).unwrap();
+        assert!(!default.contains("auth"), "{default}");
+        let empty: AzureEndpointOptions = toml::from_str("").unwrap();
+        assert_eq!(empty, AzureEndpointOptions::default());
+        assert_eq!(
+            empty.fetch(Some(&container("releases"))),
+            AzureFetchOptions::default()
+        );
+    }
+
+    #[test]
+    fn a_grant_applies_to_one_container_only() {
+        let opts: AzureEndpointOptions = toml::from_str(
+            r#"
+            [auth]
+            releases = true
+            public = false
+            "#,
+        )
+        .unwrap();
+
+        assert!(opts.fetch(Some(&container("releases"))).auth.is_granted());
+        assert!(!opts.fetch(Some(&container("public"))).auth.is_granted());
+        assert!(!opts.fetch(Some(&container("staging"))).auth.is_granted());
+
+        assert!(!opts.fetch(None).auth.is_granted());
+
+        // `grants` reports what the file says, explicit `false` included.
+        let grants: HashMap<_, _> = opts.grants().collect();
+        assert_eq!(
+            grants,
+            HashMap::from([
+                (&container("public"), Auth::Anonymous),
+                (&container("releases"), Auth::DefaultChain),
+            ])
+        );
+    }
+
+    #[test]
+    fn an_unusable_container_key_is_rejected() {
+        let err = toml::from_str::<AzureEndpointOptions>("[auth]\nReleases = true\n")
+            .expect_err("uppercase is not a legal container name");
+        assert!(err.to_string().contains("Releases"), "{err}");
+    }
+
+    #[test]
+    fn an_unknown_field_is_rejected() {
+        for document in [
+            "[Auth]\nreleases = true\n",
+            "[authz]\nreleases = true\n",
+            "path-style = true\n",
+        ] {
+            assert!(
+                toml::from_str::<AzureEndpointOptions>(document).is_err(),
+                "silently ignored: {document}"
+            );
+        }
+    }
+}

--- a/crates/rattler_azure/src/options.rs
+++ b/crates/rattler_azure/src/options.rs
@@ -41,7 +41,6 @@ impl Auth {
     }
 }
 
-/// The wire scheme an `az://` channel URL is rewritten to when a request is sent.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
@@ -70,7 +69,6 @@ impl std::fmt::Display for AzureScheme {
     }
 }
 
-/// What the fetch middleware needs to send a request.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AzureFetchOptions {
     pub auth: Auth,
@@ -78,7 +76,6 @@ pub struct AzureFetchOptions {
     pub scheme: AzureScheme,
 }
 
-/// The options of one endpoint entry.
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",

--- a/crates/rattler_azure/src/options.rs
+++ b/crates/rattler_azure/src/options.rs
@@ -143,10 +143,7 @@ mod tests {
         );
 
         let written = toml::to_string(&opts).unwrap();
-        assert!(written.contains("releases = true"), "{written}");
-        assert!(written.contains("public = false"), "{written}");
-        assert!(written.contains(r#"scheme = "http""#), "{written}");
-        assert!(!written.contains("DefaultChain"), "{written}");
+        insta::assert_snapshot!(written);
 
         assert_eq!(toml::from_str::<AzureEndpointOptions>(&written), Ok(opts));
 

--- a/crates/rattler_azure/src/snapshots/rattler_azure__channel_url__tests__accepted_urls_canonicalize.snap
+++ b/crates/rattler_azure/src/snapshots/rattler_azure__channel_url__tests__accepted_urls_canonicalize.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rattler_azure/src/channel_url.rs
+expression: canonical
+---
+"az://acct.blob.core.windows.net/general/prefix": "az://acct.blob.core.windows.net/general/prefix"
+"az://acct.blob.core.windows.net/general/": "az://acct.blob.core.windows.net/general/"
+"az://acct.blob.core.windows.net/": "az://acct.blob.core.windows.net/"
+"az://acct.blob.core.windows.net": "az://acct.blob.core.windows.net/"
+"az://acct.blob.core.windows.net/general/p?sv=token#frag": "az://acct.blob.core.windows.net/general/p?sv=token#frag"
+"az://acct.blob.core.windows.net/general/..hidden/...": "az://acct.blob.core.windows.net/general/..hidden/..."
+"az://acct.blob.core.windows.net/general/café": "az://acct.blob.core.windows.net/general/caf%C3%A9"
+"az://acct.blob.core.windows.net/general/with space": "az://acct.blob.core.windows.net/general/with%20space"
+"az://acct.blob.core.windows.net/general/with%20space": "az://acct.blob.core.windows.net/general/with%20space"
+"az://acct.blob.core.windows.net/general/caf%C3%A9": "az://acct.blob.core.windows.net/general/caf%C3%A9"

--- a/crates/rattler_azure/src/snapshots/rattler_azure__channel_url__tests__rejected_urls.snap
+++ b/crates/rattler_azure/src/snapshots/rattler_azure__channel_url__tests__rejected_urls.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rattler_azure/src/channel_url.rs
+expression: rejections
+---
+"https://acct.blob.core.windows.net/general": "Azure blob channel URL must use the `az://` scheme, got `https://acct.blob.core.windows.net/general`"
+"http://acct.blob.core.windows.net/general": "Azure blob channel URL must use the `az://` scheme, got `http://acct.blob.core.windows.net/general`"
+"ftp://acct.blob.core.windows.net/general": "Azure blob channel URL must use the `az://` scheme, got `ftp://acct.blob.core.windows.net/general`"
+acct.blob.core.windows.net/general: "Azure blob channel URL must use the `az://` scheme, got `acct.blob.core.windows.net/general`"
+"az://acct.blob.core.windows.net/general/%2e%2e/%2e%2e/othercontainer/x": "Azure blob channel URL segment `%2e%2e` is a relative path segment; a channel URL must name the container it addresses directly, so write the path without `.` or `..`"
+"az://127.0.0.1:10000/devstoreaccount1/general/%2e%2e/%2e%2e/otheraccount/othercontainer": "Azure blob channel URL segment `%2e%2e` is a relative path segment; a channel URL must name the container it addresses directly, so write the path without `.` or `..`"
+"az://acct.blob.core.windows.net/general/../../othercontainer": "Azure blob channel URL segment `..` is a relative path segment; a channel URL must name the container it addresses directly, so write the path without `.` or `..`"
+"az://acct.blob.core.windows.net/general/./noarch": "Azure blob channel URL segment `.` is a relative path segment; a channel URL must name the container it addresses directly, so write the path without `.` or `..`"
+"az://acct.blob.core.windows.net/general/%2E%2E/othercontainer": "Azure blob channel URL segment `%2E%2E` is a relative path segment; a channel URL must name the container it addresses directly, so write the path without `.` or `..`"
+"az://acct.blob.core.windows.net//general/noarch": "Azure blob channel URL path `//general/noarch` has an empty segment; a doubled `/` names nothing, so write the path with single separators"
+"az://acct.blob.core.windows.net/general//noarch": "Azure blob channel URL path `/general//noarch` has an empty segment; a doubled `/` names nothing, so write the path with single separators"
+"az://127.0.0.1:10000//devstoreaccount1/general": "Azure blob channel URL path `//devstoreaccount1/general` has an empty segment; a doubled `/` names nothing, so write the path with single separators"
+"az://acct.blob.core.windows.net/general/gen%eral": "Azure blob channel URL segment `gen%eral` contains `%er`, which is not a valid percent-escape; write a literal `%` as `%25`"
+"az://acct.blob.core.windows.net/general/100%": "Azure blob channel URL segment `100%` contains `%`, which is not a valid percent-escape; write a literal `%` as `%25`"
+"az://acct.blob.core.windows.net/general/%zz": "Azure blob channel URL segment `%zz` contains `%zz`, which is not a valid percent-escape; write a literal `%` as `%25`"
+"az://acct.blob.core.windows.net/general/%ff": "Azure blob channel URL segment `%ff` percent-decodes to bytes that are not UTF-8, so it cannot name a blob"
+"az://acct.blob.core.windows.net/general/caf%C3é": "Azure blob channel URL segment `caf%C3é` percent-decodes to bytes that are not UTF-8, so it cannot name a blob"
+"az://acct.blob.core.windows.net/general/%C3é": "Azure blob channel URL segment `%C3é` percent-decodes to bytes that are not UTF-8, so it cannot name a blob"

--- a/crates/rattler_azure/src/snapshots/rattler_azure__host__tests__host_rejects_anything_that_is_not_a_bare_authority.snap
+++ b/crates/rattler_azure/src/snapshots/rattler_azure__host__tests__host_rejects_anything_that_is_not_a_bare_authority.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rattler_azure/src/host.rs
+expression: rejections
+---
+acct.blob.core.windows.net/general: "`acct.blob.core.windows.net/general` is not a valid Azure host: it carries a path, query or fragment; expected `host` or `host:port`"
+acct.blob.core.windows.net?sv=token: "`acct.blob.core.windows.net?sv=token` is not a valid Azure host: it carries a path, query or fragment; expected `host` or `host:port`"
+"acct.blob.core.windows.net#frag": "`acct.blob.core.windows.net#frag` is not a valid Azure host: it carries a path, query or fragment; expected `host` or `host:port`"
+"https://acct.blob.core.windows.net": "`https://acct.blob.core.windows.net` is not a valid Azure host: it carries a path, query or fragment; expected `host` or `host:port`"
+"": "`` is not a valid Azure host: empty host; expected `host` or `host:port`"
+"acct.blob.core.windows.net:notaport": "`acct.blob.core.windows.net:notaport` is not a valid Azure host: invalid port number; expected `host` or `host:port`"
+"acct.blob.core.windows.net:": "`acct.blob.core.windows.net:` is not a valid Azure host: its port is empty; expected `host` or `host:port`"
+"acct.blob.core.windows.net:0": "`acct.blob.core.windows.net:0` is not a valid Azure host: port 0 cannot be connected to; expected `host` or `host:port`"
+"[::1]:": "`[::1]:` is not a valid Azure host: its port is empty; expected `host` or `host:port`"
+"[::1]:0": "`[::1]:0` is not a valid Azure host: port 0 cannot be connected to; expected `host` or `host:port`"
+acct..blob.core.windows.net: "`acct..blob.core.windows.net` is not a valid Azure host: one of its labels is empty; expected `host` or `host:port`"
+acct.blob.example..: "`acct.blob.example..` is not a valid Azure host: one of its labels is empty; expected `host` or `host:port`"
+".example": "`.example` is not a valid Azure host: one of its labels is empty; expected `host` or `host:port`"

--- a/crates/rattler_azure/src/snapshots/rattler_azure__options__tests__enums_round_trip_as_toml_bools.snap
+++ b/crates/rattler_azure/src/snapshots/rattler_azure__options__tests__enums_round_trip_as_toml_bools.snap
@@ -1,0 +1,9 @@
+---
+source: crates/rattler_azure/src/options.rs
+expression: written
+---
+scheme = "http"
+
+[auth]
+releases = true
+public = false

--- a/crates/rattler_azure/src/test_support.rs
+++ b/crates/rattler_azure/src/test_support.rs
@@ -1,0 +1,7 @@
+//! Shared helpers for unit tests across this crate's modules.
+
+use crate::AzureChannelUrl;
+
+pub(crate) fn channel(url: &str) -> AzureChannelUrl {
+    AzureChannelUrl::parse(url).unwrap_or_else(|err| panic!("{url} should parse: {err}"))
+}


### PR DESCRIPTION
### Description

First PR of a stack splitting #2727 into smaller pieces:

1. **this PR** — `az://` URL parsing core
2. endpoint keys and addressing resolution
3. opendal azblob backend
4. clap credential options and az CLI SAS minting

This PR adds the `rattler_azure` crate with the URL model for Azure Blob
channels:

- `AzureChannelUrl` — parses and validates `az://host[:port]/…` channel URLs,
  normalizing spelling so equivalent URLs compare equal. `Display`/`Debug`
  mask any inline SAS signature so values are log-safe; only `wire()`
  reproduces the signed form.
- `AzureHost` — authority validation (rejects userinfo, empty labels,
  bad ports) and detection of Azure's own blob endpoints across clouds.
- `AccountName` / `ContainerName` — validated name newtypes.
- `AzureEndpointOptions` / `AzureFetchOptions` / `Auth` — per-endpoint
  configuration types, with an optional `serde` feature for config crates.
- `AzureCredentials`, `AzureUrlError`.

A few accessors consumed only by the addressing layer land
with their consumer in PR 2 to keep this PR free of dead code.

### How Has This Been Tested?

17 unit tests. Rejection and canonicalization behavior is pinned as insta
snapshot tables, one entry per input mapping to
the exact error message or canonical URL, so every AzureUrlError
message is asserted. Round-trip invariants, port handling, and SAS
redaction remain as plain asserts (redaction so a snapshot
can't record a leaked secret on cargo insta accept):

```bash
cargo nextest run -p rattler_azure --all-features
cargo clippy -p rattler_azure --all-targets --all-features
```

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
