### PR TITLE
fix(networking): require a path-segment boundary in MirrorMiddleware prefix match

### DIFF
--- a/crates/rattler_networking/src/mirror_middleware.rs
+++ b/crates/rattler_networking/src/mirror_middleware.rs
@@ -149,6 +149,17 @@ impl Middleware for MirrorMiddleware {
 
         for (key, url) in self.keys() {
             if let Some(url_rest) = url_str.strip_prefix(key) {
+                // `key` is used as a prefix, but a plain string prefix match
+                // has no notion of path-segment boundaries: without this
+                // check, a key like "https://host/conda-forge" would also
+                // match "https://host/conda-forge2/...", silently routing
+                // an unrelated channel to this mirror. Require the matched
+                // prefix to already end in '/', or the remainder to be
+                // empty or start with '/'.
+                if !key.ends_with('/') && !url_rest.is_empty() && !url_rest.starts_with('/') {
+                    continue;
+                }
+
                 let url_rest = url_rest.trim_start_matches('/');
                 // replace the key with the mirror
                 let mirrors = self.mirror_map.get(url).unwrap();
@@ -238,6 +249,13 @@ mod test {
 
     async fn broken_return() -> StatusCode {
         StatusCode::INTERNAL_SERVER_ERROR
+    }
+
+    /// Echoes back whatever path it received, prefixed to identify which
+    /// server handled the request. Used to make misrouted requests
+    /// unmistakable in the cross-channel-boundary test below.
+    async fn echo_path_prefixed(prefix: &'static str, req: axum::extract::Request) -> String {
+        format!("HIT {prefix} at path: {}", req.uri().path())
     }
 
     async fn test_server(name: &str, broken: bool) -> Url {
@@ -394,6 +412,74 @@ mod test {
         assert!(res.status().is_success(), "status: {}", res.status());
         let body = res.text().await.unwrap();
         assert_eq!(body, "Hi from counter: mirror server");
+    }
+
+    #[tokio::test]
+    async fn test_mirror_middleware_does_not_cross_channel_boundary() {
+        // Server backing the "conda-forge" mirror. `fallback` echoes back
+        // whatever path it actually received, so a misrouted request is
+        // unmistakable.
+        let mirror_router = Router::new()
+            .fallback(|req: axum::extract::Request| echo_path_prefixed("conda-forge mirror", req));
+        let mirror_addr = SocketAddr::new([127, 0, 0, 1].into(), 0);
+        let mirror_listener = tokio::net::TcpListener::bind(&mirror_addr).await.unwrap();
+        let mirror_addr = mirror_listener.local_addr().unwrap();
+        tokio::spawn(axum::serve(mirror_listener, mirror_router.into_make_service()).into_future());
+        let mirror_url: Url = format!("http://{}:{}", mirror_addr.ip(), mirror_addr.port())
+            .parse()
+            .unwrap();
+
+        // A second, separate server standing in for the *real* upstream
+        // that "conda-forge2" should be reaching (unmodified) when no
+        // mirror matches. Registering the mirror map key against this same
+        // host:port lets us assert the request lands here, not at the
+        // conda-forge mirror.
+        let upstream_router = Router::new()
+            .fallback(|req: axum::extract::Request| echo_path_prefixed("real upstream", req));
+        let upstream_addr = SocketAddr::new([127, 0, 0, 1].into(), 0);
+        let upstream_listener = tokio::net::TcpListener::bind(&upstream_addr).await.unwrap();
+        let upstream_addr = upstream_listener.local_addr().unwrap();
+        tokio::spawn(
+            axum::serve(upstream_listener, upstream_router.into_make_service()).into_future(),
+        );
+
+        let mut mirror_map = std::collections::HashMap::new();
+        // Registered WITHOUT a trailing slash, as a direct `from_map` caller
+        // may do (only `from_config` force-adds the trailing slash).
+        mirror_map.insert(
+            format!(
+                "http://{}:{}/conda-forge",
+                upstream_addr.ip(),
+                upstream_addr.port()
+            )
+            .parse()
+            .unwrap(),
+            vec![mirror_setting(mirror_url)],
+        );
+
+        let middleware = MirrorMiddleware::from_map(mirror_map);
+        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
+            .with(middleware)
+            .build();
+
+        // "conda-forge2" is an unrelated channel with no mirror registered
+        // for it; it must reach the real upstream unmodified, NOT the
+        // "conda-forge" mirror.
+        let res = client
+            .get(format!(
+                "http://{}:{}/conda-forge2/count",
+                upstream_addr.ip(),
+                upstream_addr.port()
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert!(res.status().is_success(), "status: {}", res.status());
+        let body = res.text().await.unwrap();
+        assert_eq!(
+            body, "HIT real upstream at path: /conda-forge2/count",
+            "request for the unrelated 'conda-forge2' channel was routed to the 'conda-forge' mirror instead of the real upstream: {body}"
+        );
     }
 
     #[cfg(feature = "rattler_config")]

--- a/crates/rattler_networking/src/mirror_middleware.rs
+++ b/crates/rattler_networking/src/mirror_middleware.rs
@@ -245,9 +245,7 @@ mod test {
         StatusCode::INTERNAL_SERVER_ERROR
     }
 
-    /// Echoes back whatever path it received, prefixed to identify which
-    /// server handled the request. Used to make misrouted requests
-    /// unmistakable in the cross-channel-boundary test below.
+    /// Echoes the server identity and request path to detect misrouting.
     async fn echo_path_prefixed(prefix: &'static str, req: axum::extract::Request) -> String {
         format!("HIT {prefix} at path: {}", req.uri().path())
     }
@@ -410,9 +408,7 @@ mod test {
 
     #[tokio::test]
     async fn test_mirror_middleware_does_not_cross_channel_boundary() {
-        // Server backing the "conda-forge" mirror. `fallback` echoes back
-        // whatever path it actually received, so a misrouted request is
-        // unmistakable.
+        // Echo requests received by the conda-forge mirror.
         let mirror_router = Router::new()
             .fallback(|req: axum::extract::Request| echo_path_prefixed("conda-forge mirror", req));
         let mirror_addr = SocketAddr::new([127, 0, 0, 1].into(), 0);
@@ -423,11 +419,7 @@ mod test {
             .parse()
             .unwrap();
 
-        // A second, separate server standing in for the *real* upstream
-        // that "conda-forge2" should be reaching (unmodified) when no
-        // mirror matches. Registering the mirror map key against this same
-        // host:port lets us assert the request lands here, not at the
-        // conda-forge mirror.
+        // Unmatched channels should reach this upstream server unchanged.
         let upstream_router = Router::new()
             .fallback(|req: axum::extract::Request| echo_path_prefixed("real upstream", req));
         let upstream_addr = SocketAddr::new([127, 0, 0, 1].into(), 0);
@@ -438,8 +430,7 @@ mod test {
         );
 
         let mut mirror_map = std::collections::HashMap::new();
-        // Registered WITHOUT a trailing slash, as a direct `from_map` caller
-        // may do (only `from_config` force-adds the trailing slash).
+        // `from_map` permits keys without a trailing slash.
         mirror_map.insert(
             format!(
                 "http://{}:{}/conda-forge",
@@ -456,9 +447,7 @@ mod test {
             .with(middleware)
             .build();
 
-        // "conda-forge2" is an unrelated channel with no mirror registered
-        // for it; it must reach the real upstream unmodified, NOT the
-        // "conda-forge" mirror.
+        // conda-forge2 must reach upstream unchanged.
         let res = client
             .get(format!(
                 "http://{}:{}/conda-forge2/count",

--- a/crates/rattler_networking/src/mirror_middleware.rs
+++ b/crates/rattler_networking/src/mirror_middleware.rs
@@ -149,13 +149,7 @@ impl Middleware for MirrorMiddleware {
 
         for (key, url) in self.keys() {
             if let Some(url_rest) = url_str.strip_prefix(key) {
-                // `key` is used as a prefix, but a plain string prefix match
-                // has no notion of path-segment boundaries: without this
-                // check, a key like "https://host/conda-forge" would also
-                // match "https://host/conda-forge2/...", silently routing
-                // an unrelated channel to this mirror. Require the matched
-                // prefix to already end in '/', or the remainder to be
-                // empty or start with '/'.
+                // Require a path-segment boundary so `conda-forge` doesn't match `conda-forge2`.
                 if !key.ends_with('/') && !url_rest.is_empty() && !url_rest.starts_with('/') {
                     continue;
                 }


### PR DESCRIPTION
### Description

`MirrorMiddleware` matches request URLs against configured mirror keys with a raw string prefix check (`url_str.strip_prefix(key)`). A key registered without a trailing slash (e.g. `"https://host/conda-forge"`, which any direct `from_map` caller could do) also matches an unrelated channel that merely shares the string as a prefix (e.g. `"https://host/conda-forge2/..."`), silently forwarding that request to the wrong mirror with a corrupted path.

`from_config` avoids the common case by force-appending a trailing slash to every configured key, but `from_map` — the underlying public constructor — has no such guard. This adds a path-segment boundary check directly in the matching loop, so it holds regardless of how the middleware was constructed.

Fixes #2757

### How Has This Been Tested?

Added `test_mirror_middleware_does_not_cross_channel_boundary` in `crates/rattler_networking/src/mirror_middleware.rs`. It registers a mirror for `"https://host/conda-forge"` (no trailing slash) and requests the unrelated `"...conda-forge2/count"`, asserting the request reaches a separate "real upstream" server unmodified rather than the `conda-forge` mirror.

Before the fix, this failed by actually reaching the mirror server with a corrupted path:
```
status: 200 OK
body: HIT conda-forge mirror at path: /2/count

thread '...' panicked: request for the unrelated 'conda-forge2' channel was routed to the 'conda-forge' mirror: HIT conda-forge mirror at path: /2/count
```

After the fix, full test suite for this module:
```
running 6 tests
test mirror_middleware::test::test_mirror_sort ... ok
test mirror_middleware::test::from_config_appends_trailing_slashes ... ok
test mirror_middleware::test::test_mirror_middleware_path_rewrite ... ok
test mirror_middleware::test::test_mirror_middleware_does_not_cross_channel_boundary ... ok
test mirror_middleware::test::test_mirror_middleware ... ok
test mirror_middleware::test::test_mirror_middleware_broken ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 80 filtered out; finished in 0.75s
```

`test_mirror_middleware_path_rewrite` (existing test, same-boundary matching) still passes, confirming legitimate matches are unaffected.

Also ran `cargo fmt -p rattler_networking` and `cargo clippy -p rattler_networking --all-targets --all-features -- -D warnings` with no issues.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code



### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
