### PR TITLE
feat(rattler-bin): extend inspect with about, run exports, sizes and --json

### DIFF
--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -4,9 +4,7 @@ use std::path::PathBuf;
 use indicatif::HumanBytes;
 use miette::{Context, IntoDiagnostic};
 use rattler_conda_types::NoArchKind;
-use rattler_conda_types::package::{
-    AboutJson, Files, IndexJson, PackageFile, PathsJson, RunExportsJson,
-};
+use rattler_conda_types::package::{AboutJson, IndexJson, PackageFile, PathsJson, RunExportsJson};
 use rattler_package_streaming::archive::PackageArchive;
 use serde::Serialize;
 use url::Url;
@@ -37,10 +35,6 @@ struct Metadata {
     run_exports: Option<RunExportsJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
     paths: Option<PathsJson>,
-    /// Fallback file listing from `info/files` for old packages that do not
-    /// contain a `paths.json`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    files: Option<Vec<PathBuf>>,
 }
 
 pub async fn inspect(opt: Opt, offline: bool) -> miette::Result<()> {
@@ -60,7 +54,6 @@ pub async fn inspect(opt: Opt, offline: bool) -> miette::Result<()> {
             AboutJson::package_path(),
             RunExportsJson::package_path(),
             PathsJson::package_path(),
-            Files::package_path(),
         ])
         .await
         .into_diagnostic()
@@ -71,18 +64,12 @@ pub async fn inspect(opt: Opt, offline: bool) -> miette::Result<()> {
     let about: Option<AboutJson> = parse_from_batch(&mut files)?;
     let run_exports: Option<RunExportsJson> = parse_from_batch(&mut files)?;
     let paths: Option<PathsJson> = parse_from_batch(&mut files)?;
-    let legacy_files: Option<Files> = if paths.is_none() {
-        parse_from_batch(&mut files)?
-    } else {
-        None
-    };
 
     let metadata = Metadata {
         index,
         about,
         run_exports: run_exports.filter(|run_exports| !run_exports.is_empty()),
         paths,
-        files: legacy_files.map(|files| files.files),
     };
 
     if opt.json {
@@ -234,16 +221,6 @@ fn print_paths(metadata: &Metadata, limit: usize) {
                 ),
                 None => println!("  - {}", entry.relative_path.display()),
             }
-        }
-        if total > limit {
-            println!("  ... and {} more", total - limit);
-        }
-    } else if let Some(files) = &metadata.files {
-        let total = files.len();
-        println!("paths: ({total} total, from info/files)");
-        let limit = if limit == 0 { total } else { limit };
-        for path in files.iter().take(limit) {
-            println!("  - {}", path.display());
         }
         if total > limit {
             println!("  ... and {} more", total - limit);

--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -28,6 +28,8 @@ pub struct Opt {
 /// All metadata read from the package; serialized as-is by `--json`.
 #[derive(Serialize)]
 struct Metadata {
+    /// Size in bytes of the package archive itself.
+    size: u64,
     index: IndexJson,
     #[serde(skip_serializing_if = "Option::is_none")]
     about: Option<AboutJson>,
@@ -66,6 +68,7 @@ pub async fn inspect(opt: Opt, offline: bool) -> miette::Result<()> {
         .ok_or_else(|| miette::miette!("package does not contain an info/paths.json"))?;
 
     let metadata = Metadata {
+        size: archive.size(),
         index,
         about,
         run_exports: run_exports.filter(|run_exports| !run_exports.is_empty()),
@@ -100,7 +103,7 @@ fn parse_from_batch<P: PackageFile>(
 }
 
 fn print_human(metadata: &Metadata, limit: i64) {
-    print_index(&metadata.index);
+    print_index(&metadata.index, metadata.size);
     if let Some(about) = &metadata.about {
         print_about(about);
     }
@@ -110,7 +113,7 @@ fn print_human(metadata: &Metadata, limit: i64) {
     print_paths(&metadata.paths, limit);
 }
 
-fn print_index(index: &IndexJson) {
+fn print_index(index: &IndexJson, size: u64) {
     println!("name: {}", index.name.as_normalized());
     println!("version: {}", index.version);
     println!("build: {}", index.build);
@@ -131,6 +134,7 @@ fn print_index(index: &IndexJson) {
     if let Some(timestamp) = &index.timestamp {
         println!("timestamp: {}", timestamp.jiff_timestamp());
     }
+    println!("size: {}", HumanBytes(size));
     print_list("depends", &index.depends);
     print_list("constrains", &index.constrains);
     if !index.extra_depends.is_empty() {

--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -16,9 +16,9 @@ pub struct Opt {
     #[clap(required = true)]
     url: Url,
 
-    /// Number of files to print (0 prints all files)
-    #[clap(long, default_value_t = 10)]
-    limit: usize,
+    /// Number of files to print (a negative value prints all files)
+    #[clap(long, default_value_t = 10, allow_hyphen_values = true)]
+    limit: i64,
 
     /// Print the package metadata as JSON
     #[clap(long)]
@@ -33,8 +33,7 @@ struct Metadata {
     about: Option<AboutJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
     run_exports: Option<RunExportsJson>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    paths: Option<PathsJson>,
+    paths: PathsJson,
 }
 
 pub async fn inspect(opt: Opt, offline: bool) -> miette::Result<()> {
@@ -63,7 +62,8 @@ pub async fn inspect(opt: Opt, offline: bool) -> miette::Result<()> {
         .ok_or_else(|| miette::miette!("package does not contain an info/index.json"))?;
     let about: Option<AboutJson> = parse_from_batch(&mut files)?;
     let run_exports: Option<RunExportsJson> = parse_from_batch(&mut files)?;
-    let paths: Option<PathsJson> = parse_from_batch(&mut files)?;
+    let paths: PathsJson = parse_from_batch(&mut files)?
+        .ok_or_else(|| miette::miette!("package does not contain an info/paths.json"))?;
 
     let metadata = Metadata {
         index,
@@ -99,7 +99,7 @@ fn parse_from_batch<P: PackageFile>(
         .transpose()
 }
 
-fn print_human(metadata: &Metadata, limit: usize) {
+fn print_human(metadata: &Metadata, limit: i64) {
     print_index(&metadata.index);
     if let Some(about) = &metadata.about {
         print_about(about);
@@ -107,7 +107,7 @@ fn print_human(metadata: &Metadata, limit: usize) {
     if let Some(run_exports) = &metadata.run_exports {
         print_run_exports(run_exports);
     }
-    print_paths(metadata, limit);
+    print_paths(&metadata.paths, limit);
 }
 
 fn print_index(index: &IndexJson) {
@@ -127,9 +127,6 @@ fn print_index(index: &IndexJson) {
     }
     if let Some(license) = &index.license {
         println!("license: {license}");
-    }
-    if let Some(license_family) = &index.license_family {
-        println!("license family: {license_family}");
     }
     if let Some(timestamp) = &index.timestamp {
         println!("timestamp: {}", timestamp.jiff_timestamp());
@@ -174,7 +171,7 @@ fn print_about(about: &AboutJson) {
     }
     print_urls("homepage", &about.home);
     print_urls("documentation", &about.doc_url);
-    print_urls("development", &about.dev_url);
+    print_urls("repository", &about.dev_url);
     if let Some(source_url) = &about.source_url {
         println!("source: {source_url}");
     }
@@ -190,43 +187,39 @@ fn print_run_exports(run_exports: &RunExportsJson) {
     print_indented_list("strong constrains", &run_exports.strong_constrains);
 }
 
-fn print_paths(metadata: &Metadata, limit: usize) {
+fn print_paths(paths: &PathsJson, limit: i64) {
     println!();
-    if let Some(paths) = &metadata.paths {
-        let total = paths.paths.len();
-        if paths
+    let total = paths.paths.len();
+    if paths
+        .paths
+        .iter()
+        .any(|entry| entry.size_in_bytes.is_some())
+    {
+        let total_size: u64 = paths
             .paths
             .iter()
-            .any(|entry| entry.size_in_bytes.is_some())
-        {
-            let total_size: u64 = paths
-                .paths
-                .iter()
-                .filter_map(|entry| entry.size_in_bytes)
-                .sum();
-            println!(
-                "paths: ({total} total, {} installed)",
-                HumanBytes(total_size)
-            );
-        } else {
-            println!("paths: ({total} total)");
-        }
-        let limit = if limit == 0 { total } else { limit };
-        for entry in paths.paths.iter().take(limit) {
-            match entry.size_in_bytes {
-                Some(size) => println!(
-                    "  - {} ({})",
-                    entry.relative_path.display(),
-                    HumanBytes(size)
-                ),
-                None => println!("  - {}", entry.relative_path.display()),
-            }
-        }
-        if total > limit {
-            println!("  ... and {} more", total - limit);
-        }
+            .filter_map(|entry| entry.size_in_bytes)
+            .sum();
+        println!(
+            "paths: ({total} total, {} installed)",
+            HumanBytes(total_size)
+        );
     } else {
-        println!("paths: (package lists no files)");
+        println!("paths: ({total} total)");
+    }
+    let limit = usize::try_from(limit).unwrap_or(total);
+    for entry in paths.paths.iter().take(limit) {
+        match entry.size_in_bytes {
+            Some(size) => println!(
+                "  - {} ({})",
+                entry.relative_path.display(),
+                HumanBytes(size)
+            ),
+            None => println!("  - {}", entry.relative_path.display()),
+        }
+    }
+    if total > limit {
+        println!("  ... and {} more", total - limit);
     }
 }
 

--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -1,63 +1,307 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use indicatif::HumanBytes;
 use miette::{Context, IntoDiagnostic};
-use rattler_conda_types::package::{IndexJson, PathsJson};
-use rattler_package_streaming::reqwest::fetch::fetch_package_file_from_remote_url;
+use rattler_conda_types::NoArchKind;
+use rattler_conda_types::package::{
+    AboutJson, Files, IndexJson, PackageFile, PathsJson, RunExportsJson,
+};
+use rattler_package_streaming::archive::PackageArchive;
+use serde::Serialize;
 use url::Url;
 
 /// Inspect package metadata from a remote conda package.
 #[derive(Debug, clap::Parser)]
 pub struct Opt {
-    /// URL of the conda package to inspect (must be a .conda archive)
+    /// URL of the conda package to inspect (.conda or .tar.bz2 archive)
     #[clap(required = true)]
     url: Url,
 
-    /// Number of files to print
+    /// Number of files to print (0 prints all files)
     #[clap(long, default_value_t = 10)]
     limit: usize,
+
+    /// Print the package metadata as JSON
+    #[clap(long)]
+    json: bool,
+}
+
+/// All metadata read from the package; serialized as-is by `--json`.
+#[derive(Serialize)]
+struct Metadata {
+    index: IndexJson,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    about: Option<AboutJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_exports: Option<RunExportsJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    paths: Option<PathsJson>,
+    /// Fallback file listing from `info/files` for old packages that do not
+    /// contain a `paths.json`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    files: Option<Vec<PathBuf>>,
 }
 
 pub async fn inspect(opt: Opt, offline: bool) -> miette::Result<()> {
     let client = super::client::create_client_with_middleware(offline)?;
 
-    let index_json: IndexJson = fetch_package_file_from_remote_url(client.clone(), opt.url.clone())
+    let archive = PackageArchive::from_url(client, opt.url.clone())
         .await
         .into_diagnostic()
-        .context("failed to read index.json")?;
+        .with_context(|| format!("failed to open package archive at {}", opt.url))?;
 
-    println!("name: {}", index_json.name.as_normalized());
-    println!("version: {}", index_json.version);
-    println!("build: {}", index_json.build);
-    if let Some(ref license) = index_json.license {
-        println!("license: {license}");
+    // All metadata lives in the info section; a single batched call reads it
+    // in one pass (for sparse `.conda` archives usually straight from the
+    // cached archive tail).
+    let mut files = archive
+        .read_files([
+            IndexJson::package_path(),
+            AboutJson::package_path(),
+            RunExportsJson::package_path(),
+            PathsJson::package_path(),
+            Files::package_path(),
+        ])
+        .await
+        .into_diagnostic()
+        .context("failed to read package metadata")?;
+
+    let index: IndexJson = parse_from_batch(&mut files)?
+        .ok_or_else(|| miette::miette!("package does not contain an info/index.json"))?;
+    let about: Option<AboutJson> = parse_from_batch(&mut files)?;
+    let run_exports: Option<RunExportsJson> = parse_from_batch(&mut files)?;
+    let paths: Option<PathsJson> = parse_from_batch(&mut files)?;
+    let legacy_files: Option<Files> = if paths.is_none() {
+        parse_from_batch(&mut files)?
+    } else {
+        None
+    };
+
+    let metadata = Metadata {
+        index,
+        about,
+        run_exports: run_exports.filter(|run_exports| !run_exports.is_empty()),
+        paths,
+        files: legacy_files.map(|files| files.files),
+    };
+
+    if opt.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&metadata).into_diagnostic()?
+        );
+    } else {
+        print_human(&metadata, opt.limit);
     }
-    if let Some(ref subdir) = index_json.subdir {
+    Ok(())
+}
+
+/// Takes a file out of a batched `read_files` result and parses it, or `None`
+/// when the package does not contain it.
+fn parse_from_batch<P: PackageFile>(
+    files: &mut HashMap<PathBuf, Option<Vec<u8>>>,
+) -> miette::Result<Option<P>> {
+    files
+        .remove(P::package_path())
+        .flatten()
+        .map(|bytes| {
+            P::from_slice(&bytes)
+                .into_diagnostic()
+                .with_context(|| format!("failed to parse {}", P::package_path().display()))
+        })
+        .transpose()
+}
+
+fn print_human(metadata: &Metadata, limit: usize) {
+    print_index(&metadata.index);
+    if let Some(about) = &metadata.about {
+        print_about(about);
+    }
+    if let Some(run_exports) = &metadata.run_exports {
+        print_run_exports(run_exports);
+    }
+    print_paths(metadata, limit);
+}
+
+fn print_index(index: &IndexJson) {
+    println!("name: {}", index.name.as_normalized());
+    println!("version: {}", index.version);
+    println!("build: {}", index.build);
+    println!("build number: {}", index.build_number);
+    if let Some(subdir) = &index.subdir {
         println!("subdir: {subdir}");
     }
-    if !index_json.depends.is_empty() {
-        println!("depends:");
-        for dep in &index_json.depends {
-            println!("  - {dep}");
+    if let Some(noarch) = index.noarch.kind() {
+        let noarch = match noarch {
+            NoArchKind::Python => "python",
+            NoArchKind::Generic => "generic",
+        };
+        println!("noarch: {noarch}");
+    }
+    if let Some(license) = &index.license {
+        println!("license: {license}");
+    }
+    if let Some(license_family) = &index.license_family {
+        println!("license family: {license_family}");
+    }
+    if let Some(timestamp) = &index.timestamp {
+        println!("timestamp: {}", timestamp.jiff_timestamp());
+    }
+    print_list("depends", &index.depends);
+    print_list("constrains", &index.constrains);
+    if !index.extra_depends.is_empty() {
+        println!("extra depends:");
+        for (extra, depends) in &index.extra_depends {
+            println!("  {extra}:");
+            for dep in depends {
+                println!("    - {dep}");
+            }
         }
     }
-    if !index_json.constrains.is_empty() {
-        println!("constrains:");
-        for c in &index_json.constrains {
-            println!("  - {c}");
+    print_list("track features", &index.track_features);
+    if let Some(purls) = &index.purls {
+        print_list("purls", purls);
+    }
+    if let Some(site_packages_path) = &index.python_site_packages_path {
+        println!("python site-packages path: {site_packages_path}");
+    }
+}
+
+fn print_about(about: &AboutJson) {
+    let has_content = about.summary.is_some()
+        || about.description.is_some()
+        || !about.home.is_empty()
+        || !about.doc_url.is_empty()
+        || !about.dev_url.is_empty()
+        || about.source_url.is_some();
+    if !has_content {
+        return;
+    }
+
+    println!();
+    if let Some(summary) = &about.summary {
+        print_text("summary", summary);
+    }
+    if let Some(description) = &about.description {
+        print_text("description", description);
+    }
+    print_urls("homepage", &about.home);
+    print_urls("documentation", &about.doc_url);
+    print_urls("development", &about.dev_url);
+    if let Some(source_url) = &about.source_url {
+        println!("source: {source_url}");
+    }
+}
+
+fn print_run_exports(run_exports: &RunExportsJson) {
+    println!();
+    println!("run exports:");
+    print_indented_list("weak", &run_exports.weak);
+    print_indented_list("strong", &run_exports.strong);
+    print_indented_list("noarch", &run_exports.noarch);
+    print_indented_list("weak constrains", &run_exports.weak_constrains);
+    print_indented_list("strong constrains", &run_exports.strong_constrains);
+}
+
+fn print_paths(metadata: &Metadata, limit: usize) {
+    println!();
+    if let Some(paths) = &metadata.paths {
+        let total = paths.paths.len();
+        if paths
+            .paths
+            .iter()
+            .any(|entry| entry.size_in_bytes.is_some())
+        {
+            let total_size: u64 = paths
+                .paths
+                .iter()
+                .filter_map(|entry| entry.size_in_bytes)
+                .sum();
+            println!(
+                "paths: ({total} total, {} installed)",
+                HumanBytes(total_size)
+            );
+        } else {
+            println!("paths: ({total} total)");
+        }
+        let limit = if limit == 0 { total } else { limit };
+        for entry in paths.paths.iter().take(limit) {
+            match entry.size_in_bytes {
+                Some(size) => println!(
+                    "  - {} ({})",
+                    entry.relative_path.display(),
+                    HumanBytes(size)
+                ),
+                None => println!("  - {}", entry.relative_path.display()),
+            }
+        }
+        if total > limit {
+            println!("  ... and {} more", total - limit);
+        }
+    } else if let Some(files) = &metadata.files {
+        let total = files.len();
+        println!("paths: ({total} total, from info/files)");
+        let limit = if limit == 0 { total } else { limit };
+        for path in files.iter().take(limit) {
+            println!("  - {}", path.display());
+        }
+        if total > limit {
+            println!("  ... and {} more", total - limit);
+        }
+    } else {
+        println!("paths: (package lists no files)");
+    }
+}
+
+/// Prints a `label:` line followed by one `  - item` line per item, or
+/// nothing when there are no items.
+fn print_list(label: &str, items: impl IntoIterator<Item = impl std::fmt::Display>) {
+    let mut items = items.into_iter().peekable();
+    if items.peek().is_none() {
+        return;
+    }
+    println!("{label}:");
+    for item in items {
+        println!("  - {item}");
+    }
+}
+
+/// Like [`print_list`] but indented one level, for the run exports section.
+fn print_indented_list(label: &str, items: &[String]) {
+    if items.is_empty() {
+        return;
+    }
+    println!("  {label}:");
+    for item in items {
+        println!("    - {item}");
+    }
+}
+
+/// Prints a single-line value inline and a multi-line value as an indented
+/// block.
+fn print_text(label: &str, text: &str) {
+    let text = text.trim_end();
+    if text.contains('\n') {
+        println!("{label}:");
+        for line in text.lines() {
+            println!("  {line}");
+        }
+    } else {
+        println!("{label}: {text}");
+    }
+}
+
+/// Prints a single URL inline and multiple URLs as a list, or nothing when
+/// there are none.
+fn print_urls(label: &str, urls: &[Url]) {
+    match urls {
+        [] => {}
+        [url] => println!("{label}: {url}"),
+        urls => {
+            println!("{label}:");
+            for url in urls {
+                println!("  - {url}");
+            }
         }
     }
-
-    let paths_json: PathsJson = fetch_package_file_from_remote_url(client, opt.url)
-        .await
-        .into_diagnostic()
-        .context("failed to read paths.json")?;
-
-    let total = paths_json.paths.len();
-    println!("paths: ({total} total)");
-    for entry in paths_json.paths.iter().take(opt.limit) {
-        println!("  - {}", entry.relative_path.display());
-    }
-    if total > opt.limit {
-        println!("  ... and {} more", total - opt.limit);
-    }
-
-    Ok(())
 }

--- a/crates/rattler_package_streaming/src/archive.rs
+++ b/crates/rattler_package_streaming/src/archive.rs
@@ -226,6 +226,8 @@ enum CondaSource {
 #[derive(Clone)]
 pub struct PackageArchive {
     backend: Arc<Backend>,
+    /// Size in bytes of the whole archive, captured at open time.
+    size: u64,
 }
 
 /// A boxed reader used for the section decompression pipelines.
@@ -357,6 +359,12 @@ impl PackageArchive {
         let archive_type =
             CondaArchiveType::try_from(path).ok_or(ExtractError::UnsupportedArchiveType)?;
         Self::open_local(path.to_owned(), archive_type, None).await
+    }
+
+    /// Returns the size in bytes of the whole package archive (the `.conda`
+    /// or `.tar.bz2` file itself, not its extracted contents).
+    pub fn size(&self) -> u64 {
+        self.size
     }
 
     /// Returns how this handle accesses the archive.
@@ -648,6 +656,7 @@ impl PackageArchive {
                 },
                 members,
             }),
+            size,
         })
     }
 
@@ -698,10 +707,10 @@ impl PackageArchive {
         archive_type: CondaArchiveType,
         temp: Option<tempfile::TempPath>,
     ) -> Result<Self, ExtractError> {
+        let size = tokio::fs::metadata(&path).await?.len();
         let backend = match archive_type {
             CondaArchiveType::Conda => {
                 let file = tokio::fs::File::open(&path).await?;
-                let size = file.metadata().await?.len();
                 let buf_reader =
                     futures::io::BufReader::new(tokio::io::BufReader::new(file).compat());
                 let zip = ZipFileReader::new(buf_reader).await?;
@@ -715,6 +724,7 @@ impl PackageArchive {
         };
         Ok(Self {
             backend: Arc::new(backend),
+            size,
         })
     }
 
@@ -1099,6 +1109,10 @@ mod tests {
         let archive = PackageArchive::from_url(client, url).await.unwrap();
         assert_eq!(archive.access(), ArchiveAccess::Sparse);
         assert_eq!(requests.load(Ordering::Relaxed), 1, "open = 1 request");
+        assert_eq!(
+            archive.size(),
+            std::fs::metadata(conda_test_file()).unwrap().len()
+        );
 
         // Typed metadata reads: the test package is tiny, so everything is
         // served from the cached tail without further requests.
@@ -1151,6 +1165,10 @@ mod tests {
         let archive = PackageArchive::from_url(client, url).await.unwrap();
         assert_eq!(archive.access(), ArchiveAccess::Spooled);
         assert_eq!(requests.load(Ordering::Relaxed), 1, "one full download");
+        assert_eq!(
+            archive.size(),
+            std::fs::metadata(tar_bz2_test_file()).unwrap().len()
+        );
 
         let files = archive
             .read_files(["info/index.json", "clobber.txt"])
@@ -1535,6 +1553,10 @@ mod tests {
     async fn test_local_conda() {
         let archive = PackageArchive::from_path(conda_test_file()).await.unwrap();
         assert_eq!(archive.access(), ArchiveAccess::Local);
+        assert_eq!(
+            archive.size(),
+            std::fs::metadata(conda_test_file()).unwrap().len()
+        );
         let index: IndexJson = archive.read_package_file().await.unwrap();
         assert_eq!(index.name.as_normalized(), "clobber-fd-1");
         let content = archive.read_file("clobber").await.unwrap().unwrap();


### PR DESCRIPTION
### Description

Extends `rattler inspect` and makes it cheaper on the wire. The command now opens the package once as a `PackageArchive` and reads all metadata files in a single batched `read_files` pass, instead of opening the archive from scratch for every file. On top of that it:

- prints an `about.json` section (summary, description, homepage, documentation, repository, source) when present
- prints `run_exports.json` when present and non-empty
- prints more `index.json` fields: build number, noarch kind, timestamp, extra depends, track features, purls and the python site-packages path
- prints the size of the package archive itself (exposed as a new `PackageArchive::size()` accessor in `rattler_package_streaming`; known for free at open time)
- shows per-file and total installed sizes in the paths listing; `--limit -1` (any negative value) prints all files
- adds `--json` for machine-readable output of everything that was read
- accepts `.tar.bz2` archives in addition to `.conda`

#### Example output

```console
$ rattler inspect https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
name: zlib
version: 1.3.1
build: hb9d3cd8_2
build number: 2
subdir: linux-64
license: Zlib
timestamp: 2024-10-03T13:45:53.079Z
size: 90.12 KiB
depends:
  - __glibc >=2.17,<3.0.a0
  - libgcc >=13
  - libzlib 1.3.1 hb9d3cd8_2

summary: Massively spiffy yet delicately unobtrusive compression library
description:
  zlib is designed to be a free, general-purpose, lossless data-compression
  library for use on virtually any computer hardware and operating system.
homepage: http://zlib.net/
documentation: http://zlib.net/manual.html
repository: https://github.com/madler/zlib

run exports:
  weak:
    - libzlib >=1.3.1,<2.0a0

paths: (5 total, 373.67 KiB installed)
  - include/zconf.h (16.08 KiB)
  - include/zlib.h (94.56 KiB)
  - lib/libz.a (152.50 KiB)
  - lib/libz.so (110.04 KiB)
  - lib/pkgconfig/zlib.pc (503 B)
```

Before, the same command printed only name/version/build/license/subdir/depends/constrains and the bare path names.

#### Performance (before vs. after)

HTTP requests per invocation, counted via `RUST_LOG=rattler_package_streaming=debug` (the old code opened the archive once per file read; the new code opens it once and batches all reads into one pass over the info section):

| Package | before | after |
|---|---|---|
| `zlib-1.3.1` `.conda` (~90 KiB, info inside the 64 KiB tail) | 2 requests | 1 request |
| `python-3.12.7` `.conda` (~32 MiB, info outside the tail) | 4 requests (2 tail + 2 ranged GETs) | 2 requests (1 tail + 1 ranged GET) |
| `zlib-1.2.11` `.tar.bz2` | 2 streaming downloads (one per file, aborted early) | 1 spooled download |

Note the "after" column also reads two files more than before (`about.json`, `run_exports.json`).

Wall-clock time against conda.anaconda.org is dominated by network latency and noisy; medians over 5 runs each were equal to slightly faster (e.g. `zlib .conda` 0.39 s → 0.28 s, `pip` noarch 0.27 s → 0.23 s, `python .conda` 0.41 s → 0.49 s, `zlib .tar.bz2` 0.30 s → 0.25 s). The request halving is the structural win, and matters most on high-latency connections and for servers that bill per request.

### How Has This Been Tested?

Ran the debug binary against real conda-forge packages:

- `linux-64/zlib-1.3.1-hb9d3cd8_2.conda` — about + run exports sections, per-file and total sizes; the reported archive size matches the server's `Content-Length`
- `noarch/pip-24.0-pyhd8ed1ab_0.conda` — noarch field, `--limit 3`, `--limit -1`, `--json`
- `linux-64/zlib-1.2.11-0.tar.bz2` — legacy archive format via the spooled fallback

`cargo fmt` and `cargo clippy --all-targets -- -D warnings -Dclippy::dbg_macro` pass for the touched crates. The existing `rattler_package_streaming` archive tests pass and now also assert `PackageArchive::size()` against the fixture file sizes for the sparse, spooled, and local paths.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

```plaintext
Give me an overview of what rattler inspect can do and what rattler fetch-file can do.
How would you improve inspect? I would think also printing the info section of the
package would be nice. Do you have other ideas? Let's implement all.
[follow-ups: drop the info/files fallback; no need for printing license_family; call
development "repository" instead, like in recipe v1; use a negative --limit for all
files instead of 0; make paths.json required; add example output and a small
before/after benchmark to the PR description; also print the size of the whole
conda file]
```

### Checklist:
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJT6oReskLZ5vzsKyYMKcx