### PR TITLE
feat(installer): force regular files to use softlinks

### DIFF
--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -59,6 +59,10 @@ pub struct LinkOptions {
     /// If true, ref links (or copy-on-write links) will be allowed to install
     /// files to the disk. Defaults to `true` if `None`.
     pub allow_ref_links: Option<bool>,
+
+    /// If true, ordinary unmodified package files are symbolically linked to
+    /// the package cache instead of being reflinked, hardlinked, or copied.
+    pub force_symbolic_links: bool,
 }
 
 #[cfg(feature = "rattler_config")]
@@ -68,6 +72,7 @@ impl From<&rattler_config::config::CommonConfig> for LinkOptions {
             allow_symbolic_links: config.allow_symbolic_links,
             allow_hard_links: config.allow_hard_links,
             allow_ref_links: config.allow_ref_links,
+            force_symbolic_links: false,
         }
     }
 }
@@ -658,6 +663,7 @@ impl Installer {
             allow_symbolic_links: self.link_options.allow_symbolic_links,
             allow_hard_links: self.link_options.allow_hard_links,
             allow_ref_links: self.link_options.allow_ref_links,
+            force_symbolic_links: self.link_options.force_symbolic_links,
             external_symlink_policy: self.external_symlink_policy,
             ..InstallOptions::default()
         };

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -159,6 +159,7 @@ pub fn link_file(
     allow_symbolic_links: bool,
     allow_hard_links: bool,
     allow_ref_links: bool,
+    force_symbolic_links: bool,
     target_platform: Platform,
     apple_codesign_behavior: AppleCodeSignBehavior,
     modification_time: filetime::FileTime,
@@ -286,6 +287,8 @@ pub fn link_file(
             .map_err(LinkFileError::FailedToUpdateDestinationFileTimestamps)?;
 
         LinkMethod::Patched(*file_mode)
+    } else if path_json_entry.path_type == PathType::HardLink && force_symbolic_links {
+        softlink_file_to_destination(&source_path, &destination_path)?
     } else if path_json_entry.path_type == PathType::HardLink && allow_ref_links {
         reflink_to_destination(&source_path, &destination_path, allow_hard_links)?
     } else if path_json_entry.path_type == PathType::HardLink && allow_hard_links {
@@ -566,6 +569,33 @@ fn symlink_to_destination(
                     destination_path.display()
                 );
                 return copy_symlink_target_to_destination(source_path, destination_path);
+            }
+        }
+    }
+}
+
+/// Symbolically link a regular package file to its cache source, falling back
+/// to a copy when the platform does not permit creating the link.
+fn softlink_file_to_destination(
+    source_path: &Path,
+    destination_path: &Path,
+) -> Result<LinkMethod, LinkFileError> {
+    let source_path =
+        fs::canonicalize(source_path).map_err(LinkFileError::FailedToReadSourceFileMetadata)?;
+    loop {
+        match symlink(&source_path, destination_path) {
+            Ok(()) => return Ok(LinkMethod::Softlink),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                fs::remove_file(destination_path).map_err(|err| {
+                    LinkFileError::IoError(String::from("removing clobbered file"), err)
+                })?;
+            }
+            Err(error) => {
+                tracing::debug!(
+                    "failed to symlink {}: {error}, falling back to copying.",
+                    destination_path.display()
+                );
+                return copy_to_destination(&source_path, destination_path);
             }
         }
     }
@@ -985,6 +1015,7 @@ mod test {
             true,
             true,
             true,
+            false,
             Platform::Linux64,
             AppleCodeSignBehavior::DoNothing,
             modification_time,
@@ -1046,6 +1077,7 @@ mod test {
             true,
             true,
             true,
+            false,
             Platform::Linux64,
             AppleCodeSignBehavior::DoNothing,
             modification_time,
@@ -1068,6 +1100,53 @@ mod test {
         assert_eq!(
             dest_mtime, source_time,
             "unpatched file should keep source mtime ({source_time}), not modification_time ({modification_time})",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_force_symbolic_links_links_regular_files_to_cache() {
+        use super::AppleCodeSignBehavior;
+        use rattler_conda_types::package::{PathType, PathsEntry};
+        use rattler_conda_types::prefix::Prefix;
+        use std::path::PathBuf;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let package_dir = temp_dir.path().join("package");
+        fs::create_dir_all(&package_dir).unwrap();
+        fs::write(package_dir.join("data.txt"), "from cache\n").unwrap();
+        let target_dir = Prefix::create(temp_dir.path().join("target")).unwrap();
+        let entry = PathsEntry {
+            relative_path: PathBuf::from("data.txt"),
+            no_link: false,
+            path_type: PathType::HardLink,
+            prefix_placeholder: None,
+            sha256: None,
+            size_in_bytes: None,
+        };
+
+        let result = super::link_file(
+            &entry,
+            PathBuf::from("data.txt"),
+            &package_dir,
+            &target_dir,
+            target_dir.path().to_str().unwrap(),
+            true,
+            true,
+            true,
+            true,
+            Platform::Linux64,
+            AppleCodeSignBehavior::DoNothing,
+            filetime::FileTime::now(),
+            ExternalSymlinkPolicy::Deny,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(result.method, super::LinkMethod::Softlink);
+        assert_eq!(
+            fs::read_link(target_dir.path().join("data.txt")).unwrap(),
+            fs::canonicalize(package_dir.join("data.txt")).unwrap()
         );
     }
 
@@ -1108,6 +1187,7 @@ mod test {
             true,
             true,
             true,
+            false,
             Platform::Linux64,
             AppleCodeSignBehavior::DoNothing,
             modification_time,

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -159,38 +159,6 @@ pub fn link_file(
     allow_symbolic_links: bool,
     allow_hard_links: bool,
     allow_ref_links: bool,
-    target_platform: Platform,
-    apple_codesign_behavior: AppleCodeSignBehavior,
-    modification_time: filetime::FileTime,
-    external_symlink_policy: ExternalSymlinkPolicy,
-) -> Result<Option<LinkedFile>, LinkFileError> {
-    link_file_with_options(
-        path_json_entry,
-        destination_relative_path,
-        package_dir,
-        target_dir,
-        target_prefix,
-        allow_symbolic_links,
-        allow_hard_links,
-        allow_ref_links,
-        false,
-        target_platform,
-        apple_codesign_behavior,
-        modification_time,
-        external_symlink_policy,
-    )
-}
-
-#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
-pub(crate) fn link_file_with_options(
-    path_json_entry: &PathsEntry,
-    destination_relative_path: PathBuf,
-    package_dir: &Path,
-    target_dir: &Prefix,
-    target_prefix: &str,
-    allow_symbolic_links: bool,
-    allow_hard_links: bool,
-    allow_ref_links: bool,
     force_symbolic_links: bool,
     target_platform: Platform,
     apple_codesign_behavior: AppleCodeSignBehavior,
@@ -1047,6 +1015,7 @@ mod test {
             true,
             true,
             true,
+            false,
             Platform::Linux64,
             AppleCodeSignBehavior::DoNothing,
             modification_time,
@@ -1108,6 +1077,7 @@ mod test {
             true,
             true,
             true,
+            false,
             Platform::Linux64,
             AppleCodeSignBehavior::DoNothing,
             modification_time,
@@ -1155,7 +1125,7 @@ mod test {
             size_in_bytes: None,
         };
 
-        let result = super::link_file_with_options(
+        let result = super::link_file(
             &entry,
             PathBuf::from("data.txt"),
             &package_dir,
@@ -1217,6 +1187,7 @@ mod test {
             true,
             true,
             true,
+            false,
             Platform::Linux64,
             AppleCodeSignBehavior::DoNothing,
             modification_time,

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -159,6 +159,38 @@ pub fn link_file(
     allow_symbolic_links: bool,
     allow_hard_links: bool,
     allow_ref_links: bool,
+    target_platform: Platform,
+    apple_codesign_behavior: AppleCodeSignBehavior,
+    modification_time: filetime::FileTime,
+    external_symlink_policy: ExternalSymlinkPolicy,
+) -> Result<Option<LinkedFile>, LinkFileError> {
+    link_file_with_options(
+        path_json_entry,
+        destination_relative_path,
+        package_dir,
+        target_dir,
+        target_prefix,
+        allow_symbolic_links,
+        allow_hard_links,
+        allow_ref_links,
+        false,
+        target_platform,
+        apple_codesign_behavior,
+        modification_time,
+        external_symlink_policy,
+    )
+}
+
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+pub(crate) fn link_file_with_options(
+    path_json_entry: &PathsEntry,
+    destination_relative_path: PathBuf,
+    package_dir: &Path,
+    target_dir: &Prefix,
+    target_prefix: &str,
+    allow_symbolic_links: bool,
+    allow_hard_links: bool,
+    allow_ref_links: bool,
     force_symbolic_links: bool,
     target_platform: Platform,
     apple_codesign_behavior: AppleCodeSignBehavior,
@@ -1015,7 +1047,6 @@ mod test {
             true,
             true,
             true,
-            false,
             Platform::Linux64,
             AppleCodeSignBehavior::DoNothing,
             modification_time,
@@ -1077,7 +1108,6 @@ mod test {
             true,
             true,
             true,
-            false,
             Platform::Linux64,
             AppleCodeSignBehavior::DoNothing,
             modification_time,
@@ -1125,7 +1155,7 @@ mod test {
             size_in_bytes: None,
         };
 
-        let result = super::link_file(
+        let result = super::link_file_with_options(
             &entry,
             PathBuf::from("data.txt"),
             &package_dir,
@@ -1187,7 +1217,6 @@ mod test {
             true,
             true,
             true,
-            false,
             Platform::Linux64,
             AppleCodeSignBehavior::DoNothing,
             modification_time,

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -451,7 +451,7 @@ pub async fn link_package(
             let cloned_entry = entry.clone();
             let is_clobber = link_path.clobber_path.is_some();
             let result = match tokio::task::spawn_blocking(move || {
-                link::link_file_with_options(
+                link_file(
                     &cloned_entry,
                     link_path.clobber_path.unwrap_or(link_path.computed_path),
                     &package_dir,
@@ -886,7 +886,7 @@ pub fn link_package_sync(
                 let entry = link_path.entry;
 
                 let is_clobber = link_path.clobber_path.is_some();
-                let link_result = link::link_file_with_options(
+                let link_result = link_file(
                     &entry,
                     link_path
                         .clobber_path

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -220,6 +220,11 @@ pub struct InstallOptions {
     /// instead (if allowed).
     pub allow_ref_links: Option<bool>,
 
+    /// Force ordinary unmodified package files to use symbolic links to the
+    /// package cache. Files marked `no_link` or requiring prefix replacement
+    /// are still copied.
+    pub force_symbolic_links: bool,
+
     /// The platform for which the package is installed. Some operations like
     /// signing require different behavior depending on the platform. If the
     /// field is set to `None` the current platform is used.
@@ -455,6 +460,7 @@ pub async fn link_package(
                     allow_symbolic_links && !cloned_entry.no_link,
                     allow_hard_links && !cloned_entry.no_link,
                     allow_ref_links && !cloned_entry.no_link,
+                    options.force_symbolic_links && !cloned_entry.no_link,
                     platform,
                     options.apple_codesign_behavior,
                     modification_time,
@@ -891,6 +897,7 @@ pub fn link_package_sync(
                     allow_symbolic_links && !entry.no_link,
                     allow_hard_links && !entry.no_link,
                     allow_ref_links && !entry.no_link,
+                    options.force_symbolic_links && !entry.no_link,
                     platform,
                     options.apple_codesign_behavior,
                     modification_time,

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -451,7 +451,7 @@ pub async fn link_package(
             let cloned_entry = entry.clone();
             let is_clobber = link_path.clobber_path.is_some();
             let result = match tokio::task::spawn_blocking(move || {
-                link_file(
+                link::link_file_with_options(
                     &cloned_entry,
                     link_path.clobber_path.unwrap_or(link_path.computed_path),
                     &package_dir,
@@ -886,7 +886,7 @@ pub fn link_package_sync(
                 let entry = link_path.entry;
 
                 let is_clobber = link_path.clobber_path.is_some();
-                let link_result = link_file(
+                let link_result = link::link_file_with_options(
                     &entry,
                     link_path
                         .clobber_path

--- a/py-rattler/rattler/install/installer.py
+++ b/py-rattler/rattler/install/installer.py
@@ -289,6 +289,7 @@ async def install(
     requested_specs: Optional[List[MatchSpec]] = None,
     reporter: Optional[InstallerReporter] = None,
     alternative_target_prefix: Optional[str | os.PathLike[str]] = None,
+    force_symbolic_links: bool = False,
 ) -> None:
     """
     Create an environment by downloading and linking the `dependencies` in
@@ -354,6 +355,9 @@ async def install(
                 `target_prefix`; only the prefix written into the linked files differs. This is
                 only needed in exceptional cases, for example when the environment will later be
                 relocated to or used from a different path.
+        force_symbolic_links: Install ordinary unmodified package files as symbolic links to
+                their package-cache sources. Files requiring prefix replacement or marked
+                `no_link` remain copies.
     """
 
     await py_install(
@@ -370,4 +374,5 @@ async def install(
         requested_specs=requested_specs,
         reporter=reporter,
         alternative_target_prefix=str(alternative_target_prefix) if alternative_target_prefix is not None else None,
+        force_symbolic_links=force_symbolic_links,
     )

--- a/py-rattler/src/installer.rs
+++ b/py-rattler/src/installer.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use pyo3::{Bound, Py, PyAny, PyResult, Python, exceptions::PyTypeError, pyfunction};
 use pyo3_async_runtimes::tokio::future_into_py;
 use rattler::{
-    install::{IndicatifReporter, Installer, Reporter, Transaction},
+    install::{IndicatifReporter, Installer, LinkOptions, Reporter, Transaction},
     package_cache::PackageCache,
 };
 use rattler_conda_types::{PackageName, PrefixRecord, RepoDataRecord};
@@ -214,7 +214,7 @@ impl Reporter for PyReporter {
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (records, target_prefix, execute_link_scripts=false, show_progress=false, platform=None, client=None, cache_dir=None, installed_packages=None, reinstall_packages=None, ignored_packages=None, requested_specs=None, reporter=None, alternative_target_prefix=None))]
+#[pyo3(signature = (records, target_prefix, execute_link_scripts=false, show_progress=false, platform=None, client=None, cache_dir=None, installed_packages=None, reinstall_packages=None, ignored_packages=None, requested_specs=None, reporter=None, alternative_target_prefix=None, force_symbolic_links=false))]
 pub fn py_install<'a>(
     py: Python<'a>,
     records: Vec<Bound<'a, PyAny>>,
@@ -230,6 +230,7 @@ pub fn py_install<'a>(
     requested_specs: Option<Vec<PyMatchSpec>>,
     reporter: Option<Py<PyAny>>,
     alternative_target_prefix: Option<PathBuf>,
+    force_symbolic_links: bool,
 ) -> PyResult<Bound<'a, PyAny>> {
     let dependencies = records
         .into_iter()
@@ -266,7 +267,12 @@ pub fn py_install<'a>(
     let client = client.map(|c| c.inner);
 
     future_into_py(py, async move {
-        let mut installer = Installer::new().with_execute_link_scripts(execute_link_scripts);
+        let mut installer = Installer::new()
+            .with_execute_link_scripts(execute_link_scripts)
+            .with_link_options(LinkOptions {
+                force_symbolic_links,
+                ..LinkOptions::default()
+            });
 
         if let Some(py_reporter) = reporter {
             installer.set_reporter(PyReporter {


### PR DESCRIPTION
## Description

Closes #2740.

Add `force_symbolic_links` to `LinkOptions` and `InstallOptions`. When enabled, ordinary unmodified `PathType::HardLink` files are symlinked to their canonical package-cache source before the reflink/hardlink/copy fallbacks are considered.

Files requiring prefix replacement remain copies, and installer callers continue to suppress linking for `no_link` entries. If the platform cannot create a symlink, installation falls back to copying just like package-authored symlinks do today. Defaults are unchanged.

This unblocks faithful downstream support for Conda's `always_softlink` setting.

## Tests

- A regular package file is installed as a symlink to its canonical cache source when forced.
- Existing link tests continue to exercise the default non-forced path.
- `cargo test -p rattler force_symbolic_links --lib`
- `cargo clippy -p rattler --all-targets -- -D warnings`
- `cargo fmt --check`

## AI usage

This contribution was generated with AI assistance and manually reviewed and tested by the contributor.
