### PR TITLE
feat(rattler-bin): add --constraint flag to rattler solve

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -1,12 +1,5 @@
-use std::{
-    collections::HashMap,
-    env,
-    path::PathBuf,
-    str::FromStr,
-    time::{Duration, Instant},
-};
+use std::{collections::HashMap, env, path::PathBuf, time::Instant};
 
-use clap::ValueEnum;
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
 use rattler::{
@@ -14,22 +7,14 @@ use rattler::{
     install::{IndicatifReporter, Installer, Transaction, TransactionOperation},
     package_cache::PackageCache,
 };
-use rattler_conda_types::{
-    Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, Matches, PackageName,
-    ParseMatchSpecOptions, Platform, PrefixRecord, RepoDataRecord, Version,
-};
+use rattler_conda_types::{ChannelConfig, PackageName, Platform, PrefixRecord, RepoDataRecord};
 use rattler_repodata_gateway::{Gateway, RepoData, SourceConfig};
-use rattler_solve::{
-    SolverImpl, SolverTask,
-    libsolv_c::{self},
-    resolvo,
-};
-use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
+use rattler_solve::SolverTask;
 
 use crate::{
     commands::progress::{wrap_in_async_progress, wrap_in_progress},
-    exclude_newer::ExcludeNewer,
     global_multi_progress,
+    solver_args::SolverArgs,
 };
 
 /// Create a conda environment from package listing
@@ -38,34 +23,16 @@ use crate::{
 /// pulling from the configured channels.
 #[derive(Debug, clap::Parser)]
 pub struct Opt {
-    /// Channel to search for packages
-    ///
-    /// Example: -c conda-forge -c main
-    #[clap(short, long = "channel")]
-    channels: Option<Vec<String>>,
-
     /// Package specs to install
     #[clap(required = true)]
     specs: Vec<String>,
 
+    #[clap(flatten)]
+    solver: SolverArgs,
+
     /// Simulate command without installation
     #[clap(long)]
     dry_run: bool,
-
-    /// The platform to create the environment for.
-    #[clap(long, default_value_t = Platform::current())]
-    platform: Platform,
-
-    #[clap(long)]
-    virtual_package: Option<Vec<String>>,
-
-    /// SAT Solver backend to use
-    #[clap(long)]
-    solver: Option<Solver>,
-
-    /// Request solver timeout in milliseconds
-    #[clap(long)]
-    timeout: Option<u64>,
 
     /// Target prefix (environment path) for package installation
     #[clap(
@@ -75,54 +42,6 @@ pub struct Opt {
         default_value = ".prefix"
     )]
     target_prefix: PathBuf,
-
-    #[clap(long)]
-    strategy: Option<SolveStrategy>,
-
-    /// Only install dependencies of package specs
-    #[clap(long, group = "deps_mode")]
-    only_deps: bool,
-
-    /// Only install package specifications without dependencies
-    #[clap(long, group = "deps_mode")]
-    no_deps: bool,
-
-    /// Exclude packages that have been published after the specified timestamp.
-    /// Can be specified as a timestamp (e.g., "2006-12-02T02:07:43Z") or as a date (e.g., "2006-12-02").
-    /// When using a date, packages from the entire day are included.
-    #[clap(long)]
-    exclude_newer: Option<ExcludeNewer>,
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum SolveStrategy {
-    /// Resolve the highest compatible version for every package.
-    Highest,
-
-    /// Resolve the lowest compatible version for every package.
-    Lowest,
-
-    /// Resolve the lowest compatible version for direct dependencies but the
-    /// highest compatible for transitive dependencies.
-    LowestDirect,
-}
-
-#[derive(Default, Debug, Clone, Copy, ValueEnum)]
-pub enum Solver {
-    #[default]
-    Resolvo,
-    #[value(name = "libsolv")]
-    LibSolv,
-}
-
-impl From<SolveStrategy> for rattler_solve::SolveStrategy {
-    fn from(value: SolveStrategy) -> Self {
-        match value {
-            SolveStrategy::Highest => rattler_solve::SolveStrategy::Highest,
-            SolveStrategy::Lowest => rattler_solve::SolveStrategy::LowestVersion,
-            SolveStrategy::LowestDirect => rattler_solve::SolveStrategy::LowestVersionDirect,
-        }
-    }
 }
 
 pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
@@ -131,24 +50,15 @@ pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
     // Make the target prefix absolute
     let target_prefix = std::path::absolute(opt.target_prefix).into_diagnostic()?;
 
-    let install_platform = opt.platform;
+    let install_platform = opt.solver.platform;
 
     println!("Installing for platform: {install_platform}");
 
     // Parse the specs from the command line. We do this explicitly instead of allow
     // clap to deal with this because we need to parse the `channel_config` when
     // parsing matchspecs.
-    let match_spec_options = ParseMatchSpecOptions::strict()
-        .with_extras(true)
-        .with_conditionals(true)
-        .with_flags(true);
-
-    let specs = opt
-        .specs
-        .iter()
-        .map(|spec| MatchSpec::from_str(spec, match_spec_options))
-        .collect::<Result<Vec<_>, _>>()
-        .into_diagnostic()?;
+    let specs = SolverArgs::parse_specs(&opt.specs)?;
+    let constraints = opt.solver.constraints()?;
 
     // Find the default cache directory. Create it if it doesn't exist yet.
     let cache_dir = default_cache_dir()
@@ -159,13 +69,7 @@ pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
     // Determine the channels to use from the command line or select the default.
     // Like matchspecs this also requires the use of the `channel_config` so we
     // have to do this manually.
-    let channels = opt
-        .channels
-        .unwrap_or_else(|| vec![String::from("conda-forge")])
-        .into_iter()
-        .map(|channel_str| Channel::from_str(channel_str, &channel_config))
-        .collect::<Result<Vec<_>, _>>()
-        .into_diagnostic()?;
+    let channels = opt.solver.channels(&channel_config)?;
 
     // Determine the packages that are currently installed in the environment.
     let installed_packages =
@@ -226,31 +130,8 @@ pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
     // Determine virtual packages of the system. These packages define the
     // capabilities of the system. Some packages depend on these virtual
     // packages to indicate compatibility with the hardware of the system.
-    let virtual_packages = wrap_in_progress("determining virtual packages", move || {
-        if let Some(virtual_packages) = opt.virtual_package {
-            Ok(virtual_packages
-                .iter()
-                .map(|virt_pkg| {
-                    let elems = virt_pkg.split('=').collect::<Vec<&str>>();
-                    Ok(GenericVirtualPackage {
-                        name: elems[0].try_into().into_diagnostic()?,
-                        version: elems
-                            .get(1)
-                            .map_or(Version::from_str("0"), |s| Version::from_str(s))
-                            .into_diagnostic()?,
-                        build_string: (*elems.get(2).unwrap_or(&"")).to_string(),
-                    })
-                })
-                .collect::<miette::Result<Vec<_>>>()?)
-        } else {
-            VirtualPackages::detect_for_platform(
-                install_platform,
-                &VirtualPackageOverrides::from_env(),
-                rattler::default_cache_dir().ok().as_deref(),
-            )
-            .map(|vpkgs| vpkgs.into_generic_virtual_packages().collect::<Vec<_>>())
-            .into_diagnostic()
-        }
+    let virtual_packages = wrap_in_progress("determining virtual packages", || {
+        opt.solver.virtual_packages()
     })?;
 
     println!(
@@ -259,6 +140,15 @@ pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
             .iter()
             .format_with("\n", |i, f| f(&format_args!("  - {i}",)))
     );
+
+    if !constraints.is_empty() {
+        println!(
+            "Constraints:\n{}\n",
+            constraints
+                .iter()
+                .format_with("\n", |i, f| f(&format_args!("  - {i}",)))
+        );
+    }
 
     // Now that we parsed and downloaded all information, construct the packaging
     // problem that we need to solve. We do this by constructing a
@@ -273,28 +163,22 @@ pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
         locked_packages,
         virtual_packages,
         specs: specs.clone(),
-        timeout: opt.timeout.map(Duration::from_millis),
-        strategy: opt.strategy.map_or_else(Default::default, Into::into),
-        exclude_newer: opt.exclude_newer.map(Into::into),
+        constraints,
+        timeout: opt.solver.timeout(),
+        strategy: opt.solver.strategy(),
+        channel_priority: opt.solver.channel_priority(),
+        exclude_newer: opt.solver.exclude_newer(),
         ..SolverTask::from_iter(&repo_data)
     };
 
     // Next, use a solver to solve this specific problem. This provides us with all
     // the operations we need to apply to our environment to bring it up to
     // date.
-    let solver_result = wrap_in_progress("solving", move || match opt.solver.unwrap_or_default() {
-        Solver::Resolvo => resolvo::Solver.solve(solver_task),
-        Solver::LibSolv => libsolv_c::Solver.solve(solver_task),
-    })
-    .into_diagnostic()?;
+    let solver_result =
+        wrap_in_progress("solving", || opt.solver.solve(solver_task)).into_diagnostic()?;
 
     let mut required_packages: Vec<RepoDataRecord> = solver_result.records;
-
-    if opt.no_deps {
-        required_packages.retain(|r| specs.iter().any(|s| s.matches(&r.package_record)));
-    } else if opt.only_deps {
-        required_packages.retain(|r| !specs.iter().any(|s| s.matches(&r.package_record)));
-    };
+    opt.solver.filter_deps_mode(&mut required_packages, &specs);
 
     if opt.dry_run {
         // Construct a transaction to

--- a/crates/rattler-bin/src/commands/solve.rs
+++ b/crates/rattler-bin/src/commands/solve.rs
@@ -43,6 +43,15 @@ pub struct Opt {
     #[clap(required = true)]
     specs: Vec<String>,
 
+    /// Additional constraint that the solution must satisfy.
+    ///
+    /// A constrained package is not necessarily part of the solution, but if
+    /// it is, it must match the constraint.
+    ///
+    /// Example: --constraint "numpy<2" --constraint "openssl=3.*"
+    #[clap(long = "constraint", value_name = "SPEC")]
+    constraints: Vec<String>,
+
     /// The platform to solve the environment for.
     #[clap(long, default_value_t = Platform::current())]
     platform: Platform,
@@ -133,6 +142,13 @@ pub async fn solve(opt: Opt, offline: bool) -> miette::Result<()> {
         .collect::<Result<Vec<_>, _>>()
         .into_diagnostic()?;
 
+    let constraints = opt
+        .constraints
+        .iter()
+        .map(|spec| MatchSpec::from_str(spec, match_spec_options))
+        .collect::<Result<Vec<_>, _>>()
+        .into_diagnostic()?;
+
     let cache_dir = default_cache_dir()
         .map_err(|e| miette::miette!("could not determine default cache directory: {}", e))?;
     rattler_cache::ensure_cache_dir(&cache_dir)
@@ -206,6 +222,7 @@ pub async fn solve(opt: Opt, offline: bool) -> miette::Result<()> {
     let solver_task = SolverTask {
         virtual_packages,
         specs: specs.clone(),
+        constraints,
         timeout: opt.timeout.map(Duration::from_millis),
         strategy: opt.strategy.map_or_else(Default::default, Into::into),
         exclude_newer: opt.exclude_newer.map(Into::into),

--- a/crates/rattler-bin/src/commands/solve.rs
+++ b/crates/rattler-bin/src/commands/solve.rs
@@ -1,30 +1,22 @@
 use std::{
     collections::HashMap,
     env,
-    str::FromStr,
     time::{Duration, Instant},
 };
 
-use clap::ValueEnum;
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
 use rattler::{default_cache_dir, package_cache::PackageCache};
 use rattler_conda_types::{
-    Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, Matches, PackageName,
-    ParseMatchSpecOptions, Platform, RepoDataRecord, Version,
+    ChannelConfig, MatchSpec, Matches, PackageName, Platform, RepoDataRecord,
 };
 use rattler_repodata_gateway::{Gateway, RepoData, SourceConfig};
-use rattler_solve::{
-    SolverImpl, SolverTask,
-    libsolv_c::{self},
-    resolvo,
-};
-use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
+use rattler_solve::SolverTask;
 use url::Url;
 
 use crate::{
     commands::progress::{wrap_in_async_progress, wrap_in_progress},
-    exclude_newer::ExcludeNewer,
+    solver_args::SolverArgs,
 };
 
 /// Solve a conda environment without installing it.
@@ -33,134 +25,36 @@ use crate::{
 /// resulting package set.
 #[derive(Debug, clap::Parser)]
 pub struct Opt {
-    /// Channel to search for packages.
-    ///
-    /// Example: -c conda-forge -c main
-    #[clap(short, long = "channel")]
-    channels: Option<Vec<String>>,
-
     /// Package specs to solve.
     #[clap(required = true)]
     specs: Vec<String>,
 
-    /// Additional constraint that the solution must satisfy.
-    ///
-    /// A constrained package is not necessarily part of the solution, but if
-    /// it is, it must match the constraint.
-    ///
-    /// Example: --constraint "numpy<2" --constraint "openssl=3.*"
-    #[clap(long = "constraint", value_name = "SPEC")]
-    constraints: Vec<String>,
-
-    /// The platform to solve the environment for.
-    #[clap(long, default_value_t = Platform::current())]
-    platform: Platform,
-
-    /// Virtual packages to use for solving, e.g. __glibc=2.28.
-    #[clap(long)]
-    virtual_package: Option<Vec<String>>,
-
-    /// SAT Solver backend to use.
-    #[clap(long)]
-    solver: Option<Solver>,
-
-    /// Request solver timeout in milliseconds.
-    #[clap(long)]
-    timeout: Option<u64>,
-
-    /// Solver strategy to use.
-    #[clap(long)]
-    strategy: Option<SolveStrategy>,
-
-    /// Only include dependencies of package specs in the output.
-    #[clap(long, group = "deps_mode")]
-    only_deps: bool,
-
-    /// Only include package specifications without dependencies in the output.
-    #[clap(long, group = "deps_mode")]
-    no_deps: bool,
-
-    /// Exclude packages that have been published after the specified timestamp.
-    /// Can be specified as a timestamp (e.g., "2006-12-02T02:07:43Z") or as a date (e.g., "2006-12-02").
-    /// When using a date, packages from the entire day are included.
-    #[clap(long)]
-    exclude_newer: Option<ExcludeNewer>,
+    #[clap(flatten)]
+    solver: SolverArgs,
 
     /// Output in JSON format
     #[clap(long)]
     json: bool,
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum SolveStrategy {
-    /// Resolve the highest compatible version for every package.
-    Highest,
-
-    /// Resolve the lowest compatible version for every package.
-    Lowest,
-
-    /// Resolve the lowest compatible version for direct dependencies but the
-    /// highest compatible for transitive dependencies.
-    LowestDirect,
-}
-
-#[derive(Default, Debug, Clone, Copy, ValueEnum)]
-pub enum Solver {
-    #[default]
-    Resolvo,
-    #[value(name = "libsolv")]
-    LibSolv,
-}
-
-impl From<SolveStrategy> for rattler_solve::SolveStrategy {
-    fn from(value: SolveStrategy) -> Self {
-        match value {
-            SolveStrategy::Highest => rattler_solve::SolveStrategy::Highest,
-            SolveStrategy::Lowest => rattler_solve::SolveStrategy::LowestVersion,
-            SolveStrategy::LowestDirect => rattler_solve::SolveStrategy::LowestVersionDirect,
-        }
-    }
-}
-
 pub async fn solve(opt: Opt, offline: bool) -> miette::Result<()> {
     let channel_config =
         ChannelConfig::default_with_root_dir(env::current_dir().into_diagnostic()?);
+    let platform = opt.solver.platform;
 
     // All progress information goes to stderr so that stdout only contains the
     // solved package set.
-    eprintln!("Solving for platform: {}", opt.platform);
+    eprintln!("Solving for platform: {platform}");
 
-    let match_spec_options = ParseMatchSpecOptions::strict()
-        .with_extras(true)
-        .with_conditionals(true)
-        .with_flags(true);
-
-    let specs = opt
-        .specs
-        .iter()
-        .map(|spec| MatchSpec::from_str(spec, match_spec_options))
-        .collect::<Result<Vec<_>, _>>()
-        .into_diagnostic()?;
-
-    let constraints = opt
-        .constraints
-        .iter()
-        .map(|spec| MatchSpec::from_str(spec, match_spec_options))
-        .collect::<Result<Vec<_>, _>>()
-        .into_diagnostic()?;
+    let specs = SolverArgs::parse_specs(&opt.specs)?;
+    let constraints = opt.solver.constraints()?;
 
     let cache_dir = default_cache_dir()
         .map_err(|e| miette::miette!("could not determine default cache directory: {}", e))?;
     rattler_cache::ensure_cache_dir(&cache_dir)
         .map_err(|e| miette::miette!("could not create cache directory: {}", e))?;
 
-    let channels = opt
-        .channels
-        .unwrap_or_else(|| vec![String::from("conda-forge")])
-        .into_iter()
-        .map(|channel_str| Channel::from_str(channel_str, &channel_config))
-        .collect::<Result<Vec<_>, _>>()
-        .into_diagnostic()?;
+    let channels = opt.solver.channels(&channel_config)?;
 
     let download_client = super::client::create_client_with_middleware(offline)?;
 
@@ -184,7 +78,7 @@ pub async fn solve(opt: Opt, offline: bool) -> miette::Result<()> {
     let repo_data = wrap_in_async_progress(
         "loading repodata",
         gateway
-            .query(channels, [opt.platform, Platform::NoArch], specs.clone())
+            .query(channels, [platform, Platform::NoArch], specs.clone())
             .recursive(true),
     )
     .await
@@ -199,17 +93,7 @@ pub async fn solve(opt: Opt, offline: bool) -> miette::Result<()> {
     );
 
     let virtual_packages = wrap_in_progress("determining virtual packages", || {
-        if let Some(virtual_packages) = &opt.virtual_package {
-            parse_virtual_packages(virtual_packages)
-        } else {
-            VirtualPackages::detect_for_platform(
-                opt.platform,
-                &VirtualPackageOverrides::from_env(),
-                rattler::default_cache_dir().ok().as_deref(),
-            )
-            .map(|vpkgs| vpkgs.into_generic_virtual_packages().collect::<Vec<_>>())
-            .into_diagnostic()
-        }
+        opt.solver.virtual_packages()
     })?;
 
     eprintln!(
@@ -219,31 +103,33 @@ pub async fn solve(opt: Opt, offline: bool) -> miette::Result<()> {
             .format_with("\n", |i, f| f(&format_args!("  - {i}",)))
     );
 
+    if !constraints.is_empty() {
+        eprintln!(
+            "Constraints:\n{}\n",
+            constraints
+                .iter()
+                .format_with("\n", |i, f| f(&format_args!("  - {i}",)))
+        );
+    }
+
     let solver_task = SolverTask {
         virtual_packages,
         specs: specs.clone(),
-        constraints,
-        timeout: opt.timeout.map(Duration::from_millis),
-        strategy: opt.strategy.map_or_else(Default::default, Into::into),
-        exclude_newer: opt.exclude_newer.map(Into::into),
+        constraints: constraints.clone(),
+        timeout: opt.solver.timeout(),
+        strategy: opt.solver.strategy(),
+        channel_priority: opt.solver.channel_priority(),
+        exclude_newer: opt.solver.exclude_newer(),
         ..SolverTask::from_iter(&repo_data)
     };
 
     let start_solve = Instant::now();
-    let solver_result = wrap_in_progress("solving", || match opt.solver.unwrap_or_default() {
-        Solver::Resolvo => resolvo::Solver.solve(solver_task),
-        Solver::LibSolv => libsolv_c::Solver.solve(solver_task),
-    })
-    .into_diagnostic()?;
+    let solver_result =
+        wrap_in_progress("solving", || opt.solver.solve(solver_task)).into_diagnostic()?;
     let solve_duration = start_solve.elapsed();
 
     let mut solved_packages: Vec<RepoDataRecord> = solver_result.records;
-
-    if opt.no_deps {
-        solved_packages.retain(|r| specs.iter().any(|s| s.matches(&r.package_record)));
-    } else if opt.only_deps {
-        solved_packages.retain(|r| !specs.iter().any(|s| s.matches(&r.package_record)));
-    }
+    opt.solver.filter_deps_mode(&mut solved_packages, &specs);
 
     // The solver returns records in the order it decided on them, which is an
     // implementation detail and differs between backends. Sort by name so the
@@ -279,6 +165,7 @@ pub async fn solve(opt: Opt, offline: bool) -> miette::Result<()> {
             &solved_packages,
             &solver_result.extras,
             &specs,
+            &constraints,
             &channel_config,
         );
     }
@@ -296,45 +183,31 @@ fn format_elapsed(duration: Duration) -> String {
     }
 }
 
-fn parse_virtual_packages(
-    virtual_packages: &[String],
-) -> miette::Result<Vec<GenericVirtualPackage>> {
-    virtual_packages
-        .iter()
-        .map(|virt_pkg| {
-            let elems = virt_pkg.split('=').collect::<Vec<&str>>();
-            Ok(GenericVirtualPackage {
-                name: elems[0].try_into().into_diagnostic()?,
-                version: elems
-                    .get(1)
-                    .map_or(Version::from_str("0"), |s| Version::from_str(s))
-                    .into_diagnostic()?,
-                build_string: (*elems.get(2).unwrap_or(&"")).to_string(),
-            })
-        })
-        .collect::<miette::Result<Vec<_>>>()
-}
-
 /// Prints the solved records as a table with aligned columns.
 ///
 /// Packages that are explicitly requested through one of the input specs are
 /// highlighted to distinguish them from the transitive dependencies that were
-/// pulled in by the solver.
+/// pulled in by the solver. When constraints were given, an extra column shows
+/// which constraints apply to each package.
 fn print_records(
     records: &[RepoDataRecord],
     extras: &HashMap<PackageName, Vec<String>>,
     specs: &[MatchSpec],
+    constraints: &[MatchSpec],
     channel_config: &ChannelConfig,
 ) {
-    let header = [
+    let mut header = vec![
         "Package".to_string(),
         "Version".to_string(),
         "Build".to_string(),
         "Channel".to_string(),
     ];
+    if !constraints.is_empty() {
+        header.push("Constraint".to_string());
+    }
 
     // These initial widths match the header column lengths.
-    let mut widths: [usize; 4] = header.clone().map(|field| field.len());
+    let mut widths: Vec<usize> = header.iter().map(String::len).collect();
     let mut rows = Vec::with_capacity(records.len());
     for record in records {
         let mut name = record.package_record.name.as_normalized().to_string();
@@ -344,12 +217,20 @@ fn print_records(
             name.push(']');
         }
 
-        let fields = [
+        let mut fields = vec![
             name,
             record.package_record.version.to_string(),
             record.package_record.build.clone(),
             format_channel(record, channel_config),
         ];
+        if !constraints.is_empty() {
+            fields.push(
+                constraints
+                    .iter()
+                    .filter(|constraint| constraint.matches(&record.package_record))
+                    .join(", "),
+            );
+        }
         for (width, field) in widths.iter_mut().zip(&fields) {
             *width = (*width).max(field.chars().count());
         }
@@ -362,21 +243,21 @@ fn print_records(
 
     // Separates the table from the status messages on stderr.
     eprintln!();
-    let styled_header = header
-        .clone()
-        .map(|field| console::style(field).bold().to_string());
+    let styled_header: Vec<String> = header
+        .iter()
+        .map(|field| console::style(field).bold().to_string())
+        .collect();
     print_row(&styled_header, &widths, &header);
     for (fields, explicit) in &rows {
-        let styled = [
-            if *explicit {
-                console::style(&fields[0]).green().bold().to_string()
-            } else {
-                fields[0].clone()
-            },
-            fields[1].clone(),
-            console::style(&fields[2]).dim().to_string(),
-            console::style(&fields[3]).dim().to_string(),
-        ];
+        let styled: Vec<String> = fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| match i {
+                0 if *explicit => console::style(field).green().bold().to_string(),
+                0 | 1 => field.clone(),
+                _ => console::style(field).dim().to_string(),
+            })
+            .collect();
         print_row(&styled, &widths, fields);
     }
 }
@@ -387,7 +268,7 @@ fn print_records(
 /// fields without any styling. Padding is computed from `plain` because ANSI
 /// escape codes in `styled` do not occupy any terminal columns but would
 /// otherwise be counted by the formatter.
-fn print_row(styled: &[String; 4], widths: &[usize; 4], plain: &[String; 4]) {
+fn print_row(styled: &[String], widths: &[usize], plain: &[String]) {
     let mut line = String::new();
     for (i, field) in styled.iter().enumerate() {
         line.push_str(field);

--- a/crates/rattler-bin/src/main.rs
+++ b/crates/rattler-bin/src/main.rs
@@ -8,6 +8,7 @@ use crate::{commands::exec, writer::IndicatifWriter};
 
 mod commands;
 mod exclude_newer;
+mod solver_args;
 mod writer;
 
 /// Returns a global instance of [`indicatif::MultiProgress`].

--- a/crates/rattler-bin/src/solver_args.rs
+++ b/crates/rattler-bin/src/solver_args.rs
@@ -1,0 +1,229 @@
+//! Command line options shared by every command that resolves an environment.
+
+use std::{str::FromStr, time::Duration};
+
+use clap::ValueEnum;
+use miette::IntoDiagnostic;
+use rattler_conda_types::{
+    Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, Matches, ParseMatchSpecOptions,
+    Platform, RepoDataRecord, SolverResult, Version,
+};
+use rattler_solve::{IntoRepoData, SolveError, SolverImpl, SolverTask, libsolv_c, resolvo};
+use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
+
+use crate::exclude_newer::ExcludeNewer;
+
+/// Options that configure how an environment is solved.
+///
+/// Flatten this into a command's options with `#[clap(flatten)]` so that
+/// every solving command accepts the same set of flags.
+#[derive(Debug, clap::Args)]
+pub struct SolverArgs {
+    /// Channel to search for packages.
+    ///
+    /// Example: -c conda-forge -c main
+    #[clap(short, long = "channel")]
+    channels: Option<Vec<String>>,
+
+    /// Additional constraint that the solution must satisfy.
+    ///
+    /// A constrained package is not necessarily part of the solution, but if
+    /// it is, it must match the constraint.
+    ///
+    /// Example: --constraint "numpy<2" --constraint "openssl=3.*"
+    #[clap(long = "constraint", value_name = "SPEC")]
+    constraints: Vec<String>,
+
+    /// The platform to solve for.
+    #[clap(long, default_value_t = Platform::current())]
+    pub platform: Platform,
+
+    /// Virtual packages to use for solving, e.g. __glibc=2.28.
+    ///
+    /// When omitted, the virtual packages of the current system are detected.
+    #[clap(long)]
+    virtual_package: Option<Vec<String>>,
+
+    /// SAT Solver backend to use.
+    #[clap(long)]
+    solver: Option<Solver>,
+
+    /// Request solver timeout in milliseconds.
+    #[clap(long)]
+    timeout: Option<u64>,
+
+    /// Solver strategy to use.
+    #[clap(long)]
+    strategy: Option<SolveStrategy>,
+
+    /// How to prioritize packages from different channels.
+    #[clap(long)]
+    channel_priority: Option<ChannelPriority>,
+
+    /// Only include dependencies of the package specs, not the specs themselves.
+    #[clap(long, group = "deps_mode")]
+    only_deps: bool,
+
+    /// Only include the package specs themselves, without their dependencies.
+    #[clap(long, group = "deps_mode")]
+    no_deps: bool,
+
+    /// Exclude packages that have been published after the specified timestamp.
+    /// Can be specified as a timestamp (e.g., "2006-12-02T02:07:43Z") or as a date (e.g., "2006-12-02").
+    /// When using a date, packages from the entire day are included.
+    #[clap(long)]
+    exclude_newer: Option<ExcludeNewer>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum SolveStrategy {
+    /// Resolve the highest compatible version for every package.
+    Highest,
+
+    /// Resolve the lowest compatible version for every package.
+    Lowest,
+
+    /// Resolve the lowest compatible version for direct dependencies but the
+    /// highest compatible for transitive dependencies.
+    LowestDirect,
+}
+
+impl From<SolveStrategy> for rattler_solve::SolveStrategy {
+    fn from(value: SolveStrategy) -> Self {
+        match value {
+            SolveStrategy::Highest => rattler_solve::SolveStrategy::Highest,
+            SolveStrategy::Lowest => rattler_solve::SolveStrategy::LowestVersion,
+            SolveStrategy::LowestDirect => rattler_solve::SolveStrategy::LowestVersionDirect,
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, ValueEnum)]
+pub enum Solver {
+    #[default]
+    Resolvo,
+    #[value(name = "libsolv")]
+    LibSolv,
+}
+
+#[derive(Default, Debug, Clone, Copy, ValueEnum)]
+pub enum ChannelPriority {
+    /// A package is only taken from the first channel it is found in.
+    #[default]
+    Strict,
+
+    /// Candidates from a higher-priority channel are exhausted before falling
+    /// back to the next channel, regardless of version.
+    Flexible,
+
+    /// Packages can come from any channel, the version takes precedence.
+    Disabled,
+}
+
+impl From<ChannelPriority> for rattler_solve::ChannelPriority {
+    fn from(value: ChannelPriority) -> Self {
+        match value {
+            ChannelPriority::Strict => rattler_solve::ChannelPriority::Strict,
+            ChannelPriority::Flexible => rattler_solve::ChannelPriority::Flexible,
+            ChannelPriority::Disabled => rattler_solve::ChannelPriority::Disabled,
+        }
+    }
+}
+
+impl SolverArgs {
+    /// Parses match specs as they are given on the command line.
+    pub fn parse_specs(specs: &[String]) -> miette::Result<Vec<MatchSpec>> {
+        let options = ParseMatchSpecOptions::strict()
+            .with_extras(true)
+            .with_conditionals(true)
+            .with_flags(true);
+        specs
+            .iter()
+            .map(|spec| MatchSpec::from_str(spec, options))
+            .collect::<Result<Vec<_>, _>>()
+            .into_diagnostic()
+    }
+
+    /// The constraints the solution must satisfy.
+    pub fn constraints(&self) -> miette::Result<Vec<MatchSpec>> {
+        Self::parse_specs(&self.constraints)
+    }
+
+    /// The channels to solve from, defaulting to `conda-forge`.
+    pub fn channels(&self, channel_config: &ChannelConfig) -> miette::Result<Vec<Channel>> {
+        self.channels
+            .clone()
+            .unwrap_or_else(|| vec![String::from("conda-forge")])
+            .into_iter()
+            .map(|channel_str| Channel::from_str(channel_str, channel_config))
+            .collect::<Result<Vec<_>, _>>()
+            .into_diagnostic()
+    }
+
+    /// The virtual packages to solve with, either as given on the command line
+    /// or detected from the current system.
+    pub fn virtual_packages(&self) -> miette::Result<Vec<GenericVirtualPackage>> {
+        let Some(virtual_packages) = &self.virtual_package else {
+            return VirtualPackages::detect_for_platform(
+                self.platform,
+                &VirtualPackageOverrides::from_env(),
+                rattler::default_cache_dir().ok().as_deref(),
+            )
+            .map(|vpkgs| vpkgs.into_generic_virtual_packages().collect::<Vec<_>>())
+            .into_diagnostic();
+        };
+
+        virtual_packages
+            .iter()
+            .map(|virt_pkg| {
+                let elems = virt_pkg.split('=').collect::<Vec<&str>>();
+                Ok(GenericVirtualPackage {
+                    name: elems[0].try_into().into_diagnostic()?,
+                    version: elems
+                        .get(1)
+                        .map_or(Version::from_str("0"), |s| Version::from_str(s))
+                        .into_diagnostic()?,
+                    build_string: (*elems.get(2).unwrap_or(&"")).to_string(),
+                })
+            })
+            .collect()
+    }
+
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout.map(Duration::from_millis)
+    }
+
+    pub fn strategy(&self) -> rattler_solve::SolveStrategy {
+        self.strategy.map_or_else(Default::default, Into::into)
+    }
+
+    pub fn channel_priority(&self) -> rattler_solve::ChannelPriority {
+        self.channel_priority.unwrap_or_default().into()
+    }
+
+    pub fn exclude_newer(&self) -> Option<rattler_solve::ExcludeNewer> {
+        self.exclude_newer.map(Into::into)
+    }
+
+    /// Solves the task with the selected backend.
+    pub fn solve<'a, R, I>(&self, task: SolverTask<'a, I>) -> Result<SolverResult, SolveError>
+    where
+        I: IntoIterator<Item = R>,
+        R: IntoRepoData<'a, resolvo::RepoData<'a>> + IntoRepoData<'a, libsolv_c::RepoData<'a>>,
+    {
+        match self.solver.unwrap_or_default() {
+            Solver::Resolvo => resolvo::Solver.solve(task),
+            Solver::LibSolv => libsolv_c::Solver.solve(task),
+        }
+    }
+
+    /// Applies `--only-deps` / `--no-deps` to the solved records. A record is
+    /// considered explicitly requested when it matches one of `specs`.
+    pub fn filter_deps_mode(&self, records: &mut Vec<RepoDataRecord>, specs: &[MatchSpec]) {
+        if self.no_deps {
+            records.retain(|r| specs.iter().any(|s| s.matches(&r.package_record)));
+        } else if self.only_deps {
+            records.retain(|r| !specs.iter().any(|s| s.matches(&r.package_record)));
+        }
+    }
+}


### PR DESCRIPTION
Adds a repeatable `--constraint <SPEC>` flag to `rattler solve` that maps
to `SolverTask::constraints`: a constrained package is not necessarily
part of the solution, but if it is, it must match the constraint.

Constraints are parsed with the same strict MatchSpec options as the
positional specs but are not fed into the repodata gateway query and do
not count as explicit specs for --no-deps/--only-deps or output
highlighting, mirroring how py-rattler handles them.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F8wHDg6DoAAQzNAazXJk1D