### PR TITLE
perf: extract packages on a blocking worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,16 +321,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
 
 [[package]]
-name = "async-spooled-tempfile"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5"
-dependencies = [
- "tempfile",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5332,11 +5322,11 @@ dependencies = [
  "astral_async_http_range_reader",
  "astral_async_zip",
  "async-compression",
- "async-spooled-tempfile",
  "async-trait",
  "axum",
  "bytes",
  "bzip2",
+ "dunce",
  "filetime",
  "fs-err",
  "futures",

--- a/crates/rattler-bin/src/commands/extract.rs
+++ b/crates/rattler-bin/src/commands/extract.rs
@@ -1,115 +1,194 @@
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
+use futures_util::{StreamExt, stream};
 use miette::{Context, IntoDiagnostic};
+use rattler_conda_types::package::{CondaArchiveIdentifier, CondaArchiveType};
+use rattler_package_streaming::ExtractResult;
+use reqwest_middleware::ClientWithMiddleware;
 use url::Url;
 
-/// Extract a local or remote conda package.
+/// Extract one or more local or remote conda packages.
 #[derive(Debug, clap::Parser)]
 pub struct Opt {
-    /// Path or URL to the conda package archive (.tar.bz2 or .conda)
+    /// Paths or URLs to conda package archives (.tar.bz2 or .conda)
     #[clap(required = true)]
-    package: String,
+    packages: Vec<String>,
 
-    /// Destination directory where the package will be extracted
-    /// If not specified, extracts to a directory with the same name as the package
+    /// Destination directory. With a single package this is the directory the
+    /// package is extracted into. With multiple packages each package is
+    /// extracted into a subdirectory of this directory named after the package.
+    /// Defaults to the current directory.
     #[clap(short, long)]
     destination: Option<PathBuf>,
+
+    /// How local files are read. Remote packages always stream.
+    #[clap(long, value_enum, default_value_t = Mode::Sync)]
+    mode: Mode,
+
+    /// Number of packages to extract concurrently.
+    #[clap(long, default_value_t = 1)]
+    concurrency: usize,
 }
 
-/// Strips package extensions (.tar.bz2 or .conda) from a filename
-fn strip_package_extension(filename: &str) -> String {
-    if let Some(stripped) = filename.strip_suffix(".tar.bz2") {
-        stripped.to_string()
-    } else if let Some(stripped) = filename.strip_suffix(".conda") {
-        stripped.to_string()
-    } else {
-        filename.to_string()
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Mode {
+    /// Read the file directly on the extraction thread, like the package
+    /// cache does for local files.
+    Sync,
+    /// Stream the file through the same path downloads take: an async reader
+    /// feeding an extraction worker.
+    Async,
+}
+
+/// A package to extract, either a local file or a remote URL.
+#[derive(Debug, Clone)]
+enum Source {
+    Url(Url),
+    Path(PathBuf),
+}
+
+impl Source {
+    fn parse(package: &str) -> Self {
+        match Url::parse(package) {
+            Ok(url) if url.scheme().len() > 1 => Self::Url(url),
+            _ => Self::Path(PathBuf::from(package)),
+        }
+    }
+
+    /// The directory name to extract into when no explicit destination is
+    /// given: the archive identifier (`name-version-build`).
+    fn package_name(&self) -> miette::Result<String> {
+        let identifier = match self {
+            Self::Url(url) => CondaArchiveIdentifier::try_from_url(url),
+            Self::Path(path) => CondaArchiveIdentifier::try_from_path(path),
+        };
+        identifier
+            .map(|identifier| identifier.identifier.to_string())
+            .ok_or_else(|| miette::miette!("{self} is not a conda package archive name"))
     }
 }
 
-/// Determines the destination directory from a URL
-fn determine_destination_from_url(url: &Url) -> miette::Result<PathBuf> {
-    // Extract filename from URL path
-    let filename = url
-        .path_segments()
-        .and_then(Iterator::last)
-        .ok_or_else(|| miette::miette!("Could not extract package name from URL"))?;
-
-    let package_name = strip_package_extension(filename);
-    Ok(PathBuf::from(package_name))
+impl std::fmt::Display for Source {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Url(url) => write!(f, "{url}"),
+            Self::Path(path) => write!(f, "{}", path.display()),
+        }
+    }
 }
 
-/// Extracts a conda package from a URL
-async fn extract_from_url(
-    url: Url,
-    destination: Option<PathBuf>,
-    package_display: &str,
-    offline: bool,
-) -> miette::Result<(PathBuf, rattler_package_streaming::ExtractResult)> {
-    let destination = destination.map_or_else(|| determine_destination_from_url(&url), Ok)?;
-
-    println!(
-        "Extracting {} to {}",
-        package_display,
-        destination.display()
-    );
-
-    let client = super::client::create_client_with_middleware(offline)?;
-
-    let result =
-        rattler_package_streaming::reqwest::tokio::extract(client, url, &destination, None, None)
+async fn extract_one(
+    source: Source,
+    destination: PathBuf,
+    mode: Mode,
+    client: &ClientWithMiddleware,
+) -> miette::Result<(Source, PathBuf, ExtractResult, Duration)> {
+    let start = Instant::now();
+    let result = match (&source, mode) {
+        (Source::Url(url), _) => {
+            rattler_package_streaming::reqwest::tokio::extract(
+                client.clone(),
+                url.clone(),
+                &destination,
+                None,
+                None,
+            )
             .await
-            .into_diagnostic()
-            .with_context(|| format!("Failed to extract package from URL: {package_display}"))?;
+        }
+        (Source::Path(path), Mode::Async) => {
+            use rattler_package_streaming::tokio::async_read;
+            let archive_type = CondaArchiveType::try_from(path.as_path())
+                .ok_or(rattler_package_streaming::ExtractError::UnsupportedArchiveType);
+            match archive_type {
+                Err(err) => Err(err),
+                Ok(archive_type) => match tokio::fs::File::open(path).await {
+                    Err(err) => Err(rattler_package_streaming::ExtractError::IoError(err)),
+                    Ok(file) => match archive_type {
+                        CondaArchiveType::TarBz2 => {
+                            async_read::extract_tar_bz2(file, &destination).await
+                        }
+                        CondaArchiveType::Conda => {
+                            async_read::extract_conda(file, &destination).await
+                        }
+                    },
+                },
+            }
+        }
+        (Source::Path(path), Mode::Sync) => {
+            let path = path.clone();
+            let destination = destination.clone();
+            tokio::task::spawn_blocking(move || {
+                rattler_package_streaming::fs::extract(&path, &destination)
+            })
+            .await
+            .into_diagnostic()?
+        }
+    }
+    .into_diagnostic()
+    .with_context(|| format!("Failed to extract package: {source}"))?;
 
-    Ok((destination, result))
-}
-
-/// Determines the destination directory from a file path
-fn determine_destination_from_path(package_path: &str) -> miette::Result<PathBuf> {
-    let path = PathBuf::from(package_path);
-    let package_name = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .ok_or_else(|| miette::miette!("Invalid package filename"))?
-        .to_string();
-
-    Ok(PathBuf::from(package_name))
-}
-
-/// Extracts a conda package from a local file path
-fn extract_from_path(
-    package_path: &str,
-    destination: Option<PathBuf>,
-) -> miette::Result<(PathBuf, rattler_package_streaming::ExtractResult)> {
-    let destination =
-        destination.map_or_else(|| determine_destination_from_path(package_path), Ok)?;
-
-    println!("Extracting {} to {}", package_path, destination.display());
-
-    let result = rattler_package_streaming::fs::extract(&PathBuf::from(package_path), &destination)
-        .into_diagnostic()
-        .with_context(|| format!("Failed to extract package: {package_path}"))?;
-
-    Ok((destination, result))
+    Ok((source, destination, result, start.elapsed()))
 }
 
 pub async fn extract(opt: Opt, offline: bool) -> miette::Result<()> {
-    // Try to parse as URL, otherwise treat as file path
-    let (destination, result) = if let Ok(url) = Url::parse(&opt.package) {
-        extract_from_url(url, opt.destination, &opt.package, offline).await?
+    let sources: Vec<Source> = opt.packages.iter().map(|p| Source::parse(p)).collect();
+
+    let jobs = if let [source] = sources.as_slice() {
+        let destination = match opt.destination {
+            Some(destination) => destination,
+            None => PathBuf::from(source.package_name()?),
+        };
+        vec![(source.clone(), destination)]
     } else {
-        extract_from_path(&opt.package, opt.destination)?
+        let base = opt.destination.unwrap_or_else(|| PathBuf::from("."));
+        sources
+            .iter()
+            .map(|source| Ok((source.clone(), base.join(source.package_name()?))))
+            .collect::<miette::Result<Vec<_>>>()?
     };
 
-    println!(
-        "{} Successfully extracted package",
-        console::style("✓").green(),
-    );
-    println!("  Destination: {}", destination.display());
-    println!("  SHA256: {}", hex::encode(result.sha256));
-    println!("  MD5: {}", hex::encode(result.md5));
-    println!("  Size: {} bytes", result.total_size);
+    let concurrency = opt.concurrency.max(1);
+    let mode = opt.mode;
+    let total = jobs.len();
+    let client = super::client::create_client_with_middleware(offline)?;
+    let mut results = stream::iter(jobs)
+        .map(|(source, destination)| extract_one(source, destination, mode, &client))
+        .buffer_unordered(concurrency);
 
-    Ok(())
+    // Report each package as it finishes; a failure does not hide the others.
+    let mut extracted = 0;
+    let mut first_error = None;
+    while let Some(result) = results.next().await {
+        match result {
+            Ok((source, destination, result, elapsed)) => {
+                extracted += 1;
+                println!(
+                    "{} {} -> {} ({:.1?})",
+                    console::style("✓").green(),
+                    source,
+                    destination.display(),
+                    elapsed
+                );
+                println!("  SHA256: {}", hex::encode(result.sha256));
+                println!("  MD5: {}", hex::encode(result.md5));
+                println!("  Size: {} bytes", result.total_size);
+            }
+            Err(err) => {
+                eprintln!("{} {err:?}", console::style("✗").red());
+                first_error.get_or_insert(err);
+            }
+        }
+    }
+
+    if total > 1 {
+        println!("Extracted {extracted} of {total} packages");
+    }
+
+    match first_error {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
 }

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -13,6 +13,7 @@ readme.workspace = true
 
 [dependencies]
 bzip2 = { workspace = true }
+dunce = { workspace = true }
 jiff = { workspace = true }
 http = { workspace = true, optional = true }
 filetime = { workspace = true }
@@ -37,7 +38,7 @@ serde_json = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = [], default-features = false }
+tokio = { workspace = true, features = ["sync"], default-features = false }
 tokio-util = { workspace = true, features = ["io-util"] }
 tracing = { workspace = true }
 url = { workspace = true }
@@ -52,7 +53,6 @@ astral-tokio-tar = { workspace = true }
 bytes = { workspace = true }
 async-compression = { workspace = true }
 zstd = { workspace = true, default-features = false }
-async-spooled-tempfile = { version = "0.1" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 num_cpus = { workspace = true }

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -36,14 +36,22 @@ pub fn extract_tar_bz2(
     reader: impl Read,
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
-    std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
-
     process_with_hashing(reader, |reader| {
-        let mut archive = stream_tar_bz2(reader);
-        unpack_tar_archive_sync(&mut archive, destination)?;
-        drain_decoder(archive.into_inner())?;
-        Ok(())
+        extract_tar_bz2_without_hashing(reader, destination)
     })
+}
+
+/// Extracts a `.tar.bz2` package without computing its package hashes.
+pub(crate) fn extract_tar_bz2_without_hashing(
+    mut reader: impl Read,
+    destination: &Path,
+) -> Result<(), ExtractError> {
+    std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
+    let mut archive = stream_tar_bz2(&mut reader);
+    unpack_tar_archive_sync(&mut archive, destination)?;
+    drain_decoder(archive.into_inner())?;
+    copy(&mut reader, &mut std::io::sink())?;
+    Ok(())
 }
 
 /// Reads a decompressor to its end after the tar reader stopped at the
@@ -59,15 +67,22 @@ pub fn extract_conda_via_streaming(
     reader: impl Read,
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
-    // Construct the destination path if it doesn't exist yet
-    std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
-
     process_with_hashing(reader, |reader| {
-        while let Some(file) = read_zipfile_from_stream(reader)? {
-            extract_zipfile(file, destination)?;
-        }
-        Ok(())
+        extract_conda_via_streaming_without_hashing(reader, destination)
     })
+}
+
+/// Extracts a `.conda` package without computing its package hashes.
+pub(crate) fn extract_conda_via_streaming_without_hashing(
+    mut reader: impl Read,
+    destination: &Path,
+) -> Result<(), ExtractError> {
+    std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
+    while let Some(file) = read_zipfile_from_stream(&mut reader)? {
+        extract_zipfile(file, destination)?;
+    }
+    copy(&mut reader, &mut std::io::sink())?;
+    Ok(())
 }
 
 /// Extracts the contents of a .conda package archive by fully reading the stream and then decompressing
@@ -75,25 +90,33 @@ pub fn extract_conda_via_buffering(
     reader: impl Read,
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
+    process_with_hashing(reader, |reader| {
+        extract_conda_via_buffering_without_hashing(reader, destination)
+    })
+}
+
+/// Extracts a buffered `.conda` package without computing its package hashes.
+pub(crate) fn extract_conda_via_buffering_without_hashing(
+    mut reader: impl Read,
+    destination: &Path,
+) -> Result<(), ExtractError> {
     // delete destination first, as this method is usually used as a fallback from a failed streaming decompression
     if destination.exists() {
         std::fs::remove_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
     }
     std::fs::create_dir_all(destination).map_err(ExtractError::CouldNotCreateDestination)?;
 
-    process_with_hashing(reader, |reader| {
-        // Create a SpooledTempFile with a 5MB limit
-        let mut temp_file = SpooledTempFile::new(5 * 1024 * 1024);
-        copy(reader, &mut temp_file)?;
-        temp_file.seek(SeekFrom::Start(0))?;
-        let mut archive = ZipArchive::new(temp_file)?;
+    // Create a SpooledTempFile with a 5MB limit
+    let mut temp_file = SpooledTempFile::new(5 * 1024 * 1024);
+    copy(&mut reader, &mut temp_file)?;
+    temp_file.seek(SeekFrom::Start(0))?;
+    let mut archive = ZipArchive::new(temp_file)?;
 
-        for i in 0..archive.len() {
-            let file = archive.by_index(i)?;
-            extract_zipfile(file, destination)?;
-        }
-        Ok(())
-    })
+    for index in 0..archive.len() {
+        let file = archive.by_index(index)?;
+        extract_zipfile(file, destination)?;
+    }
+    Ok(())
 }
 
 fn extract_zipfile<R: std::io::Read>(
@@ -460,10 +483,9 @@ where
         rattler_digest::HashingReader::<_, rattler_digest::Md5>::new(sha256_reader);
     let mut size_reader = SizeCountingReader::new(&mut md5_reader);
 
+    // Every extractor reads its input to the end, so the hashes cover the
+    // whole stream once it returns.
     processor(&mut size_reader)?;
-
-    // Read the file to the end to make sure the hash is properly computed
-    std::io::copy(&mut size_reader, &mut std::io::sink())?;
 
     // Get the size and hashes
     let (_, total_size) = size_reader.finalize();

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -5,6 +5,7 @@ use super::{ExtractError, ExtractResult};
 use std::io::{Seek, SeekFrom, copy};
 use std::mem::ManuallyDrop;
 use std::{
+    collections::HashSet,
     ffi::OsStr,
     io::Read,
     path::{Component, Path, PathBuf},
@@ -40,8 +41,17 @@ pub fn extract_tar_bz2(
     process_with_hashing(reader, |reader| {
         let mut archive = stream_tar_bz2(reader);
         unpack_tar_archive_sync(&mut archive, destination)?;
+        drain_decoder(archive.into_inner())?;
         Ok(())
     })
+}
+
+/// Reads a decompressor to its end after the tar reader stopped at the
+/// end-of-archive marker, so a stream cut short in its trailer is reported
+/// instead of accepted.
+fn drain_decoder(mut decoder: impl Read) -> Result<(), ExtractError> {
+    copy(&mut decoder, &mut std::io::sink())?;
+    Ok(())
 }
 
 /// Extracts the contents of a `.conda` package archive.
@@ -103,6 +113,7 @@ fn extract_zipfile<R: std::io::Read>(
     {
         let mut archive = stream_tar_zst(&mut *file)?;
         unpack_tar_archive_sync(&mut archive, destination)?;
+        drain_decoder(archive.into_inner())?;
     } else {
         // Manually read to the end of the stream if that didn't happen.
         std::io::copy(&mut *file, &mut std::io::sink())?;
@@ -114,38 +125,227 @@ fn extract_zipfile<R: std::io::Read>(
     Ok(())
 }
 
-/// Unpacks a tar archive while handling mtime-setting failures gracefully.
+/// Unpacks a tar archive into `destination`.
 ///
-/// Disables the tar crate's automatic mtime preservation and instead sets
-/// mtimes manually with clamping (to `SAFE_MTIME_FLOOR`) and error handling.
-/// This prevents fatal extraction failures on filesystems like exFAT that
-/// do not support timestamps before 1980-01-01.
+/// Entry paths are sanitized like [`tar::Entry::unpack_in`] does, but each
+/// parent directory is validated against the destination only the first time
+/// it is seen. `unpack_in` canonicalizes both the parent and the destination
+/// for every entry, which dominates extraction time on Windows.
+///
+/// Mtimes are set manually with clamping (to `SAFE_MTIME_FLOOR`) and error
+/// handling, so filesystems like exFAT that cannot represent timestamps
+/// before 1980-01-01 do not fail the extraction.
 fn unpack_tar_archive_sync<R: Read>(
     archive: &mut tar::Archive<R>,
     destination: &Path,
 ) -> Result<(), ExtractError> {
     archive.set_preserve_mtime(false);
 
+    // `dunce` keeps Windows paths in their normal form instead of the `\\?\`
+    // verbatim form that `std::fs::canonicalize` returns.
+    let destination = dunce::canonicalize(destination).map_err(ExtractError::IoError)?;
+    let mut validated_parents: HashSet<PathBuf> = HashSet::new();
+
     for entry in archive.entries().map_err(ExtractError::IoError)? {
         let mut entry = entry.map_err(ExtractError::IoError)?;
+        let entry_type = entry.header().entry_type();
         let mtime = entry.header().mtime().unwrap_or(0);
-        let is_symlink = entry.header().entry_type().is_symlink();
         let entry_path = entry.path().map_err(ExtractError::IoError)?.into_owned();
+        // Old tar formats mark directories with a trailing slash only.
+        let is_regular_file = entry_type.is_file()
+            && !(entry.header().as_ustar().is_none() && entry.path_bytes().ends_with(b"/"));
 
-        let unpacked = entry
-            .unpack_in(destination)
-            .map_err(ExtractError::IoError)?;
+        // Entries with `..` components or that resolve to the destination
+        // itself are skipped, like `unpack_in` does.
+        let Some(file_dst) = unpacked_destination_path(&destination, &entry_path) else {
+            continue;
+        };
+        let Some(parent) = file_dst.parent() else {
+            continue;
+        };
 
-        // Set mtime on the path the entry was actually written to, recomputed
-        // with the same sanitization `unpack_in` applies. Joining the raw
-        // header path onto `destination` would let an absolute or `..` entry
-        // point the mtime write at a file outside the extraction directory.
-        if unpacked && let Some(full_path) = unpacked_destination_path(destination, &entry_path) {
-            set_mtime_safe(&full_path, mtime, is_symlink);
+        if cfg!(windows) && entry_type.is_symlink() {
+            // Creating symlinks requires elevated privileges or developer
+            // mode on Windows. Packages that ship them still extract, minus
+            // the links.
+            tracing::warn!("Skipping symlink in tar archive: {}", entry_path.display());
+            continue;
+        }
+
+        // A link can redirect a directory that was validated earlier, so
+        // every parent is validated again after one.
+        if entry_type.is_symlink() || entry_type.is_hard_link() {
+            validated_parents.clear();
+        }
+
+        if !validated_parents.contains(parent) {
+            ensure_dir_inside(&destination, parent)
+                .map_err(|err| unpack_error(&entry_path, err))?;
+            validated_parents.insert(parent.to_path_buf());
+        }
+
+        if is_regular_file {
+            unpack_file(&mut entry, &file_dst, mtime)
+                .map_err(|err| unpack_error(&entry_path, err))?;
+        } else {
+            if entry_type.is_hard_link() {
+                unpack_hard_link(&destination, &entry, &file_dst)
+            } else {
+                entry.unpack(&file_dst).map(|_| ())
+            }
+            .map_err(|err| unpack_error(&entry_path, err))?;
+            set_mtime_safe(&file_dst, mtime);
         }
     }
 
     Ok(())
+}
+
+/// Names the archive entry in an error from unpacking it.
+fn unpack_error(entry_path: &Path, err: std::io::Error) -> ExtractError {
+    ExtractError::IoError(std::io::Error::new(
+        err.kind(),
+        format!("failed to unpack `{}`: {err}", entry_path.display()),
+    ))
+}
+
+/// Largest write buffer used when unpacking a regular file.
+const UNPACK_WRITE_BUFFER_SIZE: usize = 128 * 1024;
+
+/// Writes a regular file entry to `file_dst`.
+///
+/// [`tar::Entry::unpack`] copies with 8 KiB writes; buffering up to the file
+/// size cuts the number of write calls, which dominates on Windows. The mtime
+/// is set through the open handle, saving a reopen per file.
+fn unpack_file<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    file_dst: &Path,
+    mtime: u64,
+) -> std::io::Result<()> {
+    fn create_new(path: &Path) -> std::io::Result<std::fs::File> {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+    }
+
+    // Always write a new file instead of truncating in place, so an existing
+    // hard link or symlink at the destination cannot redirect the write.
+    let file = match create_new(file_dst) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            std::fs::remove_file(file_dst)?;
+            create_new(file_dst)?
+        }
+        Err(err) => return Err(err),
+    };
+
+    let capacity = usize::try_from(entry.size())
+        .unwrap_or(UNPACK_WRITE_BUFFER_SIZE)
+        .min(UNPACK_WRITE_BUFFER_SIZE);
+    let mut writer = std::io::BufWriter::with_capacity(capacity, file);
+    copy(entry, &mut writer)?;
+    let file = writer
+        .into_inner()
+        .map_err(std::io::IntoInnerError::into_error)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(mode) = entry.header().mode() {
+            file.set_permissions(std::fs::Permissions::from_mode(mode & 0o777))?;
+        }
+    }
+
+    let clamped = std::cmp::max(mtime, SAFE_MTIME_FLOOR);
+    let file_time = filetime::FileTime::from_unix_time(clamped as i64, 0);
+    if let Err(e) = filetime::set_file_handle_times(&file, None, Some(file_time)) {
+        tracing::warn!(
+            "Failed to set mtime for '{}': {}. \
+             The target filesystem may not support this timestamp. \
+             This does not affect package integrity.",
+            file_dst.display(),
+            e
+        );
+    }
+
+    Ok(())
+}
+
+/// Creates `dir` and any missing ancestors, after checking that the deepest
+/// existing ancestor resolves inside `destination`. Checking before creating
+/// keeps a symlinked ancestor from leading directory creation outside the
+/// destination.
+fn ensure_dir_inside(destination: &Path, dir: &Path) -> std::io::Result<()> {
+    let mut missing = Vec::new();
+    let mut ancestor = dir;
+    while ancestor.symlink_metadata().is_err() {
+        missing.push(ancestor);
+        match ancestor.parent() {
+            Some(parent) => ancestor = parent,
+            None => break,
+        }
+    }
+
+    validate_inside(destination, ancestor)?;
+    for dir in missing.into_iter().rev() {
+        match std::fs::create_dir(dir) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
+}
+
+/// Errors when the canonical form of `path` is not inside `destination`.
+fn validate_inside(destination: &Path, path: &Path) -> std::io::Result<()> {
+    let canonical = dunce::canonicalize(path)?;
+    if canonical.starts_with(destination) {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "trying to unpack outside of destination path: {}",
+                path.display()
+            ),
+        ))
+    }
+}
+
+/// Creates the hard link described by `entry` at `file_dst`. The link source
+/// is resolved relative to the destination and must already exist inside it.
+fn unpack_hard_link<R: Read>(
+    destination: &Path,
+    entry: &tar::Entry<'_, R>,
+    file_dst: &Path,
+) -> std::io::Result<()> {
+    let link_name = entry.link_name()?.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "hard link entry without a link name",
+        )
+    })?;
+    let link_src = unpacked_destination_path(destination, &link_name).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "hard link source escapes the destination: {}",
+                link_name.display()
+            ),
+        )
+    })?;
+    validate_inside(destination, &link_src)?;
+    match std::fs::hard_link(&link_src, file_dst) {
+        // A retried extraction into the same destination finds the link from
+        // the previous attempt.
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            std::fs::remove_file(file_dst)?;
+            std::fs::hard_link(&link_src, file_dst)
+        }
+        result => result,
+    }
 }
 
 /// Resolves the on-disk path a tar entry is unpacked to, mirroring the
@@ -172,19 +372,15 @@ fn unpacked_destination_path(destination: &Path, entry_path: &Path) -> Option<Pa
     Some(full_path)
 }
 
-/// Sets the modification time on a file, clamping to a safe minimum and
-/// logging a warning on failure instead of propagating the error.
-fn set_mtime_safe(path: &Path, mtime: u64, is_symlink: bool) {
+/// Sets the modification time of `path` itself, without following a symlink,
+/// clamping to a safe minimum and logging a warning on failure instead of
+/// propagating the error. Never following keeps a symlink entry from
+/// redirecting the write to a location outside the destination.
+fn set_mtime_safe(path: &Path, mtime: u64) {
     let clamped = std::cmp::max(mtime, SAFE_MTIME_FLOOR);
     let file_time = filetime::FileTime::from_unix_time(clamped as i64, 0);
 
-    let result = if is_symlink {
-        filetime::set_symlink_file_times(path, file_time, file_time)
-    } else {
-        filetime::set_file_mtime(path, file_time)
-    };
-
-    if let Err(e) = result {
+    if let Err(e) = filetime::set_symlink_file_times(path, file_time, file_time) {
         tracing::warn!(
             "Failed to set mtime for '{}': {}. \
              The target filesystem may not support this timestamp. \
@@ -271,6 +467,16 @@ where
 
     // Get the size and hashes
     let (_, total_size) = size_reader.finalize();
+
+    // An empty stream decodes as an empty archive without any decoder
+    // complaining, so reject it here.
+    if total_size == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "no data was read from the package stream - the stream may have been truncated",
+        )
+        .into());
+    }
     let (sha256_reader, md5) = md5_reader.finalize();
     let (_, sha256) = sha256_reader.finalize();
 

--- a/crates/rattler_package_streaming/src/tokio/async_read.rs
+++ b/crates/rattler_package_streaming/src/tokio/async_read.rs
@@ -17,6 +17,7 @@ use std::{
 #[cfg(feature = "reqwest")]
 use futures_util::StreamExt;
 use futures_util::future::{self, Either};
+use rattler_digest::{Md5, Sha256, digest::Digest};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::{ExtractError, ExtractResult};
@@ -37,7 +38,7 @@ pub async fn extract_tar_bz2(
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
     extract_blocking(reader, destination, |reader, destination| {
-        crate::read::extract_tar_bz2(reader, destination)
+        crate::read::extract_tar_bz2_without_hashing(reader, destination)
     })
     .await
 }
@@ -49,7 +50,7 @@ pub async fn extract_conda(
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
     extract_blocking(reader, destination, |reader, destination| {
-        crate::read::extract_conda_via_streaming(reader, destination)
+        crate::read::extract_conda_via_streaming_without_hashing(reader, destination)
     })
     .await
 }
@@ -62,7 +63,7 @@ pub async fn extract_conda_via_buffering(
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
     extract_blocking(reader, destination, |reader, destination| {
-        crate::read::extract_conda_via_buffering(reader, destination)
+        crate::read::extract_conda_via_buffering_without_hashing(reader, destination)
     })
     .await
 }
@@ -127,22 +128,36 @@ impl Drop for CancelOnDrop {
     }
 }
 
-/// Runs a blocking extractor on a worker thread while pumping `reader` into
-/// it through a bounded channel of chunks.
+fn flatten_worker_result(
+    joined: Result<Result<(), ExtractError>, tokio::task::JoinError>,
+) -> Result<(), ExtractError> {
+    match joined {
+        Ok(result) => result,
+        Err(err) => {
+            if let Ok(reason) = err.try_into_panic() {
+                std::panic::resume_unwind(reason);
+            }
+            Err(ExtractError::Cancelled)
+        }
+    }
+}
+
+/// Runs a blocking extractor on a worker thread while pumping and hashing
+/// `reader` on the async runtime.
 ///
-/// The worker reads to the end so that the archive hashes cover the whole
-/// stream. If the worker stops reading early, for example because the archive
-/// is invalid, the channel closes and the pump stops. If the reader fails, the
-/// worker is told to stop and awaited before the error is returned, so the
-/// destination is not written to after this function returns. Dropping the
-/// returned future tells the worker to stop at its next read; a write already
-/// in progress on the worker thread finishes first.
+/// The worker reads to the end so the pump hashes the whole stream. If the
+/// worker stops reading early, for example because the archive is invalid, the
+/// channel closes and the pump stops. If the reader fails, the worker is told
+/// to stop and awaited before the error is returned, so the destination is not
+/// written to after this function returns. Dropping the returned future tells
+/// the worker to stop at its next read; a write already in progress on the
+/// worker thread finishes first.
 ///
 /// Must be called from within a tokio runtime.
 async fn extract_blocking<R: AsyncRead + Unpin>(
     reader: R,
     destination: &Path,
-    extract: fn(Box<dyn Read + Send>, &Path) -> Result<ExtractResult, ExtractError>,
+    extract: fn(Box<dyn Read + Send>, &Path) -> Result<(), ExtractError>,
 ) -> Result<ExtractResult, ExtractError> {
     let (sender, receiver) = tokio::sync::mpsc::channel(CHUNKS_IN_FLIGHT);
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -158,12 +173,18 @@ async fn extract_blocking<R: AsyncRead + Unpin>(
 
     let pump = async move {
         let mut reader = reader;
+        let mut sha256 = Sha256::new();
+        let mut md5 = Md5::new();
+        let mut total_size = 0;
         loop {
             let mut chunk = vec![0u8; CHUNK_SIZE];
             let read = read_exact_or_eof(&mut reader, &mut chunk).await?;
             if read == 0 {
                 break;
             }
+            sha256.update(&chunk[..read]);
+            md5.update(&chunk[..read]);
+            total_size += read as u64;
             chunk.truncate(read);
             // A closed channel means the worker stopped reading.
             if sender.send(chunk).await.is_err() || read < CHUNK_SIZE {
@@ -171,32 +192,38 @@ async fn extract_blocking<R: AsyncRead + Unpin>(
             }
         }
         // Dropping the sender signals end-of-file to the worker.
-        Ok::<_, std::io::Error>(())
+        if total_size == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "no data was read from the package stream - the stream may have been truncated",
+            ));
+        }
+        Ok::<_, std::io::Error>(ExtractResult {
+            sha256: sha256.finalize(),
+            md5: md5.finalize(),
+            total_size,
+        })
     };
 
     // The pump is polled first so a read error is reported instead of the
     // truncated-archive error the worker produces when the channel closes
     // early.
     let pump = std::pin::pin!(pump);
-    let joined = match future::select(pump, &mut worker).await {
-        Either::Left((Ok(()), worker)) => worker.await,
+    match future::select(pump, &mut worker).await {
+        Either::Left((Ok(result), worker)) => {
+            flatten_worker_result(worker.await)?;
+            Ok(result)
+        }
         Either::Left((Err(err), worker)) => {
             // The pump and its sender are gone. Stop the worker and wait for
             // it so nothing touches the destination after we return.
             drop(cancel_guard);
             let _ = worker.await;
-            return Err(ExtractError::IoError(err));
+            Err(ExtractError::IoError(err))
         }
-        Either::Right((joined, _pump)) => joined,
-    };
-
-    match joined {
-        Ok(result) => result,
-        Err(err) => {
-            if let Ok(reason) = err.try_into_panic() {
-                std::panic::resume_unwind(reason);
-            }
-            Err(ExtractError::Cancelled)
+        Either::Right((joined, pump)) => {
+            flatten_worker_result(joined)?;
+            pump.await.map_err(ExtractError::IoError)
         }
     }
 }

--- a/crates/rattler_package_streaming/src/tokio/async_read.rs
+++ b/crates/rattler_package_streaming/src/tokio/async_read.rs
@@ -1,231 +1,204 @@
 //! Functions that enable extracting or streaming a Conda package for objects
 //! that implement the [`tokio::io::AsyncRead`] trait.
+//!
+//! Extraction runs on a blocking worker thread. The async reader is pumped
+//! into a bounded channel of fixed-size chunks, so downloading continues while
+//! the worker decompresses and writes files with plain blocking I/O.
 
-use std::path::Path;
+use std::{
+    io::Read,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
-use async_compression::tokio::bufread::BzDecoder;
-use async_spooled_tempfile::SpooledTempFile;
-use async_zip::base::read::stream::ZipFileReader;
 #[cfg(feature = "reqwest")]
 use futures_util::StreamExt;
-use tokio::io::{AsyncRead, AsyncSeekExt};
-use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
+use futures_util::future::{self, Either};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
-use crate::{ExtractError, ExtractResult, read::SizeCountingReader};
+use crate::{ExtractError, ExtractResult};
 
-use super::shared::{DEFAULT_BUF_SIZE, extract_tar_zst_entry, unpack_tar_archive};
+use super::shared::DEFAULT_BUF_SIZE;
 
-/// Extracts the contents a `.tar.bz2` package archive using fully async implementation.
+/// Bytes per chunk handed to the extraction worker. Chunks are filled
+/// completely before they are sent, so the worker wakes up once per chunk
+/// rather than once per network read.
+const CHUNK_SIZE: usize = DEFAULT_BUF_SIZE;
+
+/// Chunks the download can run ahead of the extraction worker.
+const CHUNKS_IN_FLIGHT: usize = 4;
+
+/// Extracts the contents of a `.tar.bz2` package archive.
 pub async fn extract_tar_bz2(
-    reader: impl AsyncRead + Send + Unpin + 'static,
+    reader: impl AsyncRead + Unpin,
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
-    // Ensure the destination directory exists
-    tokio::fs::create_dir_all(destination)
-        .await
-        .map_err(ExtractError::CouldNotCreateDestination)?;
-
-    // Clone destination for the async block
-    let destination = destination.to_owned();
-
-    // Wrap the reading in additional readers that will compute the hashes while extracting
-    let sha256_reader = rattler_digest::HashingReader::<_, rattler_digest::Sha256>::new(reader);
-    let mut md5_reader =
-        rattler_digest::HashingReader::<_, rattler_digest::Md5>::new(sha256_reader);
-    let mut size_reader = SizeCountingReader::new(&mut md5_reader);
-
-    // Create a buffered reader for better performance
-    let buf_reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, &mut size_reader);
-
-    // Decompress bzip2 asynchronously
-    let decoder = BzDecoder::new(buf_reader);
-
-    // Build archive with optimized settings for faster extraction:
-    // - Skip automatic mtime preservation (we set mtimes manually with safe clamping)
-    // - Skip automatic permission handling (we'll set executable bits manually)
-    // - Skip extended attributes for better performance
-    let archive = tokio_tar::ArchiveBuilder::new(decoder)
-        .set_preserve_mtime(false)
-        .set_preserve_permissions(false)
-        .set_unpack_xattrs(false)
-        // We need this setting otherwise some packages in conda-forge will
-        // not extract. However, we are checking much better in rattler-build and hopefully
-        // one day can remove this.
-        .set_allow_external_symlinks(true)
-        .build();
-
-    // Unpack entries manually, preserving only executable bits on Unix
-    unpack_tar_archive(archive, &destination).await?;
-
-    // Read the file to the end to make sure the hash is properly computed
-    tokio::io::copy(&mut size_reader, &mut tokio::io::sink())
-        .await
-        .map_err(ExtractError::IoError)?;
-
-    // Get the size and hashes
-    let (_, total_size) = size_reader.finalize();
-    let (sha256_reader, md5) = md5_reader.finalize();
-    let (_, sha256) = sha256_reader.finalize();
-
-    // Validate that we actually read some data from the stream.
-    // If total_size is 0, it likely means the stream was truncated or the bzip2
-    // decompressor silently failed without detecting an incomplete stream.
-    if total_size == 0 {
-        return Err(ExtractError::IoError(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "no data was read from the package stream - the stream may have been truncated",
-        )));
-    }
-
-    Ok(ExtractResult {
-        sha256,
-        md5,
-        total_size,
+    extract_blocking(reader, destination, |reader, destination| {
+        crate::read::extract_tar_bz2(reader, destination)
     })
+    .await
 }
 
-/// Extracts the contents of a `.conda` package archive using fully async implementation.
-/// This will perform on-the-fly decompression by streaming the reader.
+/// Extracts the contents of a `.conda` package archive, decompressing the
+/// stream as it arrives.
 pub async fn extract_conda(
-    reader: impl AsyncRead + Send + Unpin + 'static,
+    reader: impl AsyncRead + Unpin,
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
-    // Ensure the destination directory exists
-    tokio::fs::create_dir_all(destination)
-        .await
-        .map_err(ExtractError::CouldNotCreateDestination)?;
-
-    // Clone destination for the async block
-    let destination = destination.to_owned();
-
-    // Wrap the reading in additional readers that will compute the hashes while extracting
-    let sha256_reader = rattler_digest::HashingReader::<_, rattler_digest::Sha256>::new(reader);
-    let mut md5_reader =
-        rattler_digest::HashingReader::<_, rattler_digest::Md5>::new(sha256_reader);
-    let mut size_reader = SizeCountingReader::new(&mut md5_reader);
-
-    // Convert to futures traits and create a buffered reader (async_zip uses futures traits)
-    let compat_reader = (&mut size_reader).compat();
-    let mut buf_reader = futures::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, compat_reader);
-
-    // Create a ZIP reader for streaming
-    let mut zip_reader = ZipFileReader::new(&mut buf_reader);
-
-    // Process each ZIP entry
-    while let Some(mut entry) = zip_reader
-        .next_with_entry()
-        .await
-        .map_err(|e| ExtractError::IoError(std::io::Error::other(e)))?
-    {
-        let filename = entry.reader().entry().filename().as_str().map_err(|e| {
-            ExtractError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
-        })?;
-
-        // Only extract .tar.zst files
-        if filename.ends_with(".tar.zst") {
-            // Get a reader for the entry and convert from futures traits to tokio traits
-            let mut compat_entry = entry.reader_mut().compat();
-            extract_tar_zst_entry(&mut compat_entry, &destination).await?;
-        }
-
-        // Skip to the next entry (required by async_zip API)
-        (.., zip_reader) = entry
-            .skip()
-            .await
-            .map_err(|e| ExtractError::IoError(std::io::Error::other(e)))?;
-    }
-
-    // Read any remaining data to ensure hash is properly computed
-    // Use futures copy since we're already in futures ecosystem
-    futures::io::copy(&mut buf_reader, &mut futures::io::sink())
-        .await
-        .map_err(ExtractError::IoError)?;
-
-    // Get the size and hashes
-    let (_, total_size) = size_reader.finalize();
-    let (sha256_reader, md5) = md5_reader.finalize();
-    let (_, sha256) = sha256_reader.finalize();
-
-    // Validate that we actually read some data from the stream
-    if total_size == 0 {
-        return Err(ExtractError::IoError(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "no data was read from the package stream - the stream may have been truncated",
-        )));
-    }
-
-    Ok(ExtractResult {
-        sha256,
-        md5,
-        total_size,
+    extract_blocking(reader, destination, |reader, destination| {
+        crate::read::extract_conda_via_streaming(reader, destination)
     })
+    .await
 }
 
-/// Extracts the contents of a .conda package archive by fully reading the
-/// stream and then decompressing. This is a fallback method for when streaming fails.
-///
-/// This implementation uses a `SpooledTempFile` (5MB in-memory threshold) to buffer
-/// the package data, then uses the seek-based ZIP API for efficient extraction.
+/// Extracts the contents of a `.conda` package archive by fully reading the
+/// stream before decompressing. This is the fallback for archives that cannot
+/// be extracted while streaming, such as those using data descriptors.
 pub async fn extract_conda_via_buffering(
-    reader: impl AsyncRead + Send + Unpin + 'static,
+    reader: impl AsyncRead + Unpin,
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
-    // Delete destination first if it exists, as this method is usually used as a fallback
-    if tokio::fs::try_exists(destination)
-        .await
-        .map_err(ExtractError::IoError)?
-    {
-        tokio::fs::remove_dir_all(destination)
-            .await
-            .map_err(ExtractError::CouldNotCreateDestination)?;
-    }
-
-    // Ensure the destination directory exists
-    tokio::fs::create_dir_all(destination)
-        .await
-        .map_err(ExtractError::CouldNotCreateDestination)?;
-
-    // Clone destination for the async block
-    let destination = destination.to_owned();
-
-    // Wrap the reading in additional readers that will compute the hashes while extracting
-    let sha256_reader = rattler_digest::HashingReader::<_, rattler_digest::Sha256>::new(reader);
-    let mut md5_reader =
-        rattler_digest::HashingReader::<_, rattler_digest::Md5>::new(sha256_reader);
-    let mut size_reader = SizeCountingReader::new(&mut md5_reader);
-
-    // Create a SpooledTempFile (uses memory up to 5MB, then switches to disk)
-    let mut spooled_file = SpooledTempFile::new(5 * 1024 * 1024);
-
-    // Copy from reader to spooled file while computing hashes
-    tokio::io::copy(&mut size_reader, &mut spooled_file)
-        .await
-        .map_err(ExtractError::IoError)?;
-
-    // Get the size and hashes now that we've read everything
-    let (_, total_size) = size_reader.finalize();
-    let (sha256_reader, md5) = md5_reader.finalize();
-    let (_, sha256) = sha256_reader.finalize();
-
-    // Validate that we actually read some data from the stream
-    if total_size == 0 {
-        return Err(ExtractError::IoError(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "no data was read from the package stream - the stream may have been truncated",
-        )));
-    }
-
-    // Rewind the spooled file to the beginning
-    spooled_file.rewind().await.map_err(ExtractError::IoError)?;
-
-    // Use the seek-based extraction (doesn't recompute hashes, we already have them)
-    crate::tokio::async_seek::extract_conda(spooled_file, &destination).await?;
-
-    Ok(ExtractResult {
-        sha256,
-        md5,
-        total_size,
+    extract_blocking(reader, destination, |reader, destination| {
+        crate::read::extract_conda_via_buffering(reader, destination)
     })
+    .await
+}
+
+/// A blocking reader over chunks received from the async pump.
+struct ChunkReader {
+    receiver: tokio::sync::mpsc::Receiver<Vec<u8>>,
+    chunk: Vec<u8>,
+    position: usize,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl Read for ChunkReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // Stop at the next read once the extraction future is gone, instead
+        // of draining buffered chunks into the destination first. Not
+        // `Interrupted`: `io::copy` and `read_exact` retry on that kind.
+        if self.cancelled.load(Ordering::Relaxed) {
+            return Err(std::io::Error::other("extraction was cancelled"));
+        }
+        while self.position == self.chunk.len() {
+            // A closed channel means the pump finished or was dropped; either
+            // way there is no more data.
+            let Some(chunk) = self.receiver.blocking_recv() else {
+                return Ok(0);
+            };
+            self.chunk = chunk;
+            self.position = 0;
+        }
+        let available = &self.chunk[self.position..];
+        let len = available.len().min(buf.len());
+        buf[..len].copy_from_slice(&available[..len]);
+        self.position += len;
+        Ok(len)
+    }
+}
+
+/// Reads until `buf` is full or the reader reaches end-of-file. Returns the
+/// number of bytes read.
+async fn read_exact_or_eof<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    buf: &mut [u8],
+) -> std::io::Result<usize> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        let read = reader.read(&mut buf[filled..]).await?;
+        if read == 0 {
+            break;
+        }
+        filled += read;
+    }
+    Ok(filled)
+}
+
+/// Sets the cancellation flag when dropped, so a worker whose future went
+/// away stops at its next read.
+struct CancelOnDrop(Arc<AtomicBool>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Runs a blocking extractor on a worker thread while pumping `reader` into
+/// it through a bounded channel of chunks.
+///
+/// The worker reads to the end so that the archive hashes cover the whole
+/// stream. If the worker stops reading early, for example because the archive
+/// is invalid, the channel closes and the pump stops. If the reader fails, the
+/// worker is told to stop and awaited before the error is returned, so the
+/// destination is not written to after this function returns. Dropping the
+/// returned future tells the worker to stop at its next read; a write already
+/// in progress on the worker thread finishes first.
+///
+/// Must be called from within a tokio runtime.
+async fn extract_blocking<R: AsyncRead + Unpin>(
+    reader: R,
+    destination: &Path,
+    extract: fn(Box<dyn Read + Send>, &Path) -> Result<ExtractResult, ExtractError>,
+) -> Result<ExtractResult, ExtractError> {
+    let (sender, receiver) = tokio::sync::mpsc::channel(CHUNKS_IN_FLIGHT);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancel_guard = CancelOnDrop(cancelled.clone());
+    let chunks = ChunkReader {
+        receiver,
+        chunk: Vec::new(),
+        position: 0,
+        cancelled,
+    };
+    let destination = destination.to_path_buf();
+    let mut worker = tokio::task::spawn_blocking(move || extract(Box::new(chunks), &destination));
+
+    let pump = async move {
+        let mut reader = reader;
+        loop {
+            let mut chunk = vec![0u8; CHUNK_SIZE];
+            let read = read_exact_or_eof(&mut reader, &mut chunk).await?;
+            if read == 0 {
+                break;
+            }
+            chunk.truncate(read);
+            // A closed channel means the worker stopped reading.
+            if sender.send(chunk).await.is_err() || read < CHUNK_SIZE {
+                break;
+            }
+        }
+        // Dropping the sender signals end-of-file to the worker.
+        Ok::<_, std::io::Error>(())
+    };
+
+    // The pump is polled first so a read error is reported instead of the
+    // truncated-archive error the worker produces when the channel closes
+    // early.
+    let pump = std::pin::pin!(pump);
+    let joined = match future::select(pump, &mut worker).await {
+        Either::Left((Ok(()), worker)) => worker.await,
+        Either::Left((Err(err), worker)) => {
+            // The pump and its sender are gone. Stop the worker and wait for
+            // it so nothing touches the destination after we return.
+            drop(cancel_guard);
+            let _ = worker.await;
+            return Err(ExtractError::IoError(err));
+        }
+        Either::Right((joined, _pump)) => joined,
+    };
+
+    match joined {
+        Ok(result) => result,
+        Err(err) => {
+            if let Ok(reason) = err.try_into_panic() {
+                std::panic::resume_unwind(reason);
+            }
+            Err(ExtractError::Cancelled)
+        }
+    }
 }
 
 /// Async equivalent of [`crate::seek::get_file_from_archive`].

--- a/crates/rattler_package_streaming/src/tokio/fs.rs
+++ b/crates/rattler_package_streaming/src/tokio/fs.rs
@@ -1,8 +1,30 @@
-//! Functions to extracting or stream a Conda package from a file on disk.
+//! Functions that enable extracting or streaming a Conda package from local
+//! files in an async context. Extraction runs on a blocking worker thread
+//! with plain file I/O, which is the fastest path for a file that is already
+//! on disk.
 
 use crate::{ExtractError, ExtractResult};
 use rattler_conda_types::package::CondaArchiveType;
 use std::path::Path;
+
+/// Runs a blocking extractor on a worker thread.
+async fn spawn_extract(
+    archive: &Path,
+    destination: &Path,
+    extract: fn(&Path, &Path) -> Result<ExtractResult, ExtractError>,
+) -> Result<ExtractResult, ExtractError> {
+    let archive = archive.to_owned();
+    let destination = destination.to_owned();
+    match tokio::task::spawn_blocking(move || extract(&archive, &destination)).await {
+        Ok(result) => result,
+        Err(err) => {
+            if let Ok(reason) = err.try_into_panic() {
+                std::panic::resume_unwind(reason);
+            }
+            Err(ExtractError::Cancelled)
+        }
+    }
+}
 
 /// Extracts the contents a `.tar.bz2` package archive at the specified path to a directory.
 ///
@@ -22,13 +44,7 @@ pub async fn extract_tar_bz2(
     archive: &Path,
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
-    // Open the file for reading using async I/O
-    let file = tokio::fs::File::open(archive)
-        .await
-        .map_err(ExtractError::IoError)?;
-
-    // Use the fully async extraction implementation
-    crate::tokio::async_read::extract_tar_bz2(file, destination).await
+    spawn_extract(archive, destination, crate::fs::extract_tar_bz2).await
 }
 
 /// Extracts the contents a `.conda` package archive at the specified path to a directory.
@@ -49,20 +65,7 @@ pub async fn extract_conda(
     archive: &Path,
     destination: &Path,
 ) -> Result<ExtractResult, ExtractError> {
-    // Spawn a block task to perform the extraction
-    let destination = destination.to_owned();
-    let archive = archive.to_owned();
-    match tokio::task::spawn_blocking(move || crate::fs::extract_conda(&archive, &destination))
-        .await
-    {
-        Ok(result) => result,
-        Err(err) => {
-            if let Ok(reason) = err.try_into_panic() {
-                std::panic::resume_unwind(reason);
-            }
-            Err(ExtractError::Cancelled)
-        }
-    }
+    spawn_extract(archive, destination, crate::fs::extract_conda).await
 }
 
 /// Extracts the contents a package archive at the specified path to a directory. The type of

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -971,6 +971,38 @@ fn file_entry_replaces_existing_symlink_without_following_it() {
     assert_eq!(std::fs::read(dest.join("victim")).unwrap(), b"new");
 }
 
+/// [`ExtractResult`] describes the complete input stream, including bytes
+/// after a `.conda` archive's zip central directory.
+#[tokio::test]
+async fn async_conda_hashes_trailing_input_after_central_directory() {
+    let mut tar = RawTar::default();
+    tar.file("payload.bin", b"complete");
+    let mut conda = build_conda("early-finish", &tar.finish());
+    assert!(conda.len() < CHUNK_SIZE);
+
+    // Exceed the bounded channel capacity so extraction must keep consuming
+    // after the archive contents are complete.
+    conda.resize(CHUNK_SIZE * 16, 0xa5);
+
+    let dest = fresh_dir("hash_after_early_worker_completion");
+    let result = tokio::time::timeout(
+        TEST_TIMEOUT,
+        rattler_package_streaming::tokio::async_read::extract_conda(conda.as_slice(), &dest),
+    )
+    .await
+    .expect("extraction hung while consuming trailing bytes")
+    .expect("trailing bytes after a complete conda archive were rejected");
+
+    assert_eq!(
+        digests(&result),
+        (sha256_hex(&conda), md5_hex(&conda), conda.len() as u64)
+    );
+    assert_eq!(
+        std::fs::read(dest.join("payload.bin")).unwrap(),
+        b"complete"
+    );
+}
+
 /// A cut that drops only trailing bytes of a `.conda` (the zip central
 /// directory) is not detected while streaming: the tar reader stops at the
 /// end-of-archive marker before the zip reader reaches its own end. Such a

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -1,18 +1,28 @@
 use std::{
+    collections::BTreeMap,
     fs::File,
-    io::Read,
+    io::{Cursor, Read, Write},
     path::{Path, PathBuf},
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::{Context, Poll},
+    time::{Duration, Instant},
 };
 
 use fs_err::tokio as tokio_fs;
 use rattler_conda_types::package::IndexJson;
+use rattler_digest::{Md5, Sha256};
 use rattler_package_streaming::{
-    ExtractError,
+    ExtractError, ExtractResult,
     read::{extract_conda_via_buffering, extract_conda_via_streaming, extract_tar_bz2},
 };
 use rstest::rstest;
 use rstest_reuse::{self, apply, template};
 use serde_json::json;
+use tokio::io::{AsyncRead, ReadBuf};
 use url::Url;
 
 fn test_data_dir() -> PathBuf {
@@ -327,8 +337,6 @@ fn test_extract_data_descriptor_package_fails_streaming_and_uses_buffering() {
 #[cfg(unix)]
 #[test]
 fn test_absolute_path_entry_does_not_set_mtime_outside_destination() {
-    use std::io::{Cursor, Write};
-
     // A file that lives outside the extraction destination. Kept short so it
     // fits the 100-byte tar name field.
     let victim = Path::new("/tmp/rattler_extract_traversal_victim.txt").to_path_buf();
@@ -388,8 +396,6 @@ fn test_absolute_path_entry_does_not_set_mtime_outside_destination() {
 /// timestamps before 1980-01-01.
 #[test]
 fn test_extract_tar_with_pre_1980_mtime() {
-    use std::io::Cursor;
-
     let temp_dir = Path::new(env!("CARGO_TARGET_TMPDIR"));
     let target_dir = temp_dir.join("pre_1980_mtime_test");
 
@@ -486,6 +492,804 @@ async fn test_extract_tar_with_pre_1980_mtime_async() {
     assert_eq!(extracted_content, content);
 }
 
+/// The sync and async paths share the extraction code but feed it
+/// differently, so the trees they write must be byte-identical.
+#[apply(conda_archives)]
+#[tokio::test]
+async fn sync_and_async_extract_conda_identical_trees(
+    #[case] input: Url,
+    #[case] sha256: &str,
+    #[case] md5: &str,
+) {
+    let file_path = tools::download_and_cache_file_async(input, sha256)
+        .await
+        .unwrap();
+    let stem = file_path.file_stem().unwrap().to_string_lossy().to_string();
+
+    let sync_dest = fresh_dir(&format!("identical_sync_{stem}"));
+    let sync_result =
+        extract_conda_via_streaming(File::open(&file_path).unwrap(), &sync_dest).unwrap();
+
+    let async_dest = fresh_dir(&format!("identical_async_{stem}"));
+    let async_result = rattler_package_streaming::tokio::async_read::extract_conda(
+        tokio_fs::File::open(&file_path).await.unwrap(),
+        &async_dest,
+    )
+    .await
+    .unwrap();
+
+    let expected = (
+        sha256.to_string(),
+        md5.to_string(),
+        std::fs::metadata(&file_path).unwrap().len(),
+    );
+    assert_eq!(digests(&sync_result), expected);
+    assert_eq!(digests(&async_result), expected);
+    let sync_tree = snapshot(&sync_dest);
+    assert!(!sync_tree.is_empty());
+    assert_eq!(sync_tree, snapshot(&async_dest));
+}
+
+#[apply(tar_bz2_archives)]
+#[tokio::test]
+async fn sync_and_async_extract_tar_bz2_identical_trees(
+    #[case] input: Url,
+    #[case] sha256: &str,
+    #[case] md5: &str,
+) {
+    let file_path = tools::download_and_cache_file_async(input, sha256)
+        .await
+        .unwrap();
+    let stem = file_path.file_stem().unwrap().to_string_lossy().to_string();
+
+    let sync_dest = fresh_dir(&format!("identical_sync_{stem}"));
+    let sync_result = extract_tar_bz2(File::open(&file_path).unwrap(), &sync_dest).unwrap();
+
+    let async_dest = fresh_dir(&format!("identical_async_{stem}"));
+    let async_result = rattler_package_streaming::tokio::async_read::extract_tar_bz2(
+        tokio_fs::File::open(&file_path).await.unwrap(),
+        &async_dest,
+    )
+    .await
+    .unwrap();
+
+    let expected = (
+        sha256.to_string(),
+        md5.to_string(),
+        std::fs::metadata(&file_path).unwrap().len(),
+    );
+    assert_eq!(digests(&sync_result), expected);
+    assert_eq!(digests(&async_result), expected);
+    let sync_tree = snapshot(&sync_dest);
+    assert!(!sync_tree.is_empty());
+    assert_eq!(sync_tree, snapshot(&async_dest));
+}
+
+/// linux-64 bzip2 ships six symlinks in both archive formats. Windows skips
+/// them and extracts the rest, unix creates them.
+#[rstest]
+#[case::tar_bz2(
+    "https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2",
+    "cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa",
+    "a1fd65c7ccbf10880423d82bca54eb54"
+)]
+#[case::conda(
+    "https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda",
+    "242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8",
+    "69b8b6202a07720f448be700e300ccf4"
+)]
+#[tokio::test]
+async fn packages_with_symlinks_extract(
+    #[case] input: Url,
+    #[case] sha256: &str,
+    #[case] md5: &str,
+) {
+    let file_path = tools::download_and_cache_file_async(input, sha256)
+        .await
+        .unwrap();
+    let dest = fresh_dir(&format!(
+        "symlinks_{}",
+        file_path.file_name().unwrap().to_string_lossy()
+    ));
+    let reader = tokio_fs::File::open(&file_path).await.unwrap();
+    let result = if file_path.extension().is_some_and(|ext| ext == "conda") {
+        rattler_package_streaming::tokio::async_read::extract_conda(reader, &dest).await
+    } else {
+        rattler_package_streaming::tokio::async_read::extract_tar_bz2(reader, &dest).await
+    }
+    .unwrap();
+    assert_eq!(hex::encode(result.sha256), sha256);
+    assert_eq!(hex::encode(result.md5), md5);
+
+    for file in [
+        "info/index.json",
+        "bin/bzgrep",
+        "bin/bzmore",
+        "bin/bzdiff",
+        "lib/libbz2.so.1.0.8",
+    ] {
+        assert!(
+            std::fs::symlink_metadata(dest.join(file))
+                .unwrap()
+                .is_file(),
+            "{file} is not a regular file"
+        );
+    }
+    for (link, target) in [
+        ("bin/bzfgrep", "bzgrep"),
+        ("bin/bzegrep", "bzgrep"),
+        ("bin/bzless", "bzmore"),
+        ("bin/bzcmp", "bzdiff"),
+        ("lib/libbz2.so", "libbz2.so.1.0.8"),
+        ("lib/libbz2.so.1.0", "libbz2.so.1.0.8"),
+    ] {
+        let on_disk = dest.join(link);
+        if cfg!(windows) {
+            assert!(
+                std::fs::symlink_metadata(&on_disk).is_err(),
+                "{link} should be skipped on windows"
+            );
+        } else {
+            let meta = std::fs::symlink_metadata(&on_disk).unwrap();
+            assert!(meta.file_type().is_symlink(), "{link} is not a symlink");
+            assert_eq!(std::fs::read_link(&on_disk).unwrap(), Path::new(target));
+        }
+    }
+}
+
+#[test]
+fn dotdot_entry_is_skipped_and_never_escapes() {
+    let tar_bz2 = RawTar::default()
+        .file("../escape_dotdot.txt", b"escaped")
+        .file("nested/../../escape_dotdot2.txt", b"escaped")
+        .file("ok.txt", b"fine")
+        .finish_bz2();
+    let dest = fresh_dir("dotdot");
+    extract_tar_bz2(Cursor::new(tar_bz2), &dest).unwrap();
+
+    let parent = dest.parent().unwrap();
+    assert!(!parent.join("escape_dotdot.txt").exists());
+    assert!(!parent.join("escape_dotdot2.txt").exists());
+    assert_eq!(std::fs::read(dest.join("ok.txt")).unwrap(), b"fine");
+    let tree = snapshot(&dest);
+    assert_eq!(tree.len(), 1, "unexpected extra entries: {tree:?}");
+}
+
+#[test]
+fn file_under_symlink_pointing_outside_is_not_written_outside() {
+    let outside = fresh_dir("symlink_escape_outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let outside_abs = outside.canonicalize().unwrap();
+
+    // A relative target that resolves to the parent of the destination and
+    // an absolute target.
+    let targets = [
+        ("rel", "..".to_string()),
+        ("abs", outside_abs.to_string_lossy().to_string()),
+    ];
+    for (label, target) in targets {
+        if target.len() >= 100 {
+            eprintln!("skipping {label}: target too long for a raw header");
+            continue;
+        }
+        let payload = format!("pwned_{label}.txt");
+        let tar_bz2 = RawTar::default()
+            .symlink("escape", &target)
+            .file(&format!("escape/{payload}"), b"pwned")
+            .dir("escape/subdir/")
+            .file(&format!("escape/subdir/{payload}"), b"pwned")
+            .file("after.txt", b"after")
+            .finish_bz2();
+        let dest = fresh_dir(&format!("symlink_escape_{label}"));
+        let result = extract_tar_bz2(Cursor::new(tar_bz2), &dest);
+
+        let parent = dest.parent().unwrap();
+        assert!(
+            !parent.join(&payload).exists(),
+            "{label}: file written outside destination via symlink"
+        );
+        assert!(
+            !parent.join("subdir").join(&payload).exists(),
+            "{label}: file written outside destination via symlink + dir"
+        );
+        assert!(
+            !outside_abs.join(&payload).exists(),
+            "{label}: file written into absolute symlink target"
+        );
+        assert!(
+            !outside_abs.join("subdir").exists(),
+            "{label}: directory created inside absolute symlink target"
+        );
+
+        if cfg!(windows) {
+            // The symlink is skipped, so `escape` is a plain directory.
+            assert!(result.is_ok(), "{label}: {result:?}");
+            assert_eq!(
+                std::fs::read(dest.join("escape").join(&payload)).unwrap(),
+                b"pwned"
+            );
+        } else {
+            assert!(
+                result.is_err(),
+                "{label}: writing through an escaping symlink must fail"
+            );
+            assert!(
+                !dest.join("after.txt").exists(),
+                "{label}: extraction continued after the failure"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn directory_entry_over_escaping_symlink_does_not_touch_outside_mtime() {
+    let outside = fresh_dir("dir_over_symlink_outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    filetime::set_file_mtime(
+        &outside,
+        filetime::FileTime::from_unix_time(1_500_000_000, 0),
+    )
+    .unwrap();
+    let outside_abs = outside.canonicalize().unwrap();
+    if outside_abs.to_string_lossy().len() >= 100 {
+        eprintln!("skipping: target too long for a raw header");
+        return;
+    }
+
+    let tar_bz2 = RawTar::default()
+        .symlink("s", &outside_abs.to_string_lossy())
+        .dir_mtime("s/", 1_600_000_000)
+        .finish_bz2();
+    let dest = fresh_dir("dir_over_symlink");
+    let result = extract_tar_bz2(Cursor::new(tar_bz2), &dest);
+
+    let mtime = filetime::FileTime::from_last_modification_time(
+        &std::fs::symlink_metadata(&outside).unwrap(),
+    );
+    assert_eq!(
+        mtime.unix_seconds(),
+        1_500_000_000,
+        "directory entry over a symlink changed the mtime outside the destination (result: {result:?})"
+    );
+}
+
+#[test]
+fn symlink_replacing_validated_directory_does_not_escape() {
+    let tar_bz2 = RawTar::default()
+        .file("d/a.txt", b"a")
+        .symlink("d", "..")
+        .file("d/b_escape.txt", b"b")
+        .finish_bz2();
+    let dest = fresh_dir("symlink_replaces_dir");
+    let result = extract_tar_bz2(Cursor::new(tar_bz2), &dest);
+    assert!(
+        !dest.parent().unwrap().join("b_escape.txt").exists(),
+        "file written outside destination (result: {result:?})"
+    );
+}
+
+#[test]
+fn hard_link_with_source_outside_destination_is_rejected() {
+    let outside = fresh_dir("hardlink_outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let outside_file = outside.join("secret.txt");
+    std::fs::write(&outside_file, b"secret").unwrap();
+    let outside_abs = outside_file.canonicalize().unwrap();
+
+    let mut targets = vec![("relative", "../hardlink_outside/secret.txt".to_string())];
+    if outside_abs.to_string_lossy().len() < 100 {
+        targets.push(("absolute", outside_abs.to_string_lossy().to_string()));
+    }
+
+    for (label, target) in targets {
+        let tar_bz2 = RawTar::default()
+            .hardlink("h.txt", &target)
+            .file("after.txt", b"after")
+            .finish_bz2();
+        let dest = fresh_dir(&format!("hardlink_outside_{label}"));
+        let result = extract_tar_bz2(Cursor::new(tar_bz2), &dest);
+        assert!(
+            result.is_err(),
+            "{label}: hard link to a file outside the destination was accepted"
+        );
+        assert!(
+            !dest.join("h.txt").exists(),
+            "{label}: hard link was created"
+        );
+        assert_eq!(std::fs::read(&outside_file).unwrap(), b"secret");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn hard_link_to_symlink_escaping_destination_is_rejected() {
+    use std::os::unix::fs::MetadataExt;
+
+    let outside = fresh_dir("hardlink_via_symlink_outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let outside_file = outside.join("secret.txt");
+    std::fs::write(&outside_file, b"secret").unwrap();
+    let outside_abs = outside_file.canonicalize().unwrap();
+    if outside_abs.to_string_lossy().len() >= 100 {
+        eprintln!("skipping: target too long for a raw header");
+        return;
+    }
+
+    let tar_bz2 = RawTar::default()
+        .symlink("s.txt", &outside_abs.to_string_lossy())
+        .hardlink("h.txt", "s.txt")
+        .finish_bz2();
+    let dest = fresh_dir("hardlink_via_symlink");
+    let result = extract_tar_bz2(Cursor::new(tar_bz2), &dest);
+    assert!(
+        result.is_err(),
+        "hard link through an escaping symlink was accepted"
+    );
+    assert!(!dest.join("h.txt").exists());
+    assert_eq!(
+        std::fs::metadata(&outside_file).unwrap().nlink(),
+        1,
+        "outside file gained a hard link"
+    );
+}
+
+#[test]
+fn hard_link_to_earlier_file_in_archive() {
+    let payload = noise(3000, 7);
+    let tar_bz2 = RawTar::default()
+        .file("a.txt", &payload)
+        .hardlink("b.txt", "a.txt")
+        .file("sub/x.txt", b"x")
+        .hardlink("sub/y.txt", "sub/x.txt")
+        .hardlink("z.txt", "./sub/x.txt")
+        .file("c.txt", b"c")
+        .finish_bz2();
+    let dest = fresh_dir("hardlink_ok");
+    extract_tar_bz2(Cursor::new(tar_bz2), &dest).unwrap();
+
+    assert_eq!(std::fs::read(dest.join("a.txt")).unwrap(), payload);
+    assert_eq!(std::fs::read(dest.join("b.txt")).unwrap(), payload);
+    assert_eq!(std::fs::read(dest.join("sub/y.txt")).unwrap(), b"x");
+    assert_eq!(std::fs::read(dest.join("z.txt")).unwrap(), b"x");
+    assert_eq!(std::fs::read(dest.join("c.txt")).unwrap(), b"c");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        assert_eq!(std::fs::metadata(dest.join("a.txt")).unwrap().nlink(), 2);
+        assert_eq!(
+            std::fs::metadata(dest.join("sub/x.txt")).unwrap().nlink(),
+            3
+        );
+    }
+}
+
+#[test]
+fn empty_files_directories_and_long_names() {
+    let long_name = format!("{}/{}.txt", "d".repeat(120), "f".repeat(60));
+    let tar_bz2 = RawTar::default()
+        .file("empty.txt", b"")
+        .dir("subdir/")
+        .file("subdir/inner.txt", b"inner")
+        .dir("emptydir/")
+        .dir("nested/deeper/")
+        .old_dir("olddir/")
+        .file("olddir/inner.txt", b"old")
+        .file("./dot/prefixed.txt", b"dot")
+        .long_file(&long_name, b"long")
+        .file("last.txt", b"last")
+        .finish_bz2();
+    let dest = fresh_dir("empty_and_dirs");
+    extract_tar_bz2(Cursor::new(tar_bz2), &dest).unwrap();
+
+    assert_eq!(std::fs::metadata(dest.join("empty.txt")).unwrap().len(), 0);
+    assert!(dest.join("subdir").is_dir());
+    assert_eq!(
+        std::fs::read(dest.join("subdir/inner.txt")).unwrap(),
+        b"inner"
+    );
+    assert!(dest.join("emptydir").is_dir());
+    assert!(dest.join("nested/deeper").is_dir());
+    assert!(dest.join("olddir").is_dir());
+    assert_eq!(
+        std::fs::read(dest.join("olddir/inner.txt")).unwrap(),
+        b"old"
+    );
+    assert_eq!(
+        std::fs::read(dest.join("dot/prefixed.txt")).unwrap(),
+        b"dot"
+    );
+    assert_eq!(std::fs::read(dest.join(&long_name)).unwrap(), b"long");
+    assert_eq!(std::fs::read(dest.join("last.txt")).unwrap(), b"last");
+}
+
+#[test]
+fn lying_size_headers_do_not_panic() {
+    let data = b"0123456789";
+
+    // The header claims more bytes than the whole archive holds.
+    let too_big = RawTar::default()
+        .file_with_size("big.txt", data, 5000)
+        .finish_bz2();
+    let dest = fresh_dir("size_too_big");
+    let result = extract_tar_bz2(Cursor::new(too_big), &dest);
+    assert!(
+        result.is_err(),
+        "size larger than the stream must fail, got {:?} with file of {:?} bytes",
+        result,
+        std::fs::metadata(dest.join("big.txt")).map(|m| m.len())
+    );
+
+    // The header claims more bytes than written but still within the padded
+    // block: the entry is the data plus zero padding.
+    let within_block = RawTar::default()
+        .file_with_size("padded.txt", data, 300)
+        .file("after.txt", b"after")
+        .finish_bz2();
+    let dest = fresh_dir("size_within_block");
+    extract_tar_bz2(Cursor::new(within_block), &dest).unwrap();
+    let padded = std::fs::read(dest.join("padded.txt")).unwrap();
+    assert_eq!(padded.len(), 300);
+    assert_eq!(&padded[..10], data);
+    assert!(padded[10..].iter().all(|b| *b == 0));
+    assert_eq!(std::fs::read(dest.join("after.txt")).unwrap(), b"after");
+
+    // The header claims fewer bytes than written: only the claimed prefix is
+    // the file and the archive continues at the next block.
+    let too_small = RawTar::default()
+        .file_with_size("short.txt", data, 3)
+        .file("after.txt", b"after")
+        .finish_bz2();
+    let dest = fresh_dir("size_too_small");
+    extract_tar_bz2(Cursor::new(too_small), &dest).unwrap();
+    assert_eq!(std::fs::read(dest.join("short.txt")).unwrap(), b"012");
+    assert_eq!(std::fs::read(dest.join("after.txt")).unwrap(), b"after");
+}
+
+#[cfg(unix)]
+#[test]
+fn file_entry_replaces_existing_symlink_without_following_it() {
+    let outside = fresh_dir("overwrite_symlink_outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let outside_file = outside.join("victim.txt");
+    std::fs::write(&outside_file, b"original").unwrap();
+
+    let dest = fresh_dir("overwrite_symlink");
+    std::fs::create_dir_all(&dest).unwrap();
+    std::os::unix::fs::symlink(&outside_file, dest.join("victim")).unwrap();
+
+    let tar_bz2 = RawTar::default().file("victim", b"new").finish_bz2();
+    extract_tar_bz2(Cursor::new(tar_bz2), &dest).unwrap();
+
+    assert_eq!(
+        std::fs::read(&outside_file).unwrap(),
+        b"original",
+        "write followed the pre-existing symlink"
+    );
+    let meta = std::fs::symlink_metadata(dest.join("victim")).unwrap();
+    assert!(meta.is_file(), "destination is still a symlink");
+    assert_eq!(std::fs::read(dest.join("victim")).unwrap(), b"new");
+}
+
+/// A cut that drops only trailing bytes of a `.conda` (the zip central
+/// directory) is not detected while streaming: the tar reader stops at the
+/// end-of-archive marker before the zip reader reaches its own end. Such a
+/// cut still yields a complete tree and a sha256 that does not match the
+/// package. A `.tar.bz2` is drained to the end of the bzip2 stream after the
+/// tar reader stops, so every cut is an error.
+#[rstest]
+#[case::conda(
+    "https://conda.anaconda.org/conda-forge/win-64/ruff-0.0.171-py310h298983d_0.conda",
+    "25c755b97189ee066576b4ae3999d5e7ff4406d236b984742194e63941838dcd"
+)]
+#[case::tar_bz2(
+    "https://conda.anaconda.org/conda-forge/win-64/conda-22.9.0-py38haa244fe_2.tar.bz2",
+    "3c2c2e8e81bde5fb1ac4b014f51a62411feff004580c708c97a0ec2b7058cdc4"
+)]
+#[tokio::test]
+async fn truncated_streams_return_errors_and_never_hang(#[case] input: Url, #[case] sha256: &str) {
+    let file_path = tools::download_and_cache_file_async(input, sha256)
+        .await
+        .unwrap();
+    let stem = file_path.file_stem().unwrap().to_string_lossy().to_string();
+    let is_conda = file_path.extension().is_some_and(|ext| ext == "conda");
+    let data = std::fs::read(&file_path).unwrap();
+    let len = data.len();
+
+    let reference_dest = fresh_dir(&format!("truncated_reference_{stem}"));
+    if is_conda {
+        extract_conda_via_streaming(Cursor::new(&data), &reference_dest).unwrap();
+    } else {
+        extract_tar_bz2(Cursor::new(&data), &reference_dest).unwrap();
+    }
+    let reference = snapshot(&reference_dest);
+
+    let mut cutoffs = vec![
+        0,
+        1,
+        CHUNK_SIZE - 1,
+        CHUNK_SIZE,
+        CHUNK_SIZE + 1,
+        len / 2,
+        len - 1,
+    ];
+    cutoffs.retain(|c| *c < len);
+    cutoffs.sort_unstable();
+    cutoffs.dedup();
+
+    for cutoff in cutoffs {
+        let dest = fresh_dir(&format!("truncated_{stem}_{cutoff}"));
+        let truncated = &data[..cutoff];
+        let outcome = if is_conda {
+            tokio::time::timeout(
+                TEST_TIMEOUT,
+                rattler_package_streaming::tokio::async_read::extract_conda(truncated, &dest),
+            )
+            .await
+        } else {
+            tokio::time::timeout(
+                TEST_TIMEOUT,
+                rattler_package_streaming::tokio::async_read::extract_tar_bz2(truncated, &dest),
+            )
+            .await
+        };
+        match outcome.unwrap_or_else(|_| panic!("{stem} cut at {cutoff}/{len}: extraction hung")) {
+            Err(err) => eprintln!("{stem} cut at {cutoff}/{len}: {err}"),
+            Ok(result) => {
+                assert!(
+                    is_conda,
+                    "{stem} cut at {cutoff}/{len}: truncated tar.bz2 extracted without error"
+                );
+                assert_ne!(
+                    hex::encode(result.sha256),
+                    sha256,
+                    "{stem} cut at {cutoff}/{len}: truncated stream hashed like the full package"
+                );
+                assert_eq!(
+                    snapshot(&dest),
+                    reference,
+                    "{stem} cut at {cutoff}/{len}: succeeded with an incomplete tree"
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn reader_error_is_reported_instead_of_truncation_error() {
+    let conda = std::fs::read(
+        tools::download_and_cache_file_async(
+            "https://conda.anaconda.org/conda-forge/win-64/ruff-0.0.171-py310h298983d_0.conda"
+                .parse()
+                .unwrap(),
+            "25c755b97189ee066576b4ae3999d5e7ff4406d236b984742194e63941838dcd",
+        )
+        .await
+        .unwrap(),
+    )
+    .unwrap();
+
+    for cutoff in [10usize, 5000, CHUNK_SIZE, conda.len() - 10] {
+        let dest = fresh_dir(&format!("reader_error_{cutoff}"));
+        let reader = FailingReader {
+            data: &conda,
+            pos: 0,
+            cutoff,
+        };
+        let result = tokio::time::timeout(
+            TEST_TIMEOUT,
+            rattler_package_streaming::tokio::async_read::extract_conda(reader, &dest),
+        )
+        .await
+        .expect("hung");
+        match result {
+            Err(ExtractError::IoError(err)) => assert_eq!(
+                err.kind(),
+                std::io::ErrorKind::Interrupted,
+                "cut at {cutoff}: expected the reader's own error, got: {err}"
+            ),
+            other => panic!("cut at {cutoff}: expected IoError(Interrupted), got {other:?}"),
+        }
+    }
+}
+
+/// Dropping the extraction future mid-stream must stop the blocking worker,
+/// otherwise the runtime cannot shut down.
+#[test]
+fn cancelled_extraction_does_not_hang_runtime_shutdown() {
+    let panics = Arc::new(AtomicUsize::new(0));
+    {
+        let panics = panics.clone();
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            panics.fetch_add(1, Ordering::SeqCst);
+            previous(info);
+        }));
+    }
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let conda = runtime.block_on(async {
+        std::fs::read(
+            tools::download_and_cache_file_async(
+                "https://conda.anaconda.org/conda-forge/win-64/ruff-0.0.171-py310h298983d_0.conda"
+                    .parse()
+                    .unwrap(),
+                "25c755b97189ee066576b4ae3999d5e7ff4406d236b984742194e63941838dcd",
+            )
+            .await
+            .unwrap(),
+        )
+        .unwrap()
+    });
+
+    let dest = fresh_dir("cancelled");
+    let started = Instant::now();
+    runtime.block_on(async {
+        let reader = SlowReader::new(conda, 512, Duration::from_millis(5));
+        let outcome = tokio::time::timeout(
+            Duration::from_millis(300),
+            rattler_package_streaming::tokio::async_read::extract_conda(reader, &dest),
+        )
+        .await;
+        assert!(
+            outcome.is_err(),
+            "extraction finished before it could be cancelled; slow the reader down"
+        );
+    });
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "cancelling took {:?}",
+        started.elapsed()
+    );
+
+    let started = Instant::now();
+    runtime.shutdown_timeout(Duration::from_secs(30));
+    let shutdown = started.elapsed();
+    assert!(
+        shutdown < Duration::from_secs(10),
+        "runtime shutdown took {shutdown:?}; a blocking worker did not exit after cancellation"
+    );
+    assert_eq!(
+        panics.load(Ordering::SeqCst),
+        0,
+        "a panic occurred during cancelled extraction"
+    );
+}
+
+/// Files around the chunk size the async path hands to the worker.
+#[tokio::test]
+async fn large_files_extract_intact() {
+    let files = [
+        ("minus_one_128k.bin", noise(CHUNK_SIZE - 1, 4)),
+        ("exact_128k.bin", noise(CHUNK_SIZE, 2)),
+        ("plus_one_128k.bin", noise(CHUNK_SIZE + 1, 3)),
+        ("one_mib_plus.bin", noise(1024 * 1024 + 7, 6)),
+    ];
+    let mut tar = RawTar::default();
+    for (name, data) in &files {
+        tar.file(name, data);
+    }
+    let pkg_tar = tar.finish();
+    let tar_bz2 = bz2(&pkg_tar);
+    let conda = build_conda("big", &pkg_tar);
+
+    let tar_bz2_dest = fresh_dir("large_files_tar_bz2");
+    let tar_bz2_result = rattler_package_streaming::tokio::async_read::extract_tar_bz2(
+        tar_bz2.as_slice(),
+        &tar_bz2_dest,
+    )
+    .await
+    .unwrap();
+    let conda_dest = fresh_dir("large_files_conda");
+    let conda_result =
+        rattler_package_streaming::tokio::async_read::extract_conda(conda.as_slice(), &conda_dest)
+            .await
+            .unwrap();
+
+    for (label, bytes, result, dest) in [
+        ("tar_bz2", &tar_bz2, tar_bz2_result, tar_bz2_dest),
+        ("conda", &conda, conda_result, conda_dest),
+    ] {
+        assert_eq!(
+            digests(&result),
+            (sha256_hex(bytes), md5_hex(bytes), bytes.len() as u64),
+            "{label}"
+        );
+        for (name, data) in &files {
+            let on_disk = std::fs::read(dest.join(name))
+                .unwrap_or_else(|err| panic!("{label}: missing {name}: {err}"));
+            assert_eq!(on_disk.len(), data.len(), "{label}: length of {name}");
+            assert!(on_disk == *data, "{label}: contents of {name} differ");
+        }
+    }
+}
+
+/// `reqwest::tokio::extract` retries with buffering when streaming fails on
+/// a package that uses data descriptors.
+#[cfg(feature = "reqwest")]
+#[tokio::test]
+async fn data_descriptor_package_over_http_falls_back_to_buffering() {
+    use reqwest::Client;
+    use reqwest_middleware::ClientWithMiddleware;
+    use tower_http::services::ServeDir;
+
+    let package = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/resources/ca-certificates-2024.7.4-hbcca054_0.conda");
+    let bytes = std::fs::read(&package).unwrap();
+
+    // Streaming this package must still fail with the data descriptor error,
+    // otherwise the fallback is not what this test exercises.
+    let streaming_dest = fresh_dir("data_descriptor_streaming");
+    let streaming = rattler_package_streaming::tokio::async_read::extract_conda(
+        bytes.as_slice(),
+        &streaming_dest,
+    )
+    .await;
+    assert_matches::assert_matches!(
+        streaming,
+        Err(ExtractError::ZipError(
+            zip::result::ZipError::UnsupportedArchive(
+                "The file length is not available in the local header"
+            )
+        ))
+    );
+
+    let app = axum::Router::new().fallback_service(ServeDir::new(package.parent().unwrap()));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let url = Url::parse(&format!(
+        "http://{addr}/{}",
+        package.file_name().unwrap().to_string_lossy()
+    ))
+    .unwrap();
+
+    let dest = fresh_dir("data_descriptor_http");
+    let result = tokio::time::timeout(
+        TEST_TIMEOUT,
+        rattler_package_streaming::reqwest::tokio::extract(
+            ClientWithMiddleware::from(Client::new()),
+            url,
+            &dest,
+            None,
+            None,
+        ),
+    )
+    .await
+    .expect("hung")
+    .expect("buffering fallback failed");
+    assert_eq!(
+        hex::encode(result.sha256),
+        "6a5d6d8a1a7552dbf8c617312ef951a77d2dac09f2aeaba661deebce603a7a97"
+    );
+    assert_eq!(hex::encode(result.md5), "a1d1adb5a5dc516dfb3dccc7b9b574a9");
+
+    assert!(dest.join("info/index.json").is_file());
+    assert!(dest.join("ssl/cacert.pem").is_file());
+    let link = dest.join("ssl/cert.pem");
+    if cfg!(windows) {
+        assert!(
+            std::fs::symlink_metadata(&link).is_err(),
+            "symlink should be skipped on windows"
+        );
+    } else {
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(std::fs::read_link(&link).unwrap(), Path::new("cacert.pem"));
+    }
+}
+
 struct FlakyReader<R: Read> {
     reader: R,
     cutoff: usize,
@@ -502,5 +1306,322 @@ impl<R: Read> Read for FlakyReader<R> {
         let bytes_read = self.reader.read(&mut buf[..max_read])?;
         self.total_read += bytes_read;
         Ok(bytes_read)
+    }
+}
+
+/// Bytes per chunk the async path hands to the extraction worker.
+const CHUNK_SIZE: usize = 128 * 1024;
+const TEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Path of an empty directory below `CARGO_TARGET_TMPDIR`. Its parent exists
+/// so tests can also place files next to a destination.
+fn fresh_dir(name: &str) -> PathBuf {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR"))
+        .join("hostile")
+        .join(name);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.parent().unwrap()).unwrap();
+    dir
+}
+
+fn digests(result: &ExtractResult) -> (String, String, u64) {
+    (
+        hex::encode(result.sha256),
+        hex::encode(result.md5),
+        result.total_size,
+    )
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(rattler_digest::compute_bytes_digest::<Sha256>(bytes))
+}
+
+fn md5_hex(bytes: &[u8]) -> String {
+    hex::encode(rattler_digest::compute_bytes_digest::<Md5>(bytes))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Node {
+    File {
+        sha256: String,
+        mtime: i64,
+        #[cfg(unix)]
+        mode: u32,
+    },
+    Dir,
+    Symlink(PathBuf),
+}
+
+/// Every entry below `root` keyed by its relative path. Symlinks are not
+/// followed.
+fn snapshot(root: &Path) -> BTreeMap<PathBuf, Node> {
+    let mut nodes = BTreeMap::new();
+    for entry in walkdir::WalkDir::new(root).follow_links(false).min_depth(1) {
+        let entry = entry.unwrap();
+        let rel = entry.path().strip_prefix(root).unwrap().to_path_buf();
+        let meta = std::fs::symlink_metadata(entry.path()).unwrap();
+        let node = if meta.file_type().is_symlink() {
+            Node::Symlink(std::fs::read_link(entry.path()).unwrap())
+        } else if meta.is_dir() {
+            Node::Dir
+        } else {
+            Node::File {
+                sha256: sha256_hex(&std::fs::read(entry.path()).unwrap()),
+                mtime: filetime::FileTime::from_last_modification_time(&meta).unix_seconds(),
+                #[cfg(unix)]
+                mode: {
+                    use std::os::unix::fs::PermissionsExt;
+                    meta.permissions().mode() & 0o777
+                },
+            }
+        };
+        nodes.insert(rel, node);
+    }
+    nodes
+}
+
+/// Deterministic pseudo-random bytes so bzip2 cannot collapse them.
+fn noise(len: usize, seed: u64) -> Vec<u8> {
+    let mut state = seed | 1;
+    let mut out = Vec::with_capacity(len + 8);
+    while out.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(len);
+    out
+}
+
+fn bz2(tar: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut encoder = bzip2::write::BzEncoder::new(&mut out, bzip2::Compression::fast());
+    encoder.write_all(tar).unwrap();
+    encoder.finish().unwrap();
+    out
+}
+
+const RAW_MTIME: u64 = 1_700_000_000;
+
+fn raw_header(kind: tar::EntryType, mode: u32, mtime: u64) -> tar::Header {
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(kind);
+    header.set_mode(mode);
+    header.set_mtime(mtime);
+    header
+}
+
+/// Builds tar archives from raw 512-byte headers so entries can carry names,
+/// link targets and sizes that `tar::Builder` would refuse or fix up.
+#[derive(Default)]
+struct RawTar(Vec<u8>);
+
+impl RawTar {
+    /// Writes `name` and `link` straight into the header fields, then `data`
+    /// padded to a whole block. `size` is what the header claims.
+    fn push(
+        &mut self,
+        mut header: tar::Header,
+        name: &str,
+        link: Option<&str>,
+        size: u64,
+        data: &[u8],
+    ) -> &mut Self {
+        assert!(name.len() < 100, "raw name too long: {name}");
+        let raw = header.as_old_mut();
+        raw.name[..name.len()].copy_from_slice(name.as_bytes());
+        if let Some(link) = link {
+            assert!(link.len() < 100, "raw link name too long: {link}");
+            raw.linkname[..link.len()].copy_from_slice(link.as_bytes());
+        }
+        header.set_size(size);
+        header.set_cksum();
+        self.0.extend_from_slice(header.as_bytes());
+        self.0.extend_from_slice(data);
+        let pad = (512 - data.len() % 512) % 512;
+        self.0.extend(std::iter::repeat_n(0u8, pad));
+        self
+    }
+
+    fn file(&mut self, name: &str, data: &[u8]) -> &mut Self {
+        self.file_with_size(name, data, data.len() as u64)
+    }
+
+    fn file_with_size(&mut self, name: &str, data: &[u8], size: u64) -> &mut Self {
+        let header = raw_header(tar::EntryType::Regular, 0o644, RAW_MTIME);
+        self.push(header, name, None, size, data)
+    }
+
+    fn dir(&mut self, name: &str) -> &mut Self {
+        let header = raw_header(tar::EntryType::Directory, 0o755, RAW_MTIME);
+        self.push(header, name, None, 0, &[])
+    }
+
+    #[cfg(unix)]
+    fn dir_mtime(&mut self, name: &str, mtime: u64) -> &mut Self {
+        let header = raw_header(tar::EntryType::Directory, 0o755, mtime);
+        self.push(header, name, None, 0, &[])
+    }
+
+    /// A pre-ustar header without magic. Such archives mark directories with
+    /// a trailing slash on a regular file entry.
+    fn old_dir(&mut self, name: &str) -> &mut Self {
+        assert!(name.ends_with('/'));
+        let mut header = tar::Header::new_old();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_mode(0o755);
+        header.set_mtime(RAW_MTIME);
+        self.push(header, name, None, 0, &[])
+    }
+
+    fn symlink(&mut self, name: &str, target: &str) -> &mut Self {
+        let header = raw_header(tar::EntryType::Symlink, 0o777, RAW_MTIME);
+        self.push(header, name, Some(target), 0, &[])
+    }
+
+    fn hardlink(&mut self, name: &str, target: &str) -> &mut Self {
+        let header = raw_header(tar::EntryType::Link, 0o644, RAW_MTIME);
+        self.push(header, name, Some(target), 0, &[])
+    }
+
+    /// Appends an entry through `tar::Builder` so GNU long-name records are
+    /// produced for paths over 100 bytes.
+    fn long_file(&mut self, name: &str, data: &[u8]) -> &mut Self {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = raw_header(tar::EntryType::Regular, 0o644, RAW_MTIME);
+        header.set_size(data.len() as u64);
+        header.set_cksum();
+        builder.append_data(&mut header, name, data).unwrap();
+        let bytes = builder.into_inner().unwrap();
+        // Drop the two end-of-archive blocks the builder appends.
+        self.0.extend_from_slice(&bytes[..bytes.len() - 1024]);
+        self
+    }
+
+    fn finish(&mut self) -> Vec<u8> {
+        let mut out = std::mem::take(&mut self.0);
+        out.extend(std::iter::repeat_n(0u8, 1024));
+        out
+    }
+
+    fn finish_bz2(&mut self) -> Vec<u8> {
+        bz2(&self.finish())
+    }
+}
+
+/// Builds a minimal `.conda` archive around the given package tar.
+fn build_conda(name: &str, pkg_tar: &[u8]) -> Vec<u8> {
+    let index = format!(
+        r#"{{"name":"{name}","version":"1.0","build":"0","build_number":0,"subdir":"noarch","depends":[]}}"#
+    );
+    let mut info = tar::Builder::new(Vec::new());
+    let mut header = raw_header(tar::EntryType::Regular, 0o644, RAW_MTIME);
+    header.set_size(index.len() as u64);
+    header.set_cksum();
+    info.append_data(&mut header, "info/index.json", index.as_bytes())
+        .unwrap();
+    let info_tar = info.into_inner().unwrap();
+
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    writer.start_file("metadata.json", options).unwrap();
+    writer
+        .write_all(br#"{"conda_pkg_format_version": 2}"#)
+        .unwrap();
+    writer
+        .start_file(format!("info-{name}-1.0-0.tar.zst"), options)
+        .unwrap();
+    writer
+        .write_all(&zstd::stream::encode_all(Cursor::new(info_tar), 3).unwrap())
+        .unwrap();
+    writer
+        .start_file(format!("pkg-{name}-1.0-0.tar.zst"), options)
+        .unwrap();
+    writer
+        .write_all(&zstd::stream::encode_all(Cursor::new(pkg_tar), 3).unwrap())
+        .unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+/// An `AsyncRead` that hands out `chunk` bytes every `delay`.
+struct SlowReader {
+    data: Vec<u8>,
+    pos: usize,
+    chunk: usize,
+    delay: Duration,
+    sleep: Option<Pin<Box<tokio::time::Sleep>>>,
+}
+
+impl SlowReader {
+    fn new(data: Vec<u8>, chunk: usize, delay: Duration) -> Self {
+        Self {
+            data,
+            pos: 0,
+            chunk,
+            delay,
+            sleep: None,
+        }
+    }
+}
+
+impl AsyncRead for SlowReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if self.pos >= self.data.len() {
+            return Poll::Ready(Ok(()));
+        }
+        if self.sleep.is_none() {
+            let delay = self.delay;
+            self.sleep = Some(Box::pin(tokio::time::sleep(delay)));
+        }
+        match self.sleep.as_mut().unwrap().as_mut().poll(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(()) => self.sleep = None,
+        }
+        let n = self
+            .chunk
+            .min(buf.remaining())
+            .min(self.data.len() - self.pos);
+        let start = self.pos;
+        buf.put_slice(&self.data[start..start + n]);
+        self.pos += n;
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// An `AsyncRead` that fails with an `Interrupted` error after `cutoff`
+/// bytes.
+struct FailingReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+    cutoff: usize,
+}
+
+impl AsyncRead for FailingReader<'_> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if self.pos >= self.cutoff {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "reader gave up",
+            )));
+        }
+        let n = buf
+            .remaining()
+            .min(self.cutoff - self.pos)
+            .min(self.data.len() - self.pos)
+            .min(1024);
+        let start = self.pos;
+        buf.put_slice(&self.data[start..start + n]);
+        self.pos += n;
+        Poll::Ready(Ok(()))
     }
 }

--- a/js-rattler/Cargo.lock
+++ b/js-rattler/Cargo.lock
@@ -165,16 +165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
 
 [[package]]
-name = "async-spooled-tempfile"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5"
-dependencies = [
- "tempfile",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,9 +2221,9 @@ dependencies = [
  "astral_async_http_range_reader",
  "astral_async_zip",
  "async-compression",
- "async-spooled-tempfile",
  "bytes",
  "bzip2",
+ "dunce",
  "filetime",
  "fs-err",
  "futures",

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -281,16 +281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
 
 [[package]]
-name = "async-spooled-tempfile"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5"
-dependencies = [
- "tempfile",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,9 +4259,9 @@ dependencies = [
  "astral_async_http_range_reader",
  "astral_async_zip",
  "async-compression",
- "async-spooled-tempfile",
  "bytes",
  "bzip2",
+ "dunce",
  "filetime",
  "fs-err",
  "futures",


### PR DESCRIPTION
Async package extraction currently runs the tar/zip loop through Tokio filesystem APIs. Every file create, write and metadata update becomes a separate blocking-pool job, which is expensive for packages with many small files.

This PR pumps the async input into a bounded channel of 128 KiB chunks and runs the sync extractor on one `spawn_blocking` worker. The pump also computes the MD5, SHA-256 and size while it forwards chunks, so hashing overlaps with decompression and writes on the worker instead of running in front of them. Local files go directly to the worker. The sync tar loop also validates parent directories once, buffers writes up to 128 KiB and sets mtimes through the open file handle. Download errors and cancellation stop the worker before returning.

The sync `extract_*` functions keep hashing through `process_with_hashing`; the async path calls new `*_without_hashing` variants. Every extractor reads its input to the end, so the result describes the whole stream even when the archive ends before the input does.

## Benchmarks

Old async extractor → this branch, using loopback HTTP and an empty destination for every run. ReFS and NTFS on Windows, ext4 in WSL2 on the same machine:

| Workload | ReFS | NTFS | ext4 |
|---|---:|---:|---:|
| Python 3.13 | 372 → 188 ms | 1.105 → 0.697 s | 534 → 178 ms |
| NumPy | 262 → 106 ms | 747 → 462 ms | 384 → 127 ms |
| Rust, 183 MiB | 1.096 → 0.925 s | 1.630 → 1.551 s | 1.238 → 0.878 s |
| 5-package env, sequential | 716 → 322 ms | 2.412 → 1.488 s | 1.156 → 0.382 s |
| 5-package env, concurrency 8 | 421 → 200 ms | 1.564 → 1.079 s | 601 → 201 ms |

The Rust package is the one dominated by large files: 176 files, 901 MiB extracted, mostly EXE, DLL and PDB. Profiling puts roughly 700 ms in Zstd, 265 ms in MD5/SHA-256 and 200 ms in writes. With hashing still on the worker this package was a small regression on ReFS (1.08 → 1.17 s). Hashing on the pump hides that cost completely: a build with hashing removed altogether is no faster (895 vs 898 ms on ReFS, 1055 vs 1072 ms on NTFS). Larger channel chunks, Zstd buffers and copy buffers did not help. The NTFS Rust row varies by about ±400 ms between runs on my machine, so read it as roughly flat.

## Testing

The numbers above are hyperfine means with one warmup and ten runs.

The `rattler_package_streaming` and `rattler_cache` test suites pass on Windows and Linux. Integration tests compare sync and async output across the test corpus and cover escaping paths and links, old-format directories, lying size headers, truncated streams, reader failures, cancellation, chunk boundaries and the data-descriptor fallback. A new test feeds more trailing bytes than the channel holds after a complete `.conda` and checks that the digests and size cover all of them.

The tar loop replaces `Entry::unpack_in`, so the path sanitization and link handling deserve a close look.
