### PR TITLE
feat(gateway): configure package format selection

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rattler_conda_types::ChannelUrl;
 use url::Url;
 
-use crate::fetch::CacheAction;
+use crate::{fetch::CacheAction, sparse::PackageFormatSelection};
 
 /// Describes additional properties that influence how the gateway fetches
 /// repodata for a specific channel.
@@ -23,6 +23,10 @@ pub struct SourceConfig {
     /// Describes fetching repodata from a channel should interact with any
     /// caches.
     pub cache_action: CacheAction,
+
+    /// Selects which package archive formats are exposed. `None` preserves the
+    /// existing backend-specific behavior.
+    pub package_format_selection: Option<PackageFormatSelection>,
 
     /// When the gateway may only read from the cache, report a package whose
     /// shard is absent as having no records instead of failing the query.
@@ -47,6 +51,7 @@ impl Default for SourceConfig {
             bz2_enabled: true,
             sharded_enabled: true,
             cache_action: CacheAction::default(),
+            package_format_selection: None,
             missing_shards_are_empty: false,
         }
     }
@@ -60,6 +65,7 @@ impl From<rattler_config::config::repodata_config::RepodataChannelConfig> for So
             bz2_enabled: !value.disable_bzip2.unwrap_or(false),
             sharded_enabled: !value.disable_sharded.unwrap_or(false),
             cache_action: CacheAction::default(),
+            package_format_selection: None,
             missing_shards_are_empty: false,
         }
     }

--- a/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
@@ -19,13 +19,23 @@ use crate::{
 /// instance of this client.
 pub struct LocalSubdirClient {
     sparse: Arc<SparseRepoData>,
+    package_format_selection: PackageFormatSelection,
 }
 
 impl LocalSubdirClient {
     /// Create a client directly from an already-loaded [`SparseRepoData`],
     /// without parsing anything from disk.
     pub fn new(sparse: Arc<SparseRepoData>) -> Self {
-        Self { sparse }
+        Self {
+            sparse,
+            package_format_selection: PackageFormatSelection::default(),
+        }
+    }
+
+    /// Set which package archive formats this client exposes.
+    pub fn with_package_format_selection(mut self, selection: PackageFormatSelection) -> Self {
+        self.package_format_selection = selection;
+        self
     }
 
     pub fn from_file(
@@ -51,6 +61,7 @@ impl LocalSubdirClient {
 
         Ok(Self {
             sparse: Arc::new(sparse),
+            package_format_selection: PackageFormatSelection::default(),
         })
     }
 
@@ -68,6 +79,7 @@ impl LocalSubdirClient {
 
         Ok(Self {
             sparse: Arc::new(sparse),
+            package_format_selection: PackageFormatSelection::default(),
         })
     }
 }
@@ -82,23 +94,23 @@ impl SubdirClient for LocalSubdirClient {
     ) -> Result<PackageRecords, GatewayError> {
         let sparse_repodata = self.sparse.clone();
         let name = name.clone();
+        let package_format_selection = self.package_format_selection;
 
-        let load_records = move || match sparse_repodata
-            .load_records(&name, PackageFormatSelection::PreferConda)
-        {
-            Ok(records) => {
-                let (unique_base_deps, unique_extra_deps) = extract_unique_deps_split(&records);
-                Ok(PackageRecords {
-                    records: records.into_iter().map(Arc::new).collect(),
-                    unique_base_deps,
-                    unique_extra_deps,
-                })
-            }
-            Err(err) => Err(GatewayError::IoError(
-                "failed to extract repodata records from sparse repodata".to_string(),
-                err,
-            )),
-        };
+        let load_records =
+            move || match sparse_repodata.load_records(&name, package_format_selection) {
+                Ok(records) => {
+                    let (unique_base_deps, unique_extra_deps) = extract_unique_deps_split(&records);
+                    Ok(PackageRecords {
+                        records: records.into_iter().map(Arc::new).collect(),
+                        unique_base_deps,
+                        unique_extra_deps,
+                    })
+                }
+                Err(err) => Err(GatewayError::IoError(
+                    "failed to extract repodata records from sparse repodata".to_string(),
+                    err,
+                )),
+            };
 
         #[cfg(target_arch = "wasm32")]
         return load_records();
@@ -109,7 +121,7 @@ impl SubdirClient for LocalSubdirClient {
     fn package_names(&self) -> Vec<String> {
         let sparse_repodata: Arc<SparseRepoData> = self.sparse.clone();
         sparse_repodata
-            .package_names(PackageFormatSelection::PreferConda)
+            .package_names(self.package_format_selection)
             .map(std::convert::Into::into)
             .collect()
     }

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/tokio.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/tokio.rs
@@ -61,6 +61,10 @@ impl RemoteSubdirClient {
                 channel.clone(),
                 platform.as_str(),
             )
+            .map(|client| match source_config.package_format_selection {
+                Some(selection) => client.with_package_format_selection(selection),
+                None => client,
+            })
         })
         .await?;
 

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/wasm.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/wasm.rs
@@ -55,6 +55,10 @@ impl RemoteSubdirClient {
         // repodata.
         let sparse =
             LocalSubdirClient::from_bytes(repodata_bytes, channel.clone(), platform.as_str())?;
+        let sparse = match source_config.package_format_selection {
+            Some(selection) => sparse.with_package_format_selection(selection),
+            None => sparse,
+        };
 
         Ok(Self { sparse })
     }

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use cfg_if::cfg_if;
@@ -14,6 +15,7 @@ use crate::{
     GatewayError,
     fetch::FetchRepoDataError,
     gateway::subdir::{PackageRecords, extract_unique_deps_split},
+    sparse::PackageFormatSelection,
 };
 
 /// Returns `true` if the HTTP status indicates that the server does not expose
@@ -92,6 +94,7 @@ async fn parse_records<R: AsRef<[u8]> + Send + 'static>(
     bytes: R,
     channel_base_url: ChannelUrl,
     base_url: Url,
+    package_format_selection: Option<PackageFormatSelection>,
 ) -> Result<PackageRecords, GatewayError> {
     let parse =
         move || {
@@ -154,6 +157,8 @@ async fn parse_records<R: AsRef<[u8]> + Send + 'static>(
                 }));
             }
 
+            records = select_package_formats(records, package_format_selection);
+
             let (unique_base_deps, unique_extra_deps) =
                 extract_unique_deps_split(records.iter().map(|r| &**r));
             Ok(PackageRecords {
@@ -170,19 +175,84 @@ async fn parse_records<R: AsRef<[u8]> + Send + 'static>(
     simple_spawn_blocking::tokio::run_blocking_task(parse).await
 }
 
+fn select_package_formats(
+    mut records: Vec<Arc<RepoDataRecord>>,
+    selection: Option<PackageFormatSelection>,
+) -> Vec<Arc<RepoDataRecord>> {
+    let Some(selection) = selection else {
+        return records;
+    };
+    match selection {
+        PackageFormatSelection::OnlyTarBz2 => {
+            records
+                .retain(|record| record.identifier.archive_type == CondaArchiveType::TarBz2.into());
+            records
+        }
+        PackageFormatSelection::OnlyConda => {
+            records
+                .retain(|record| record.identifier.archive_type == CondaArchiveType::Conda.into());
+            records
+        }
+        PackageFormatSelection::Both => {
+            records.retain(|record| {
+                matches!(
+                    record.identifier.archive_type,
+                    rattler_conda_types::package::DistArchiveType::Conda(_)
+                )
+            });
+            records
+        }
+        PackageFormatSelection::PreferConda => {
+            records.retain(|record| {
+                matches!(
+                    record.identifier.archive_type,
+                    rattler_conda_types::package::DistArchiveType::Conda(_)
+                )
+            });
+            prefer_package_formats(records)
+        }
+        PackageFormatSelection::PreferCondaWithWhl => prefer_package_formats(records),
+    }
+}
+
+fn prefer_package_formats(records: Vec<Arc<RepoDataRecord>>) -> Vec<Arc<RepoDataRecord>> {
+    let mut preferred = BTreeMap::new();
+    for record in records {
+        preferred
+            .entry(record.identifier.identifier.clone())
+            .and_modify(|existing: &mut Arc<RepoDataRecord>| {
+                if record
+                    .identifier
+                    .archive_type
+                    .cmp_preference(existing.identifier.archive_type)
+                    .is_gt()
+                {
+                    *existing = record.clone();
+                }
+            })
+            .or_insert(record);
+    }
+    preferred.into_values().collect()
+}
+
 // Tests are only run on non-wasm targets since they use tokio and axum
 #[cfg(test)]
 mod tests {
     use crate::fetch::CacheAction;
     use crate::gateway::error::GatewayError;
     use crate::gateway::subdir::SubdirClient;
+    use crate::sparse::PackageFormatSelection;
     use axum::{
         Router,
         body::Body,
         http::{Response, StatusCode},
         routing::get,
     };
-    use rattler_conda_types::{Channel, RepodataRevisions, ShardedRepodata, ShardedSubdirInfo};
+    use rattler_conda_types::{
+        Channel, PackageName, PackageRecord, RepoDataRecord, RepodataRevisions, ShardedRepodata,
+        ShardedSubdirInfo, Version,
+        package::{CondaArchiveType, DistArchiveIdentifier},
+    };
     use rattler_digest::{Sha256, parse_digest_from_hex};
     use std::future::IntoFuture;
     use std::net::SocketAddr;
@@ -195,6 +265,48 @@ mod tests {
     use url::Url;
 
     use super::{ShardCachePolicy, ShardedSubdir};
+
+    #[test]
+    fn package_format_selection_filters_shards_before_solving() {
+        let record = |archive_type| {
+            let identifier =
+                DistArchiveIdentifier::new("demo-1.0-0".parse().unwrap(), archive_type);
+            Arc::new(RepoDataRecord {
+                url: format!("https://example.invalid/{}", identifier.to_file_name())
+                    .parse()
+                    .unwrap(),
+                channel: Some("https://example.invalid".to_owned()),
+                package_record: PackageRecord::new(
+                    PackageName::new_unchecked("demo"),
+                    Version::major(1),
+                    "0".to_owned(),
+                ),
+                identifier,
+            })
+        };
+        let records = vec![
+            record(CondaArchiveType::TarBz2),
+            record(CondaArchiveType::Conda),
+        ];
+
+        let tar = super::select_package_formats(
+            records.clone(),
+            Some(PackageFormatSelection::OnlyTarBz2),
+        );
+        assert_eq!(tar.len(), 1);
+        assert_eq!(
+            tar[0].identifier.archive_type,
+            CondaArchiveType::TarBz2.into()
+        );
+
+        let preferred =
+            super::select_package_formats(records, Some(PackageFormatSelection::PreferConda));
+        assert_eq!(preferred.len(), 1);
+        assert_eq!(
+            preferred[0].identifier.archive_type,
+            CondaArchiveType::Conda.into()
+        );
+    }
 
     /// A mock server that serves a sharded repodata index but returns
     /// configurable responses for shard requests.
@@ -330,6 +442,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -399,6 +512,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .err()
@@ -438,6 +552,7 @@ mod tests {
                 action: CacheAction::NoCache,
                 missing_shards_are_empty: false,
             },
+            None,
             None,
             None,
             None,
@@ -484,6 +599,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await
         .expect("the index is served, so it is cached now");
@@ -497,6 +613,7 @@ mod tests {
                 action: cache_only_action,
                 missing_shards_are_empty,
             },
+            None,
             None,
             None,
             None,
@@ -527,6 +644,7 @@ mod tests {
                 action: CacheAction::ForceCacheOnly,
                 missing_shards_are_empty: true,
             },
+            None,
             None,
             None,
             None,

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/mod.rs
@@ -19,6 +19,7 @@ use crate::{
         subdir::{PackageRecords, SubdirClient},
     },
     reporter::ResponseReporterExt,
+    sparse::PackageFormatSelection,
 };
 use fs_err::tokio as tokio_fs;
 use futures::future::OptionFuture;
@@ -63,6 +64,7 @@ pub struct ShardedSubdir {
     io_concurrency_semaphore: Option<Arc<tokio::sync::Semaphore>>,
     cache_dir: PathBuf,
     cache_policy: ShardCachePolicy,
+    package_format_selection: Option<PackageFormatSelection>,
 }
 
 impl ShardedSubdir {
@@ -73,6 +75,7 @@ impl ShardedSubdir {
         client: LazyClient,
         cache_dir: PathBuf,
         cache_policy: ShardCachePolicy,
+        package_format_selection: Option<PackageFormatSelection>,
         concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
         io_concurrency_semaphore: Option<Arc<tokio::sync::Semaphore>>,
         reporter: Option<&dyn Reporter>,
@@ -141,6 +144,7 @@ impl ShardedSubdir {
             sharded_repodata,
             cache_dir,
             cache_policy,
+            package_format_selection,
             concurrent_requests_semaphore,
             io_concurrency_semaphore,
         })
@@ -224,6 +228,7 @@ impl SubdirClient for ShardedSubdir {
                         cached_bytes,
                         self.channel.base_url.clone(),
                         self.package_base_url.clone(),
+                        self.package_format_selection,
                     )
                     .await;
                 }
@@ -302,6 +307,7 @@ impl SubdirClient for ShardedSubdir {
             shard_bytes,
             self.channel.base_url.clone(),
             self.package_base_url.clone(),
+            self.package_format_selection,
         );
 
         // Await both futures concurrently.

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/wasm/mod.rs
@@ -22,6 +22,7 @@ use crate::{
         subdir::{PackageRecords, SubdirClient},
     },
     reporter::ResponseReporterExt,
+    sparse::PackageFormatSelection,
     utils::js_fetch::JsFetcher,
 };
 
@@ -33,6 +34,7 @@ pub struct ShardedSubdir {
     package_base_url: Url,
     sharded_repodata: ShardedRepodata,
     concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
+    package_format_selection: Option<PackageFormatSelection>,
 }
 
 impl ShardedSubdir {
@@ -41,6 +43,7 @@ impl ShardedSubdir {
         subdir: String,
         client: LazyClient,
         js_fetch: Option<JsFetcher>,
+        package_format_selection: Option<PackageFormatSelection>,
         concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
         reporter: Option<&dyn Reporter>,
     ) -> Result<Self, GatewayError> {
@@ -110,6 +113,7 @@ impl ShardedSubdir {
             package_base_url: add_trailing_slash(&package_base_url).into_owned(),
             sharded_repodata,
             concurrent_requests_semaphore,
+            package_format_selection,
         })
     }
 }
@@ -182,6 +186,7 @@ impl SubdirClient for ShardedSubdir {
             shard_bytes,
             self.channel.base_url.clone(),
             self.package_base_url.clone(),
+            self.package_format_selection,
         )
         .await
     }

--- a/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
@@ -41,10 +41,11 @@ impl<'g> SubdirBuilder<'g> {
 
     pub async fn build(self) -> Result<Subdir, GatewayError> {
         let url = self.channel.platform_url(self.platform);
+        let source_config = self.gateway.channel_config.get(&self.channel.base_url);
 
         let subdir_data = if url.scheme() == "file" {
             if let Some(path) = url_to_path(&url) {
-                self.build_local(&path).await
+                self.build_local(&path, source_config).await
             } else {
                 return Err(GatewayError::UnsupportedUrl(
                     "unsupported file based url".to_string(),
@@ -56,8 +57,6 @@ impl<'g> SubdirBuilder<'g> {
             || url.scheme() == "oci"
             || url.scheme() == "s3"
         {
-            let source_config = self.gateway.channel_config.get(&self.channel.base_url);
-
             // Use sharded repodata if enabled
             let subdir_data = if source_config.sharded_enabled
                 || gateway::force_sharded_repodata(&url)
@@ -152,6 +151,8 @@ impl<'g> SubdirBuilder<'g> {
             self.gateway.client.clone(),
             #[cfg(target_arch = "wasm32")]
             self.gateway.js_fetch.clone(),
+            #[cfg(target_arch = "wasm32")]
+            _source_config.package_format_selection,
             #[cfg(not(target_arch = "wasm32"))]
             self.gateway.cache.clone(),
             #[cfg(not(target_arch = "wasm32"))]
@@ -159,6 +160,8 @@ impl<'g> SubdirBuilder<'g> {
                 action: _source_config.cache_action,
                 missing_shards_are_empty: _source_config.missing_shards_are_empty,
             },
+            #[cfg(not(target_arch = "wasm32"))]
+            _source_config.package_format_selection,
             self.gateway.concurrent_requests_semaphore.clone(),
             #[cfg(not(target_arch = "wasm32"))]
             self.gateway.io_concurrency_semaphore.clone(),
@@ -169,12 +172,23 @@ impl<'g> SubdirBuilder<'g> {
         Ok(SubdirData::from_client(client))
     }
 
-    async fn build_local(&self, path: &Path) -> Result<SubdirData, GatewayError> {
+    async fn build_local(
+        &self,
+        path: &Path,
+        source_config: &SourceConfig,
+    ) -> Result<SubdirData, GatewayError> {
         let channel = self.channel.clone();
         let platform = self.platform;
         let path = path.join("repodata.json");
-        let build_client =
-            move || LocalSubdirClient::from_file(&path, channel.clone(), platform.as_str());
+        let package_format_selection = source_config.package_format_selection;
+        let build_client = move || {
+            LocalSubdirClient::from_file(&path, channel.clone(), platform.as_str()).map(|client| {
+                match package_format_selection {
+                    Some(selection) => client.with_package_format_selection(selection),
+                    None => client,
+                }
+            })
+        };
 
         #[cfg(target_arch = "wasm32")]
         let client = build_client()?;


### PR DESCRIPTION
## Description

Closes #2741.

Expose `PackageFormatSelection` through `SourceConfig` and apply an explicit selection consistently to local, remote, and sharded subdirs.

`None` preserves the existing backend-specific defaults, so existing callers and default Gateway behavior are unchanged. Ordinary JSON-backed subdirs reuse `SparseRepoData`'s existing selection logic. Sharded records apply equivalent archive filtering and preference before dependency extraction and solving.

This unblocks faithful downstream support for Conda's `use_only_tar_bz2` setting.

## Tests

- Exercises `OnlyTarBz2` and `PreferConda` on a shard containing equivalent `.tar.bz2` and `.conda` records.
- Reuses the existing sparse-repodata selection matrix for ordinary repodata.
- `cargo test -p rattler_repodata_gateway --features gateway package_format_selection --lib`
- `cargo clippy -p rattler_repodata_gateway --all-targets --features gateway -- -D warnings`
- `cargo fmt --check`

## AI usage

This contribution was generated with AI assistance and manually reviewed and tested by the contributor.
