### PR TITLE
feat(gateway): configure repodata variant fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5433,6 +5433,7 @@ dependencies = [
  "http-cache-semantics",
  "humansize",
  "humantime",
+ "indexmap 2.14.0",
  "indicatif",
  "insta",
  "itertools 0.15.0",

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -34,6 +34,7 @@ http-cache-semantics = { workspace = true, optional = true, features = ["reqwest
 humansize = { workspace = true }
 humantime = { workspace = true }
 indicatif = { workspace = true, optional = true }
+indexmap = { workspace = true }
 itertools = { workspace = true, optional = true }
 json-patch = { workspace = true }
 self_cell = { workspace = true, optional = true }

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -110,7 +110,7 @@ impl From<tokio::task::JoinError> for FetchRepoDataError {
 /// Defines which type of repodata.json file to download. Usually you want to
 /// use the [`Variant::AfterPatches`] variant because that reflects the repodata
 /// with any patches applied.
-#[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Default, Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Variant {
     /// Fetch the `repodata.json` file. This `repodata.json` has repodata
     /// patches applied. Packages may have also been removed from this file

--- a/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rattler_conda_types::ChannelUrl;
 use url::Url;
 
-use crate::fetch::CacheAction;
+use crate::fetch::{CacheAction, Variant};
 
 /// Describes additional properties that influence how the gateway fetches
 /// repodata for a specific channel.
@@ -23,6 +23,10 @@ pub struct SourceConfig {
     /// Describes fetching repodata from a channel should interact with any
     /// caches.
     pub cache_action: CacheAction,
+
+    /// Ordered repodata variants to try. `None` preserves the existing
+    /// `repodata.json`-only behavior.
+    pub repodata_variants: Option<Vec<Variant>>,
 
     /// When the gateway may only read from the cache, report a package whose
     /// shard is absent as having no records instead of failing the query.
@@ -47,6 +51,7 @@ impl Default for SourceConfig {
             bz2_enabled: true,
             sharded_enabled: true,
             cache_action: CacheAction::default(),
+            repodata_variants: None,
             missing_shards_are_empty: false,
         }
     }
@@ -60,6 +65,7 @@ impl From<rattler_config::config::repodata_config::RepodataChannelConfig> for So
             bz2_enabled: !value.disable_bzip2.unwrap_or(false),
             sharded_enabled: !value.disable_sharded.unwrap_or(false),
             cache_action: CacheAction::default(),
+            repodata_variants: None,
             missing_shards_are_empty: false,
         }
     }

--- a/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/channel_config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use indexmap::IndexSet;
 use rattler_conda_types::ChannelUrl;
 use url::Url;
 
@@ -24,9 +25,8 @@ pub struct SourceConfig {
     /// caches.
     pub cache_action: CacheAction,
 
-    /// Ordered repodata variants to try. `None` preserves the existing
-    /// `repodata.json`-only behavior.
-    pub repodata_variants: Option<Vec<Variant>>,
+    /// Ordered repodata variants to try. `None` fetches only `repodata.json`.
+    pub repodata_variants: Option<IndexSet<Variant>>,
 
     /// When the gateway may only read from the cache, report a package whose
     /// shard is absent as having no records instead of failing the query.

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -459,7 +459,9 @@ mod test {
 
     use crate::{
         DownloadReporter, GatewayError, RepoData, Reporter, SourceConfig, SubdirSelection,
-        UnsupportedRepodataRevision, fetch::CacheAction, gateway::Gateway,
+        UnsupportedRepodataRevision,
+        fetch::{CacheAction, Variant},
+        gateway::{ChannelConfig as GatewayChannelConfig, Gateway},
         utils::simple_channel_server::SimpleChannelServer,
     };
     use rattler_conda_types::RepodataRevision;
@@ -524,6 +526,54 @@ mod test {
 
         let total_records: usize = records.iter().map(RepoData::len).sum();
         assert_eq!(total_records, 45060);
+    }
+
+    #[tokio::test]
+    async fn configured_repodata_variants_use_ordered_fallback() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let noarch = tempdir.path().join("noarch");
+        fs_err::create_dir_all(&noarch).unwrap();
+        let repodata = r#"{
+            "info": {"subdir": "noarch"},
+            "packages": {
+                "demo-1.0-0.tar.bz2": {
+                    "build": "0", "build_number": 0, "depends": [],
+                    "name": "demo", "noarch": "generic", "subdir": "noarch",
+                    "version": "1.0"
+                }
+            },
+            "packages.conda": {}
+        }"#;
+        fs_err::write(noarch.join("current_repodata.json"), repodata).unwrap();
+
+        let source_config = SourceConfig {
+            sharded_enabled: false,
+            repodata_variants: Some(vec![Variant::Current, Variant::AfterPatches]),
+            ..SourceConfig::default()
+        };
+        let gateway_config = GatewayChannelConfig {
+            default: source_config,
+            ..GatewayChannelConfig::default()
+        };
+        let query = |gateway: &Gateway| {
+            gateway.query(
+                vec![Channel::try_from_directory(tempdir.path()).unwrap()],
+                vec![Platform::NoArch],
+                vec![PackageName::from_str("demo").unwrap()],
+            )
+        };
+
+        let gateway = Gateway::builder()
+            .with_channel_config(gateway_config.clone())
+            .finish();
+        assert_eq!(query(&gateway).await.unwrap()[0].len(), 1);
+
+        fs_err::remove_file(noarch.join("current_repodata.json")).unwrap();
+        fs_err::write(noarch.join("repodata.json"), repodata).unwrap();
+        let gateway = Gateway::builder()
+            .with_channel_config(gateway_config)
+            .finish();
+        assert_eq!(query(&gateway).await.unwrap()[0].len(), 1);
     }
 
     #[tokio::test]

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -548,7 +548,11 @@ mod test {
 
         let source_config = SourceConfig {
             sharded_enabled: false,
-            repodata_variants: Some(vec![Variant::Current, Variant::AfterPatches]),
+            repodata_variants: Some(
+                [Variant::Current, Variant::AfterPatches]
+                    .into_iter()
+                    .collect(),
+            ),
             ..SourceConfig::default()
         };
         let gateway_config = GatewayChannelConfig {

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/tokio.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/tokio.rs
@@ -28,30 +28,47 @@ impl RemoteSubdirClient {
     ) -> Result<Self, GatewayError> {
         let subdir_url = channel.platform_url(platform);
 
-        // Fetch the repodata from the remote server
-        let repodata = fetch_repo_data(
-            subdir_url,
-            client,
-            cache_dir,
-            FetchRepoDataOptions {
-                cache_action: source_config.cache_action,
-                zstd_enabled: source_config.zstd_enabled,
-                bz2_enabled: source_config.bz2_enabled,
-                ..FetchRepoDataOptions::default()
-            },
-            reporter,
-        )
-        .await
-        .map_err(|e| match e {
-            FetchRepoDataError::NotFound(e) => {
-                GatewayError::SubdirNotFoundError(Box::new(SubdirNotFoundError {
-                    channel: channel.clone(),
-                    subdir: platform.to_string(),
-                    source: e.into(),
-                }))
+        // Fetch the first available configured repodata variant.
+        let variants = source_config
+            .repodata_variants
+            .filter(|variants| !variants.is_empty())
+            .unwrap_or_else(|| vec![Variant::default()]);
+        let variant_count = variants.len();
+        let mut repodata = None;
+        for (index, variant) in variants.into_iter().enumerate() {
+            match fetch_repo_data(
+                subdir_url.clone(),
+                client.clone(),
+                cache_dir.clone(),
+                FetchRepoDataOptions {
+                    cache_action: source_config.cache_action,
+                    variant,
+                    zstd_enabled: source_config.zstd_enabled,
+                    bz2_enabled: source_config.bz2_enabled,
+                    ..FetchRepoDataOptions::default()
+                },
+                reporter.clone(),
+            )
+            .await
+            {
+                Ok(value) => {
+                    repodata = Some(value);
+                    break;
+                }
+                Err(FetchRepoDataError::NotFound(_)) if index + 1 < variant_count => {}
+                Err(FetchRepoDataError::NotFound(error)) => {
+                    return Err(GatewayError::SubdirNotFoundError(Box::new(
+                        SubdirNotFoundError {
+                            channel: channel.clone(),
+                            subdir: platform.to_string(),
+                            source: error.into(),
+                        },
+                    )));
+                }
+                Err(error) => return Err(GatewayError::FetchRepoDataError(error)),
             }
-            e => GatewayError::FetchRepoDataError(e),
-        })?;
+        }
+        let repodata = repodata.expect("repodata variant lists are non-empty");
 
         // Create a new sparse repodata client that can be used to read records from the
         // repodata.

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/tokio.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/tokio.rs
@@ -32,7 +32,7 @@ impl RemoteSubdirClient {
         let variants = source_config
             .repodata_variants
             .filter(|variants| !variants.is_empty())
-            .unwrap_or_else(|| vec![Variant::default()]);
+            .unwrap_or_else(|| indexmap::IndexSet::from([Variant::default()]));
         let variant_count = variants.len();
         let mut repodata = None;
         for (index, variant) in variants.into_iter().enumerate() {

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/wasm.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/wasm.rs
@@ -6,7 +6,7 @@ use rattler_networking::LazyClient;
 use crate::{
     Reporter,
     fetch::{
-        FetchRepoDataError,
+        FetchRepoDataError, Variant,
         no_cache::{FetchRepoDataOptions, fetch_repo_data, fetch_repo_data_js},
     },
     gateway::{
@@ -29,27 +29,50 @@ impl RemoteSubdirClient {
         reporter: Option<Arc<dyn Reporter>>,
     ) -> Result<Self, GatewayError> {
         let subdir_url = channel.platform_url(platform);
-        let options = FetchRepoDataOptions {
-            zstd_enabled: source_config.zstd_enabled,
-            bz2_enabled: source_config.bz2_enabled,
-            ..FetchRepoDataOptions::default()
-        };
-
-        // Fetch the repodata from the remote server
-        let repodata_bytes = match js_fetch {
-            Some(fetcher) => fetch_repo_data_js(subdir_url, fetcher, options).await,
-            None => fetch_repo_data(subdir_url, client, options, reporter).await,
-        }
-        .map_err(|e| match e {
-            FetchRepoDataError::NotFound(e) => {
-                GatewayError::SubdirNotFoundError(Box::new(SubdirNotFoundError {
-                    channel: channel.clone(),
-                    subdir: platform.to_string(),
-                    source: e.into(),
-                }))
+        let variants = source_config
+            .repodata_variants
+            .filter(|variants| !variants.is_empty())
+            .unwrap_or_else(|| vec![Variant::default()]);
+        let variant_count = variants.len();
+        let mut repodata_bytes = None;
+        for (index, variant) in variants.into_iter().enumerate() {
+            let options = FetchRepoDataOptions {
+                variant,
+                zstd_enabled: source_config.zstd_enabled,
+                bz2_enabled: source_config.bz2_enabled,
+                ..FetchRepoDataOptions::default()
+            };
+            let result = match js_fetch.clone() {
+                Some(fetcher) => fetch_repo_data_js(subdir_url.clone(), fetcher, options).await,
+                None => {
+                    fetch_repo_data(
+                        subdir_url.clone(),
+                        client.clone(),
+                        options,
+                        reporter.clone(),
+                    )
+                    .await
+                }
+            };
+            match result {
+                Ok(value) => {
+                    repodata_bytes = Some(value);
+                    break;
+                }
+                Err(FetchRepoDataError::NotFound(_)) if index + 1 < variant_count => {}
+                Err(FetchRepoDataError::NotFound(error)) => {
+                    return Err(GatewayError::SubdirNotFoundError(Box::new(
+                        SubdirNotFoundError {
+                            channel: channel.clone(),
+                            subdir: platform.to_string(),
+                            source: error.into(),
+                        },
+                    )));
+                }
+                Err(error) => return Err(GatewayError::FetchRepoDataError(error)),
             }
-            e => GatewayError::FetchRepoDataError(e),
-        })?;
+        }
+        let repodata_bytes = repodata_bytes.expect("repodata variant lists are non-empty");
 
         // Create a new sparse repodata client that can be used to read records from the
         // repodata.

--- a/crates/rattler_repodata_gateway/src/gateway/remote_subdir/wasm.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/remote_subdir/wasm.rs
@@ -32,7 +32,7 @@ impl RemoteSubdirClient {
         let variants = source_config
             .repodata_variants
             .filter(|variants| !variants.is_empty())
-            .unwrap_or_else(|| vec![Variant::default()]);
+            .unwrap_or_else(|| indexmap::IndexSet::from([Variant::default()]));
         let variant_count = variants.len();
         let mut repodata_bytes = None;
         for (index, variant) in variants.into_iter().enumerate() {

--- a/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
@@ -179,7 +179,7 @@ impl<'g> SubdirBuilder<'g> {
             .repodata_variants
             .clone()
             .filter(|variants| !variants.is_empty())
-            .unwrap_or_else(|| vec![crate::fetch::Variant::default()]);
+            .unwrap_or_else(|| indexmap::IndexSet::from([crate::fetch::Variant::default()]));
         let path = variants
             .iter()
             .map(|variant| path.join(variant.file_name()))

--- a/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
@@ -41,10 +41,11 @@ impl<'g> SubdirBuilder<'g> {
 
     pub async fn build(self) -> Result<Subdir, GatewayError> {
         let url = self.channel.platform_url(self.platform);
+        let source_config = self.gateway.channel_config.get(&self.channel.base_url);
 
         let subdir_data = if url.scheme() == "file" {
             if let Some(path) = url_to_path(&url) {
-                self.build_local(&path).await
+                self.build_local(&path, source_config).await
             } else {
                 return Err(GatewayError::UnsupportedUrl(
                     "unsupported file based url".to_string(),
@@ -56,8 +57,6 @@ impl<'g> SubdirBuilder<'g> {
             || url.scheme() == "oci"
             || url.scheme() == "s3"
         {
-            let source_config = self.gateway.channel_config.get(&self.channel.base_url);
-
             // Use sharded repodata if enabled
             let subdir_data = if source_config.sharded_enabled
                 || gateway::force_sharded_repodata(&url)
@@ -169,10 +168,23 @@ impl<'g> SubdirBuilder<'g> {
         Ok(SubdirData::from_client(client))
     }
 
-    async fn build_local(&self, path: &Path) -> Result<SubdirData, GatewayError> {
+    async fn build_local(
+        &self,
+        path: &Path,
+        source_config: &SourceConfig,
+    ) -> Result<SubdirData, GatewayError> {
         let channel = self.channel.clone();
         let platform = self.platform;
-        let path = path.join("repodata.json");
+        let variants = source_config
+            .repodata_variants
+            .clone()
+            .filter(|variants| !variants.is_empty())
+            .unwrap_or_else(|| vec![crate::fetch::Variant::default()]);
+        let path = variants
+            .iter()
+            .map(|variant| path.join(variant.file_name()))
+            .find(|candidate| candidate.is_file())
+            .unwrap_or_else(|| path.join(variants[0].file_name()));
         let build_client =
             move || LocalSubdirClient::from_file(&path, channel.clone(), platform.as_str());
 

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -4346,6 +4346,7 @@ dependencies = [
  "http-cache-semantics",
  "humansize",
  "humantime",
+ "indexmap 2.14.0",
  "indicatif",
  "itertools 0.15.0",
  "jiff",


### PR DESCRIPTION
## Description

Closes #2742.

Add an optional ordered `repodata_variants` list to `SourceConfig`. Local, remote Tokio, and remote WASM subdirs try variants in order and fall back only on `NotFound`; transport, parsing, and other errors are returned immediately. Empty and absent lists preserve the existing `repodata.json` behavior.

The low-level fetch layer already uses variant-specific filenames for cache keys, so fallback variants remain isolated in the cache. Sharded repodata remains the first choice when enabled; downstream callers that explicitly select nonstandard repodata filenames can disable shards in the same `SourceConfig`.

This unblocks Conda-compatible `repodata_fns` support using the existing `Current`, `AfterPatches`, and `FromPackages` variants.

## Tests

- A local Gateway configured with `Current, AfterPatches` reads `current_repodata.json` first.
- Removing it and supplying only `repodata.json` exercises ordered fallback.
- `cargo test -p rattler_repodata_gateway --features gateway configured_repodata_variants --lib`
- `cargo clippy -p rattler_repodata_gateway --all-targets --features gateway -- -D warnings`
- `cargo fmt --check`

## AI usage

This contribution was generated with AI assistance and manually reviewed and tested by the contributor.
