### PR TITLE
perf(rattler-bin): honor configured download concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4946,6 +4946,7 @@ dependencies = [
  "rattler",
  "rattler_cache",
  "rattler_conda_types",
+ "rattler_config",
  "rattler_index",
  "rattler_menuinst",
  "rattler_networking",

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -51,6 +51,7 @@ miette = { workspace = true }
 once_cell = { workspace = true }
 rattler = { workspace = true, features = ["indicatif", "cli-tools", "auth-interactive"] }
 rattler_conda_types = { workspace = true, default-features = false }
+rattler_config = { workspace = true, default-features = false }
 rattler_index = { workspace = true, default-features = false }
 rattler_networking = { workspace = true, default-features = false, features = [
   "system-integration",

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -8,6 +8,7 @@ use rattler::{
     package_cache::PackageCache,
 };
 use rattler_conda_types::{ChannelConfig, PackageName, Platform, PrefixRecord, RepoDataRecord};
+use rattler_config::{ConfigBase, NoExtension};
 use rattler_repodata_gateway::{Gateway, RepoData, SourceConfig};
 use rattler_solve::SolverTask;
 
@@ -45,6 +46,9 @@ pub struct Opt {
 }
 
 pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
+    let config = ConfigBase::<NoExtension>::load_from_default_locations("rattler")
+        .into_diagnostic()
+        .context("failed to load configuration")?;
     let channel_config =
         ChannelConfig::default_with_root_dir(env::current_dir().into_diagnostic()?);
     // Make the target prefix absolute
@@ -89,6 +93,7 @@ pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
             cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR),
         ))
         .with_client(download_client.clone())
+        .with_max_concurrent_requests(config.concurrency.downloads)
         .with_channel_config(rattler_repodata_gateway::ChannelConfig {
             default: SourceConfig {
                 sharded_enabled: true,
@@ -203,6 +208,7 @@ pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
     let install_start = Instant::now();
     let result = Installer::new()
         .with_download_client(download_client)
+        .with_max_concurrent_requests(config.concurrency.downloads)
         .with_target_platform(install_platform)
         .with_installed_packages(installed_packages)
         .with_execute_link_scripts(true)


### PR DESCRIPTION
### Description

`rattler create` currently ignores the shared `concurrency.downloads` setting. Both repodata requests and package downloads therefore use unlimited request concurrency, which can overload slower storage and spend more CPU on contention.

This loads the default Rattler configuration and applies the configured limit to both the repodata gateway and the installer. I left the default of 50 unchanged; users can lower it for machines where less concurrency performs better.

In controlled runs on a 2-vCPU Codespace, setting the limit to 4 improved the paired median wall time for a fresh `python=3.12 matplotlib` environment by 9.7%. On a larger environment, request limiting alone reduced average wall time from 36.84s to 31.15s. I kept this PR as a draft because choosing a different global default needs a broader machine and network benchmark.

### How Has This Been Tested?

- `cargo check --package rattler-bin`
- `cargo test --package rattler-bin` — 18 tests passed
- A local threaded channel with two generated packages verified that `downloads = 2` allowed exactly two simultaneous package requests and `downloads = 1` allowed exactly one.
- A fresh-cache Codespace install with `downloads = 4` successfully installed Python 3.12 and Matplotlib; importing Matplotlib reported version 3.11.1.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist

- [x] I have performed a self-review of my own code
