### PR TITLE
feat: hardlink executables and native libraries on macOS

### DIFF
--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -286,7 +286,10 @@ pub fn link_file(
             .map_err(LinkFileError::FailedToUpdateDestinationFileTimestamps)?;
 
         LinkMethod::Patched(*file_mode)
-    } else if path_json_entry.path_type == PathType::HardLink && allow_ref_links {
+    } else if path_json_entry.path_type == PathType::HardLink
+        && allow_ref_links
+        && !(allow_hard_links && shares_inode_across_prefixes(&source_path))
+    {
         reflink_to_destination(&source_path, &destination_path, allow_hard_links)?
     } else if path_json_entry.path_type == PathType::HardLink && allow_hard_links {
         hardlink_to_destination(&source_path, &destination_path)?
@@ -420,6 +423,40 @@ fn map_or_read_source_file(source_path: &Path) -> Result<MmapOrBytes, LinkFileEr
             MmapOrBytes::Bytes(bytes)
         }
     })
+}
+
+/// Whether a file is hard linked into the prefix even when a reflink is
+/// possible, so that every prefix shares the cached file's inode.
+///
+/// On macOS, a clone is a new inode, and the kernel validates the code
+/// signature of an executable or library per inode the first time it is
+/// loaded. With one inode per prefix that validation repeats for every
+/// prefix, which makes the first run of a freshly created environment
+/// noticeably slower than the second. Hard links keep the inode that was
+/// already validated when the file was first used from any prefix.
+///
+/// Native libraries are recognised by extension, executables by their mode.
+fn shares_inode_across_prefixes(source_path: &Path) -> bool {
+    if !cfg!(target_os = "macos") {
+        return false;
+    }
+    if is_native_library(source_path) {
+        return true;
+    }
+    fs::symlink_metadata(source_path)
+        .is_ok_and(|metadata| has_executable_permissions(&metadata.permissions()))
+}
+
+/// Whether the file name looks like a shared library (`.dylib`, `.so`, `.so.1.2`).
+fn is_native_library(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    name.ends_with(".dylib")
+        || name.ends_with(".so")
+        || name.rsplit_once(".so.").is_some_and(|(_, version)| {
+            !version.is_empty() && version.bytes().all(|b| b.is_ascii_digit() || b == b'.')
+        })
 }
 
 /// Reflink (Copy-On-Write) the specified file from the source (or cached) directory. If the file
@@ -1333,6 +1370,31 @@ mod test {
     }
 
     #[test]
+    fn test_is_native_library() {
+        use super::is_native_library;
+        use std::path::Path;
+
+        for name in [
+            "lib/libfoo.dylib",
+            "lib/libfoo.so",
+            "lib/libfoo.so.1",
+            "lib/libfoo.so.1.2.3",
+            "lib/python3.12/site-packages/numpy/_core/_multiarray_umath.cpython-312-darwin.so",
+        ] {
+            assert!(is_native_library(Path::new(name)), "{name}");
+        }
+        for name in [
+            "bin/python",
+            "lib/libfoo.so.txt",
+            "lib/libfoo.so.",
+            "share/doc/README.dylib.md",
+            "lib/foo.a",
+        ] {
+            assert!(!is_native_library(Path::new(name)), "{name}");
+        }
+    }
+
+    #[test]
     fn test_detect_file_type() {
         use super::FileType;
 
@@ -1373,6 +1435,10 @@ mod test {
         assert_eq!(FileType::detect(&empty), None);
     }
 
+    #[cfg_attr(
+        windows,
+        ignore = "creating symlinks on Windows requires elevated privileges"
+    )]
     #[test]
     fn test_symlink_escape_rejected() {
         use super::{LinkFileError, symlink_to_destination};
@@ -1405,6 +1471,10 @@ mod test {
         ));
     }
 
+    #[cfg_attr(
+        windows,
+        ignore = "creating symlinks on Windows requires elevated privileges"
+    )]
     #[test]
     fn test_symlink_within_prefix_allowed() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -218,6 +218,11 @@ pub struct InstallOptions {
     /// Ref links are only support by a small number of OSes and filesystems. If
     /// reflinking fails for whatever reason the files are hardlinked
     /// instead (if allowed).
+    ///
+    /// On macOS, executables and native libraries are hard linked instead of
+    /// reflinked when hard links are allowed, so that every prefix shares one
+    /// inode and the code signature is validated once rather than on the
+    /// first run in each prefix.
     pub allow_ref_links: Option<bool>,
 
     /// The platform for which the package is installed. Some operations like


### PR DESCRIPTION
On macOS we reflink files from the package cache into the prefix. A clone is a new inode, and the kernel validates the code signature of an executable or dylib per inode the first time it is loaded. So every new environment pays that validation again on its first run, and the first `python -c "import torch"` in a fresh prefix is noticeably slower than the second. We've seen this in practice.

Hard links keep the cache's inode, which was already validated the first time the file was used from any prefix. This PR hard links executables and native libraries on macOS when hard links are allowed, and keeps reflinks for everything else. Native libraries are recognised by name (`.dylib`, `.so`, `.so.1.2`), executables by their mode bits. Patched files are unaffected; they are copied and re-signed as before. Other platforms keep their current behaviour.

## Testing

Unit test for the library-name check; the install link tests pass on Linux and Windows. Two existing symlink tests in this module needed elevated privileges on Windows and failed locally; they now carry the same `ignore` attribute as the third one already did.

I haven't measured the first-run gain on macOS myself, so a before/after of a fresh `pixi run python -c "import numpy"` on an M-series machine would be a good check before merging.
