### PR TITLE
fix(menuinst): resolve `..` before checking link_in_bundle containment

### DIFF
--- a/crates/rattler_menuinst/src/macos.rs
+++ b/crates/rattler_menuinst/src/macos.rs
@@ -27,6 +27,28 @@ use crate::{
 use crate::{render::replace_placeholders, utils::slugify};
 use std::collections::HashMap;
 
+/// Lexically resolves `..` and `.` components in `path`, without touching
+/// the filesystem (the path may not exist yet). Unlike `Path::join` +
+/// `Path::starts_with`, which never resolve `..`, this makes a containment
+/// check against the result meaningful: a `..`-laden path can no longer
+/// masquerade as a descendant of its base directory just because their
+/// unresolved component prefixes happen to match.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                if !result.pop() {
+                    result.push(component);
+                }
+            }
+            std::path::Component::CurDir => {}
+            other => result.push(other),
+        }
+    }
+    result
+}
+
 pub fn quote_args<I, S>(args: I) -> Vec<String>
 where
     I: IntoIterator<Item = S>,
@@ -402,7 +424,7 @@ impl MacOSMenu {
         for (src, dest) in link_in_bundle {
             let src = src.resolve(&self.placeholders);
             let dest = dest.resolve(&self.placeholders);
-            let dest = self.directories.location.join(&dest);
+            let dest = lexically_normalize(&self.directories.location.join(&dest));
             if !dest.starts_with(&self.directories.location) {
                 return Err(MenuInstError::InstallError(format!(
                     "'link_in_bundle' destinations MUST be created inside the .app bundle ({}), but it points to '{}'.",
@@ -924,6 +946,27 @@ mod tests {
         let dirs = super::Directories::new_test();
         assert!(dirs.location.exists());
         assert!(dirs.nested_location.exists());
+    }
+
+    #[test]
+    fn test_lexically_normalize() {
+        use super::lexically_normalize;
+
+        assert_eq!(
+            lexically_normalize(Path::new("/a/b/./c")),
+            PathBuf::from("/a/b/c")
+        );
+        assert_eq!(
+            lexically_normalize(Path::new("/a/b/../c")),
+            PathBuf::from("/a/c")
+        );
+        // A `link_in_bundle` destination that escapes the bundle directory
+        // must no longer look contained after normalization.
+        let location = PathBuf::from("/Users/victim/Applications/MyApp.app");
+        let dest = location.join("../../../../.ssh/authorized_keys");
+        let normalized = lexically_normalize(&dest);
+        assert!(!normalized.starts_with(&location));
+        assert_eq!(normalized, PathBuf::from("/.ssh/authorized_keys"));
     }
 
     struct FakePlaceholders {


### PR DESCRIPTION
### Description

`MacOsInstaller::precreate` creates symlinks for the `link_in_bundle` map declared in a package's `menu.json` (package-author-controlled data). The only containment check was `dest.starts_with(&self.directories.location)`, but `Path::join`/`Path::starts_with` never resolve `..`, so a `dest` value like `../../../../.ssh/authorized_keys` passed the check while pointing outside the `.app` bundle.

This adds a small lexical path-normalization helper (`lexically_normalize`) that resolves `.`/`..` components without touching the filesystem, and runs the containment check against the normalized path instead of the raw joined path.

Fixes #2756

### How Has This Been Tested?

Added `test_lexically_normalize` in `crates/rattler_menuinst/src/macos.rs`, which:
- checks basic `.`/`..` normalization
- reproduces the exact traversal from the issue (`../../../../.ssh/authorized_keys` against a bundle location) and asserts the normalized path is no longer contained within the bundle location

```
running 4 tests
test macos::tests::test_directories ... ok
test macos::tests::test_lexically_normalize ... ok
test macos::tests::test_macos_version ... ok
test macos::tests::test_macos_menu_installation ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.08s
```

The existing `test_macos_menu_installation` integration test still passes, confirming legitimate `link_in_bundle` entries are unaffected.

Also ran `cargo fmt -p rattler_menuinst` and `cargo clippy -p rattler_menuinst --all-targets --all-features -- -D warnings` with no issues.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.



### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
