### PR TITLE
feat(lock)!: reject credentials and queries during serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,6 +5219,7 @@ dependencies = [
  "pep508_rs",
  "rattler_conda_types",
  "rattler_digest",
+ "rattler_redaction",
  "rattler_solve",
  "rstest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,6 +5230,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "similar-asserts",
+ "tempfile",
  "thiserror 2.0.20",
  "tracing",
  "typed-path",

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -18,6 +18,7 @@ indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 rattler_conda_types = { workspace = true, default-features = false }
 rattler_digest = { workspace = true, default-features = false }
+rattler_redaction = { workspace = true, default-features = false }
 rattler_solve = { workspace = true, default-features = false, features = ["serde"] }
 file_url = { workspace = true }
 pep508_rs = { workspace = true }

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -40,3 +40,4 @@ insta = { workspace = true, features = ["yaml"] }
 serde_json = { workspace = true }
 similar-asserts = { workspace = true }
 rstest = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/rattler_lock/src/export.rs
+++ b/crates/rattler_lock/src/export.rs
@@ -1,0 +1,155 @@
+//! Opt-in checks for URLs in reusable lockfiles.
+
+use pep508_rs::VersionOrUrl;
+use rattler_redaction::strip_url_for_serialization;
+use url::Url;
+
+use crate::{
+    CondaPackageData, FindLinksUrlOrPath, LockFile, LockedPackage, PackageBuildSource,
+    PypiPackageData, UrlOrPath, source::SourceLocation,
+};
+
+/// A URL field that cannot be exported under the durable-output URL policy.
+///
+/// Neither the original URL nor user-supplied names are retained in this error,
+/// so its `Display` and `Debug` implementations do not disclose those values.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("URL at {location} is unsafe or invalid for export")]
+pub struct UrlExportError {
+    /// The field location, using numeric indices rather than user-supplied names.
+    /// Package indices refer to [`LockFile::packages`].
+    pub location: String,
+}
+
+impl LockFile {
+    /// Check URL fields before publishing or committing this lockfile.
+    ///
+    /// Rejects URLs that [`rattler_redaction::strip_url_for_serialization`] would
+    /// change: userinfo, Conda token prefixes, query strings, and non-digest
+    /// fragments. This is conservative: even a public username or a non-secret
+    /// query is rejected. Callers must supply durable resource URLs and arrange
+    /// authentication separately rather than silently changing a resource URL.
+    ///
+    /// Checks Conda and `PyPI` package locations, channels, indexes, source URLs,
+    /// direct `PyPI` requirements, and preserved verbatim URL spellings. Local
+    /// paths are accepted. This is not a general secret scanner: arbitrary
+    /// metadata, path contents, and unrecognized credential conventions are not
+    /// checked.
+    ///
+    /// The first failing field is returned without including the original URL.
+    /// This method does not modify the lockfile. Ordinary serialization,
+    /// [`Self::render_to_string`], and [`Self::to_path`] remain lossless and do not
+    /// invoke this check automatically.
+    ///
+    /// ```
+    /// # use rattler_lock::LockFile;
+    /// # fn export(lock: &LockFile) -> Result<String, Box<dyn std::error::Error>> {
+    /// lock.validate_urls_for_export()?;
+    /// let contents = lock.render_to_string()?;
+    /// # Ok(contents)
+    /// # }
+    /// ```
+    pub fn validate_urls_for_export(&self) -> Result<(), UrlExportError> {
+        for (environment_index, environment) in self.inner.environments.iter().enumerate() {
+            let field = format!("environments[{environment_index}]");
+            for (index, channel) in environment.channels.iter().enumerate() {
+                check_text(&channel.url, &format!("{field}.channels[{index}].url"))?;
+            }
+            if let Some(indexes) = &environment.indexes {
+                for (index, url) in indexes.indexes.iter().enumerate() {
+                    check_url(url, &format!("{field}.indexes[{index}]"))?;
+                }
+                for (index, link) in indexes.find_links.iter().enumerate() {
+                    if let FindLinksUrlOrPath::Url(url) = link {
+                        check_url(url, &format!("{field}.find_links[{index}]"))?;
+                    }
+                }
+            }
+        }
+        // Also covers packages referenced only by source build/host environments.
+        for (index, package) in self.packages().iter().enumerate() {
+            let field = format!("packages[{index}]");
+            match package {
+                LockedPackage::Conda(CondaPackageData::Binary(package)) => {
+                    check_location(&package.location, &format!("{field}.location"))?;
+                    if let Some(channel) = &package.channel {
+                        check_url(channel.as_ref(), &format!("{field}.channel"))?;
+                    }
+                }
+                LockedPackage::Conda(CondaPackageData::Source(package)) => {
+                    check_location(&package.location, &format!("{field}.location"))?;
+                    match &package.package_build_source {
+                        Some(
+                            PackageBuildSource::Git { url, .. }
+                            | PackageBuildSource::Url { url, .. },
+                        ) => {
+                            check_url(url, &format!("{field}.package_build_source"))?;
+                        }
+                        Some(PackageBuildSource::Path { .. }) | None => {}
+                    }
+                    for (index, source) in package.sources.values().enumerate() {
+                        let url = match source {
+                            SourceLocation::Url(source) => &source.url,
+                            SourceLocation::Git(source) => &source.git,
+                            SourceLocation::Path(_) => continue,
+                        };
+                        check_url(url, &format!("{field}.sources[{index}]"))?;
+                    }
+                }
+                LockedPackage::Pypi(package) => {
+                    let location = package.location();
+                    check_location(location.inner(), &format!("{field}.location"))?;
+                    if let Some(given) = location.given() {
+                        check_text(given, &format!("{field}.location.given"))?;
+                    }
+                    if let PypiPackageData::Distribution(package) = package
+                        && let Some(index) = &package.index_url
+                    {
+                        check_url(index, &format!("{field}.index_url"))?;
+                    }
+                    for (index, requirement) in package.requires_dist().iter().enumerate() {
+                        if let Some(VersionOrUrl::Url(url)) = &requirement.version_or_url {
+                            let field = format!("{field}.requires_dist[{index}]");
+                            check_url(url, &field)?;
+                            if let Some(given) = url.given() {
+                                check_text(given, &field)?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn check_url(url: &Url, location: &str) -> Result<(), UrlExportError> {
+    if strip_url_for_serialization(url) != *url {
+        return Err(UrlExportError {
+            location: location.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn check_location(value: &UrlOrPath, location: &str) -> Result<(), UrlExportError> {
+    if let UrlOrPath::Url(url) = value {
+        check_url(url, location)?;
+    }
+    Ok(())
+}
+
+fn check_text(value: &str, location: &str) -> Result<(), UrlExportError> {
+    // Keep file URLs intact while checking: normalizing them to paths first can
+    // discard URL components. Windows drive paths are not URL userinfo/schemes.
+    match Url::parse(value) {
+        Ok(url) if url.scheme().len() == 1 && url.scheme().as_bytes()[0].is_ascii_alphabetic() => {
+            Ok(())
+        }
+        Ok(url) => check_url(&url, location),
+        Err(url::ParseError::RelativeUrlWithoutBase) => Ok(()),
+        Err(_) => Err(UrlExportError {
+            location: location.to_owned(),
+        }),
+    }
+}

--- a/crates/rattler_lock/src/export.rs
+++ b/crates/rattler_lock/src/export.rs
@@ -1,4 +1,4 @@
-//! Opt-in checks for URLs in reusable lockfiles.
+//! Default URL policy for reusable lockfiles.
 
 use pep508_rs::VersionOrUrl;
 use rattler_redaction::strip_url_for_serialization;
@@ -22,7 +22,7 @@ pub struct UrlExportError {
 }
 
 impl LockFile {
-    /// Check URL fields before publishing or committing this lockfile.
+    /// Check URL fields using the default serialization policy.
     ///
     /// Rejects URLs that [`rattler_redaction::strip_url_for_serialization`] would
     /// change: userinfo, Conda token prefixes, query strings, and non-digest
@@ -37,9 +37,11 @@ impl LockFile {
     /// checked.
     ///
     /// The first failing field is returned without including the original URL.
-    /// This method does not modify the lockfile. Ordinary serialization,
-    /// [`Self::render_to_string`], and [`Self::to_path`] remain lossless and do not
-    /// invoke this check automatically.
+    /// This method does not modify the lockfile. Ordinary Serde serialization,
+    /// [`Self::render_to_string`], and [`Self::to_path`] invoke this check
+    /// automatically. Parsing remains permissive so legacy lockfiles can be
+    /// inspected and migrated. [`Self::allow_unsafe_urls`] provides an explicit
+    /// serialization-only opt-out.
     ///
     /// ```
     /// # use rattler_lock::LockFile;
@@ -133,17 +135,23 @@ fn check_url(url: &Url, location: &str) -> Result<(), UrlExportError> {
 }
 
 fn check_location(value: &UrlOrPath, location: &str) -> Result<(), UrlExportError> {
-    if let UrlOrPath::Url(url) = value {
-        check_url(url, location)?;
+    // UrlOrPath is serialized as a string, including when callers construct
+    // its Path variant directly with URL-shaped contents.
+    match value {
+        UrlOrPath::Url(url) => check_url(url, location),
+        UrlOrPath::Path(path) => check_text(path.as_str(), location),
     }
-    Ok(())
 }
 
 fn check_text(value: &str, location: &str) -> Result<(), UrlExportError> {
     // Keep file URLs intact while checking: normalizing them to paths first can
     // discard URL components. Windows drive paths are not URL userinfo/schemes.
     match Url::parse(value) {
-        Ok(url) if url.scheme().len() == 1 && url.scheme().as_bytes()[0].is_ascii_alphabetic() => {
+        Ok(url)
+            if url.scheme().len() == 1
+                && url.scheme().as_bytes()[0].is_ascii_alphabetic()
+                && !url.as_str()[2..].starts_with("//") =>
+        {
             Ok(())
         }
         Ok(url) => check_url(&url, location),

--- a/crates/rattler_lock/src/export_tests.rs
+++ b/crates/rattler_lock/src/export_tests.rs
@@ -1,0 +1,289 @@
+use std::sync::Arc;
+
+use rattler_conda_types::{PackageName, PackageRecord};
+use url::Url;
+
+use crate::{
+    CondaBinaryData, CondaPackageData, CondaSourceData, FindLinksUrlOrPath, LockFile,
+    LockFileInner, LockedPackage, PackageBuildSource, PypiDistributionData, PypiIndexes,
+    PypiPackageData, PypiSourceData, SourceMetadata, UrlOrPath, Verbatim,
+    source::{GitSourceLocation, PathSourceLocation, SourceLocation, UrlSourceLocation},
+};
+
+const SAFE: &str = "https://example.com/demo-1-0.conda";
+const UNSAFE: &str = "https://example.com/demo?opaque=EXAMPLE_SECRET";
+
+fn url(text: &str) -> Url {
+    text.parse().unwrap()
+}
+
+fn record() -> PackageRecord {
+    PackageRecord::new(
+        PackageName::new_unchecked("demo"),
+        "1".parse::<rattler_conda_types::Version>().unwrap(),
+        "0".to_owned(),
+    )
+}
+
+fn with_package(package: LockedPackage) -> LockFile {
+    LockFile {
+        inner: Arc::new(LockFileInner {
+            packages: vec![package],
+            ..Default::default()
+        }),
+    }
+}
+
+fn conda() -> CondaBinaryData {
+    CondaBinaryData {
+        package_record: record(),
+        location: url(SAFE).into(),
+        file_name: "demo-1-0.conda".parse().unwrap(),
+        channel: None,
+    }
+}
+
+fn pypi() -> PypiDistributionData {
+    PypiDistributionData {
+        name: "demo".parse().unwrap(),
+        version: "1".parse().unwrap(),
+        location: Verbatim::new(url(SAFE).into()),
+        index_url: None,
+        hash: None,
+        requires_dist: vec![],
+        requires_python: None,
+    }
+}
+
+fn conda_source() -> CondaSourceData {
+    CondaSourceData {
+        location: UrlOrPath::Path(".".into()),
+        package_build_source: None,
+        variants: std::collections::BTreeMap::new(),
+        identifier_hash: None,
+        sources: std::collections::BTreeMap::new(),
+        source_data: crate::SourceData::default(),
+        metadata: SourceMetadata::Full(Box::new(record())),
+    }
+}
+
+fn rejected(lock: &LockFile, location: &str) {
+    let error = lock.validate_urls_for_export().unwrap_err();
+    assert_eq!(error.location, location);
+    assert!(!format!("{error:?}: {error}").contains("EXAMPLE_SECRET"));
+}
+
+#[test]
+fn channel_validation_is_opt_in_and_does_not_change_serialization() {
+    for value in [
+        "https://EXAMPLE_SECRET@example.com/channel",
+        "https://user:EXAMPLE_SECRET@example.com/channel",
+        "https://example.com/t/EXAMPLE_SECRET/channel",
+        "https://example.com/%74/EXAMPLE_SECRET/channel",
+        "https://example.com/%252574/EXAMPLE_SECRET/channel",
+        UNSAFE,
+        "https://example.com/channel#EXAMPLE_SECRET",
+        "file:///channel?opaque=EXAMPLE_SECRET",
+        "https://[EXAMPLE_SECRET",
+    ] {
+        let mut builder = LockFile::builder();
+        builder.set_channels("EXAMPLE_SECRET", [value]);
+        let lock = builder.finish();
+        let before = lock.render_to_string().unwrap();
+        assert!(before.contains("EXAMPLE_SECRET"));
+        rejected(&lock, "environments[0].channels[0].url");
+        assert_eq!(before, lock.render_to_string().unwrap());
+    }
+}
+
+#[test]
+fn public_urls_digest_fragments_and_local_paths_pass() {
+    for value in [
+        SAFE,
+        "https://example.com/t/",
+        "https://example.com/a#sha256:abcd",
+        "https://example.com/a#md5:0123",
+        "./channel",
+        "/opt/channel",
+        "C:\\channel",
+        "file:///opt/channel",
+    ] {
+        let mut builder = LockFile::builder();
+        builder.set_channels("default", [value]);
+        builder.set_pypi_indexes(
+            "default",
+            PypiIndexes {
+                indexes: vec![url("https://pypi.org/simple")],
+                find_links: vec![FindLinksUrlOrPath::Path("./wheels".into())],
+            },
+        );
+        let lock = builder.finish();
+        let before = lock.render_to_string().unwrap();
+        lock.validate_urls_for_export().unwrap();
+        assert_eq!(before, lock.render_to_string().unwrap());
+    }
+    with_package(LockedPackage::Conda(conda().into()))
+        .validate_urls_for_export()
+        .unwrap();
+}
+
+#[test]
+fn conda_package_locations_and_channels_are_checked() {
+    let mut package = conda();
+    package.location = url(UNSAFE).into();
+    rejected(
+        &with_package(LockedPackage::Conda(package.into())),
+        "packages[0].location",
+    );
+    let mut package = conda();
+    package.channel = Some(url(UNSAFE).into());
+    rejected(
+        &with_package(LockedPackage::Conda(package.into())),
+        "packages[0].channel",
+    );
+}
+
+#[test]
+fn source_package_urls_are_checked_without_exposing_source_names() {
+    let mut package = conda_source();
+    package.location = url(UNSAFE).into();
+    rejected(
+        &with_package(LockedPackage::Conda(CondaPackageData::Source(Box::new(
+            package,
+        )))),
+        "packages[0].location",
+    );
+    for source in [
+        PackageBuildSource::Git {
+            url: url(UNSAFE),
+            spec: None,
+            rev: "main".into(),
+            subdir: None,
+        },
+        PackageBuildSource::Url {
+            url: url(UNSAFE),
+            sha256: rattler_digest::Sha256Hash::default(),
+            subdir: None,
+        },
+    ] {
+        let mut package = conda_source();
+        package.package_build_source = Some(source);
+        rejected(
+            &with_package(LockedPackage::Conda(CondaPackageData::Source(Box::new(
+                package,
+            )))),
+            "packages[0].package_build_source",
+        );
+    }
+    for source in [
+        SourceLocation::Url(UrlSourceLocation {
+            url: url(UNSAFE),
+            md5: None,
+            sha256: None,
+            subdirectory: None,
+        }),
+        SourceLocation::Git(GitSourceLocation {
+            git: url(UNSAFE),
+            rev: None,
+            subdirectory: None,
+            lfs: None,
+        }),
+    ] {
+        let mut package = conda_source();
+        package.sources.insert("EXAMPLE_SECRET".into(), source);
+        rejected(
+            &with_package(LockedPackage::Conda(CondaPackageData::Source(Box::new(
+                package,
+            )))),
+            "packages[0].sources[0]",
+        );
+    }
+    let mut package = conda_source();
+    package.package_build_source = Some(PackageBuildSource::Path { path: ".".into() });
+    package.sources.insert(
+        "demo".into(),
+        SourceLocation::Path(PathSourceLocation {
+            path: "../demo".into(),
+        }),
+    );
+    with_package(LockedPackage::Conda(CondaPackageData::Source(Box::new(
+        package,
+    ))))
+    .validate_urls_for_export()
+    .unwrap();
+}
+
+#[test]
+fn pypi_locations_verbatim_spellings_indexes_and_requirements_are_checked() {
+    let mut package = pypi();
+    package.location = Verbatim::new(url(UNSAFE).into());
+    rejected(
+        &with_package(LockedPackage::Pypi(PypiPackageData::Distribution(
+            Box::new(package),
+        ))),
+        "packages[0].location",
+    );
+    let mut package = pypi();
+    package.location.set_given(UNSAFE.into());
+    rejected(
+        &with_package(LockedPackage::Pypi(PypiPackageData::Distribution(
+            Box::new(package),
+        ))),
+        "packages[0].location.given",
+    );
+    let mut package = pypi();
+    package.index_url = Some(url(UNSAFE));
+    rejected(
+        &with_package(LockedPackage::Pypi(PypiPackageData::Distribution(
+            Box::new(package),
+        ))),
+        "packages[0].index_url",
+    );
+    let mut package = pypi();
+    package
+        .requires_dist
+        .push(format!("dependency @ {UNSAFE}").parse().unwrap());
+    rejected(
+        &with_package(LockedPackage::Pypi(PypiPackageData::Distribution(
+            Box::new(package),
+        ))),
+        "packages[0].requires_dist[0]",
+    );
+    let package = PypiSourceData {
+        name: "demo".parse().unwrap(),
+        location: Verbatim::new_with_given(UrlOrPath::Path(".".into()), UNSAFE.into()),
+        requires_dist: vec![],
+        requires_python: None,
+        source_data: crate::SourceData::default(),
+    };
+    rejected(
+        &with_package(LockedPackage::Pypi(PypiPackageData::Source(Box::new(
+            package,
+        )))),
+        "packages[0].location.given",
+    );
+}
+
+#[test]
+fn environment_indexes_and_find_links_are_checked() {
+    for (indexes, field) in [
+        (
+            PypiIndexes {
+                indexes: vec![url(UNSAFE)],
+                find_links: vec![],
+            },
+            "environments[0].indexes[0]",
+        ),
+        (
+            PypiIndexes {
+                indexes: vec![],
+                find_links: vec![FindLinksUrlOrPath::Url(url(UNSAFE))],
+            },
+            "environments[0].find_links[0]",
+        ),
+    ] {
+        let mut builder = LockFile::builder();
+        builder.set_pypi_indexes("EXAMPLE_SECRET", indexes);
+        rejected(&builder.finish(), field);
+    }
+}

--- a/crates/rattler_lock/src/export_tests.rs
+++ b/crates/rattler_lock/src/export_tests.rs
@@ -71,10 +71,21 @@ fn rejected(lock: &LockFile, location: &str) {
     let error = lock.validate_urls_for_export().unwrap_err();
     assert_eq!(error.location, location);
     assert!(!format!("{error:?}: {error}").contains("EXAMPLE_SECRET"));
+    let yaml_error = serde_yaml::to_string(lock).unwrap_err();
+    let json_error = serde_json::to_string(lock).unwrap_err();
+    let render_error = lock.render_to_string().unwrap_err();
+    for message in [
+        yaml_error.to_string(),
+        json_error.to_string(),
+        render_error.to_string(),
+    ] {
+        assert!(message.contains(location));
+        assert!(!message.contains("EXAMPLE_SECRET"));
+    }
 }
 
 #[test]
-fn channel_validation_is_opt_in_and_does_not_change_serialization() {
+fn serialization_rejects_unsafe_urls_unless_explicitly_opted_out() {
     for value in [
         "https://EXAMPLE_SECRET@example.com/channel",
         "https://user:EXAMPLE_SECRET@example.com/channel",
@@ -82,18 +93,65 @@ fn channel_validation_is_opt_in_and_does_not_change_serialization() {
         "https://example.com/%74/EXAMPLE_SECRET/channel",
         "https://example.com/%252574/EXAMPLE_SECRET/channel",
         UNSAFE,
+        "https://example.com/channel?platform=linux-64",
+        "https://example.com/channel?",
         "https://example.com/channel#EXAMPLE_SECRET",
         "file:///channel?opaque=EXAMPLE_SECRET",
+        "s://example.com/channel?opaque=EXAMPLE_SECRET",
         "https://[EXAMPLE_SECRET",
     ] {
         let mut builder = LockFile::builder();
         builder.set_channels("EXAMPLE_SECRET", [value]);
         let lock = builder.finish();
-        let before = lock.render_to_string().unwrap();
-        assert!(before.contains("EXAMPLE_SECRET"));
+        let before = serde_yaml::to_string(&lock.allow_unsafe_urls()).unwrap();
+        assert!(before.contains(value));
         rejected(&lock, "environments[0].channels[0].url");
-        assert_eq!(before, lock.render_to_string().unwrap());
+        // Opting out is confined to this view; the lock and its clones still
+        // reject unsafe URLs, and parsing remains available for migration.
+        rejected(&lock.clone(), "environments[0].channels[0].url");
+        let legacy = LockFile::from_str_with_base_directory(&before, None).unwrap();
+        rejected(&legacy, "environments[0].channels[0].url");
+        assert_eq!(
+            before,
+            serde_yaml::to_string(&legacy.allow_unsafe_urls()).unwrap()
+        );
     }
+}
+
+#[test]
+fn rejection_happens_before_writing_bytes_or_opening_the_destination() {
+    let mut builder = LockFile::builder();
+    builder.set_channels("default", [UNSAFE]);
+    let lock = builder.finish();
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("lock.yml");
+
+    let error = lock.to_path(&path).unwrap_err();
+    assert!(!error.to_string().contains("EXAMPLE_SECRET"));
+    assert!(!path.exists(), "validation must run before file creation");
+    std::fs::write(&path, "existing lockfile\n").unwrap();
+    assert!(lock.to_path(&path).is_err());
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "existing lockfile\n"
+    );
+
+    let mut yaml = Vec::new();
+    assert!(serde_yaml::to_writer(&mut yaml, &lock).is_err());
+    assert!(yaml.is_empty());
+    let mut json = Vec::new();
+    assert!(serde_json::to_writer(&mut json, &lock).is_err());
+    assert!(json.is_empty());
+
+    // A valid lockfile still uses the normal file-writing path.
+    let mut builder = LockFile::builder();
+    builder.set_channels("default", [SAFE]);
+    let safe = builder.finish();
+    safe.to_path(&path).unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        safe.render_to_string().unwrap()
+    );
 }
 
 #[test]
@@ -106,6 +164,8 @@ fn public_urls_digest_fragments_and_local_paths_pass() {
         "./channel",
         "/opt/channel",
         "C:\\channel",
+        "C:/channel",
+        "C:channel",
         "file:///opt/channel",
     ] {
         let mut builder = LockFile::builder();
@@ -129,6 +189,12 @@ fn public_urls_digest_fragments_and_local_paths_pass() {
 
 #[test]
 fn conda_package_locations_and_channels_are_checked() {
+    let mut package = conda();
+    package.location = UrlOrPath::Path(UNSAFE.into());
+    rejected(
+        &with_package(LockedPackage::Conda(package.into())),
+        "packages[0].location",
+    );
     let mut package = conda();
     package.location = url(UNSAFE).into();
     rejected(

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -81,6 +81,9 @@ use std::{collections::HashMap, io::Read, path::Path, sync::Arc};
 mod builder;
 mod channel;
 mod conda;
+mod export;
+#[cfg(test)]
+mod export_tests;
 mod file_format_version;
 mod hash;
 pub mod options;
@@ -100,6 +103,7 @@ pub use conda::{
     CondaBinaryData, CondaPackageData, CondaSourceData, ConversionError, GitShallowSpec, InputHash,
     PackageBuildSource, PartialSourceMetadata, SourceMetadata, VariantValue,
 };
+pub use export::UrlExportError;
 pub use file_format_version::FileFormatVersion;
 pub use hash::PackageHashes;
 pub use options::{PypiPrereleaseMode, SolveOptions};
@@ -604,13 +608,19 @@ impl LockFile {
         parse::from_str_with_base_directory(source, base_dir)
     }
 
-    /// Writes the conda lock to a file
+    /// Writes the conda lock to a file.
+    ///
+    /// URLs are preserved. Call [`Self::validate_urls_for_export`] first when
+    /// publishing a lockfile that must not contain URL credentials.
     pub fn to_path(&self, path: &Path) -> Result<(), std::io::Error> {
         let file = std::fs::File::create(path)?;
         serde_yaml::to_writer(file, self).map_err(std::io::Error::other)
     }
 
-    /// Writes the conda lock to a string
+    /// Writes the conda lock to a string.
+    ///
+    /// URLs are preserved. Call [`Self::validate_urls_for_export`] first when
+    /// publishing a lockfile that must not contain URL credentials.
     pub fn render_to_string(&self) -> Result<String, std::io::Error> {
         serde_yaml::to_string(self).map_err(std::io::Error::other)
     }

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -42,6 +42,20 @@
 //! * Backward compatible. Older version of lock-files should still be readable
 //!   by never versions of this crate.
 //!
+//! ## URL export policy
+//!
+//! Serializing a [`LockFile`] rejects credential-bearing URLs and **all query
+//! strings**, including non-secret and empty queries. URLs are rejected rather
+//! than silently rewritten. This applies to Serde serialization as well as
+//! [`LockFile::render_to_string`] and [`LockFile::to_path`]; the latter validates
+//! before creating or truncating the destination file.
+//!
+//! See [`LockFile::validate_urls_for_export`] for the full URL policy. Parsing
+//! remains permissive so legacy lockfiles can be inspected and migrated. An
+//! explicit [`LockFile::allow_unsafe_urls`] view provides lossless serialization
+//! when deliberately exporting otherwise rejected URLs; it does not disable
+//! validation on the original lockfile or persist an opt-out flag.
+//!
 //! ## Relation to conda-lock
 //!
 //! Initially the lock-file format was based on [`conda-lock`](https://github.com/conda/conda-lock)
@@ -610,17 +624,24 @@ impl LockFile {
 
     /// Writes the conda lock to a file.
     ///
-    /// URLs are preserved. Call [`Self::validate_urls_for_export`] first when
-    /// publishing a lockfile that must not contain URL credentials.
+    /// Credential-bearing URLs and all query strings are rejected before the
+    /// destination is created or truncated. See [`Self::validate_urls_for_export`]
+    /// for the complete policy, or [`Self::allow_unsafe_urls`] for an explicit
+    /// serialization-only opt-out.
     pub fn to_path(&self, path: &Path) -> Result<(), std::io::Error> {
+        self.validate_urls_for_export()
+            .map_err(std::io::Error::other)?;
         let file = std::fs::File::create(path)?;
-        serde_yaml::to_writer(file, self).map_err(std::io::Error::other)
+        // Validation already ran before opening the file; keep writing streamed
+        // without validating twice or buffering the complete output in memory.
+        serde_yaml::to_writer(file, &self.allow_unsafe_urls()).map_err(std::io::Error::other)
     }
 
     /// Writes the conda lock to a string.
     ///
-    /// URLs are preserved. Call [`Self::validate_urls_for_export`] first when
-    /// publishing a lockfile that must not contain URL credentials.
+    /// Credential-bearing URLs and all query strings are rejected, not stripped.
+    /// See [`Self::validate_urls_for_export`] for the complete policy, or
+    /// [`Self::allow_unsafe_urls`] for an explicit serialization-only opt-out.
     pub fn render_to_string(&self) -> Result<String, std::io::Error> {
         serde_yaml::to_string(self).map_err(std::io::Error::other)
     }
@@ -960,6 +981,13 @@ mod test {
 
     use super::{DEFAULT_ENVIRONMENT_NAME, LockFile};
 
+    // These legacy fixtures encode Git revisions in URL queries. Keep testing
+    // their lossless migration, but also require normal export to reject them.
+    fn render_legacy_query_lock(lock: &LockFile) -> String {
+        assert!(lock.render_to_string().is_err());
+        serde_yaml::to_string(&lock.allow_unsafe_urls()).unwrap()
+    }
+
     fn test_path() -> PathBuf {
         if cfg!(windows) {
             PathBuf::from("C:\\tmp\\some\\test\\path")
@@ -1021,7 +1049,13 @@ mod test {
             .join("../../test-data/conda-lock")
             .join(file_name);
         let conda_lock = LockFile::from_path(&path).unwrap();
-        insta::assert_yaml_snapshot!(file_name, conda_lock);
+        if file_name == "v4/path-based-lock.yml" {
+            assert!(conda_lock.render_to_string().is_err());
+            let conda_lock = conda_lock.allow_unsafe_urls();
+            insta::assert_yaml_snapshot!(file_name, conda_lock);
+        } else {
+            insta::assert_yaml_snapshot!(file_name, conda_lock);
+        }
     }
 
     #[rstest]
@@ -1051,8 +1085,15 @@ mod test {
         // Load the lock-file
         let conda_lock = LockFile::from_path(&path).unwrap();
 
+        let render = |lock: &LockFile| {
+            if path.ends_with("v4/path-based-lock.yml") {
+                render_legacy_query_lock(lock)
+            } else {
+                lock.render_to_string().unwrap()
+            }
+        };
         // Serialize the lock-file
-        let rendered_lock_file = conda_lock.render_to_string().unwrap();
+        let rendered_lock_file = render(&conda_lock);
 
         // Parse the rendered lock-file again
         let source_path = test_path();
@@ -1061,7 +1102,7 @@ mod test {
                 .unwrap();
 
         // And re-render again
-        let rerendered_lock_file = parsed_lock_file.render_to_string().unwrap();
+        let rerendered_lock_file = render(&parsed_lock_file);
 
         similar_asserts::assert_eq!(rendered_lock_file, rerendered_lock_file);
     }
@@ -2303,7 +2344,7 @@ packages:
     requires_python: '>=3.7'
 ";
         let lock_file = LockFile::from_str_with_base_directory(lock_file_str, None).unwrap();
-        let rendered = lock_file.render_to_string().unwrap();
+        let rendered = render_legacy_query_lock(&lock_file);
 
         // After roundtrip, the two entries should be collapsed to a single entry.
         // 2 selectors (one per env) + 1 package entry = 3 occurrences of the URL.
@@ -2317,7 +2358,7 @@ packages:
 
         // A second roundtrip must be stable.
         let reparsed = LockFile::from_str_with_base_directory(&rendered, None).unwrap();
-        let rerendered = reparsed.render_to_string().unwrap();
+        let rerendered = render_legacy_query_lock(&reparsed);
         similar_asserts::assert_eq!(rendered, rerendered);
     }
 
@@ -2374,7 +2415,7 @@ packages:
             .unwrap()
             .finish();
 
-        let rendered = lock_file.render_to_string().unwrap();
+        let rendered = render_legacy_query_lock(&lock_file);
 
         // The git URL should appear exactly 3 times: 2 selectors + 1 package entry.
         let url_str = "git+https://github.com/example/minimalloc.git";
@@ -2387,7 +2428,7 @@ packages:
 
         // Roundtrip must be stable.
         let reparsed = LockFile::from_str_with_base_directory(&rendered, None).unwrap();
-        let rerendered = reparsed.render_to_string().unwrap();
+        let rerendered = render_legacy_query_lock(&reparsed);
         similar_asserts::assert_eq!(rendered, rerendered);
     }
 

--- a/crates/rattler_lock/src/parse/serialize.rs
+++ b/crates/rattler_lock/src/parse/serialize.rs
@@ -143,7 +143,46 @@ impl Serialize for LockFile {
     where
         S: Serializer,
     {
-        let inner = self.inner.as_ref();
+        self.validate_urls_for_export()
+            .map_err(serde::ser::Error::custom)?;
+        self.allow_unsafe_urls().serialize(serializer)
+    }
+}
+
+impl LockFile {
+    /// Explicitly opt out of URL validation for this serialization only.
+    ///
+    /// # Warning
+    ///
+    /// The returned view serializes URLs verbatim, including credentials and
+    /// query strings. Use it only when deliberately exporting such data, for
+    /// example during a controlled migration of a legacy lockfile. Do not
+    /// publish its output without removing credentials and query strings first.
+    ///
+    /// This does not modify the lockfile or disable validation on subsequent
+    /// calls to [`Self::render_to_string`], [`Self::to_path`], or ordinary Serde
+    /// serialization. No opt-out flag is stored in the lockfile.
+    ///
+    /// ```
+    /// # use rattler_lock::LockFile;
+    /// # fn migrate(lock: &LockFile) -> Result<String, serde_yaml::Error> {
+    /// let contents = serde_yaml::to_string(&lock.allow_unsafe_urls())?;
+    /// # Ok(contents)
+    /// # }
+    /// ```
+    pub fn allow_unsafe_urls(&self) -> impl Serialize + '_ {
+        AllowUnsafeUrls(self)
+    }
+}
+
+struct AllowUnsafeUrls<'a>(&'a LockFile);
+
+impl Serialize for AllowUnsafeUrls<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let inner = self.0.inner.as_ref();
 
         // Determine the package indexes that are used in the lock-file,
         // including those referenced transitively via source-package

--- a/crates/rattler_redaction/src/lib.rs
+++ b/crates/rattler_redaction/src/lib.rs
@@ -70,6 +70,8 @@ pub fn redact_signatures_in_text<'a>(text: &'a str, redaction: &str) -> Cow<'a, 
 /// signature. Other query parameters and the fragment are left untouched, so
 /// the URL stays recognizable for debugging.
 ///
+/// Percent-encoded spellings of the `t` token marker are recognized as well.
+///
 /// Use [`strip_url_for_serialization`] instead when the URL is written into
 /// durable output.
 ///
@@ -103,7 +105,7 @@ pub fn redact_url_for_display(url: &Url, redaction: &str) -> Option<Url> {
     // have had a signature masked above; returning `None` here would throw
     // that masking away, since callers fall back to the unredacted URL.
     let token_prefixed = url.path_segments().is_some_and(|mut segments| {
-        matches!((segments.next(), segments.next()), (Some("t"), Some(_)))
+        matches!((segments.next(), segments.next()), (Some(marker), Some(_)) if is_conda_token_marker(marker))
     });
 
     if token_prefixed {
@@ -144,9 +146,14 @@ pub fn redact_known_secrets_from_url(url: &Url, redaction: &str) -> Option<Url> 
 /// fragment that is not a conda artifact digest (`md5:<hex>` or
 /// `sha256:<hex>`), which is a content address rather than a secret.
 ///
-/// Secrets are removed rather than masked so that what remains is a URL that
-/// still resolves: the same channel, reached without the credentials. Query
-/// strings go wholesale instead of by key, because arbitrary services use
+/// Percent-encoded spellings of the `t` token marker are recognized as well.
+///
+/// Secrets are removed rather than masked, leaving a syntactically valid URL
+/// without placeholder credentials. This does not guarantee that it still
+/// resolves to the same resource: a query may select a resource or authorize
+/// access. Callers that cannot change resource URLs should compare the result
+/// with the original and reject changed URLs instead of exporting them.
+/// Query strings go wholesale instead of by key, because arbitrary services use
 /// arbitrary parameter names for credentials and no allowlist can promise
 /// otherwise. Stripping an already stripped URL leaves it unchanged.
 ///
@@ -175,7 +182,7 @@ pub fn strip_url_for_serialization(url: &Url) -> Url {
         match (segments.next(), segments.next()) {
             // The remaining segments include the empty one a trailing slash
             // produces, so rejoining them preserves it.
-            (Some("t"), Some(token)) if !token.is_empty() => {
+            (Some(marker), Some(token)) if is_conda_token_marker(marker) && !token.is_empty() => {
                 Some(format!("/{}", segments.collect::<Vec<_>>().join("/")))
             }
             _ => None,
@@ -194,6 +201,22 @@ pub fn strip_url_for_serialization(url: &Url) -> Url {
     }
 
     url
+}
+
+// URL path segments retain percent escapes. Recognize an encoded `t`, including
+// repeated encoding of the percent sign, without decoding or normalizing public
+// path contents. Work is bounded by the length of the segment.
+fn is_conda_token_marker(segment: &str) -> bool {
+    if segment == "t" {
+        return true;
+    }
+    let Some(mut encoded) = segment.strip_prefix('%') else {
+        return false;
+    };
+    while let Some(rest) = encoded.strip_prefix("25") {
+        encoded = rest;
+    }
+    encoded == "74"
 }
 
 /// A trait to redact known secrets from a type.
@@ -331,6 +354,30 @@ mod test {
             redacted.to_string(),
             format!("https://user:{DEFAULT_REDACTION_STR}@prefix.dev/conda-forge/")
         );
+    }
+
+    #[test]
+    fn encoded_token_markers_are_stripped_and_redacted() {
+        for marker in ["t", "%74", "%2574", "%252574"] {
+            let url = Url::parse(&format!(
+                "https://example.com/{marker}/EXAMPLE_SECRET/channel"
+            ))
+            .unwrap();
+            assert_eq!(
+                strip_url_for_serialization(&url).as_str(),
+                "https://example.com/channel"
+            );
+            assert!(
+                !redact_url_for_display(&url, DEFAULT_REDACTION_STR)
+                    .unwrap()
+                    .as_str()
+                    .contains("EXAMPLE_SECRET")
+            );
+        }
+        for marker in ["T", "token", "%75", "%74public"] {
+            let url = Url::parse(&format!("https://example.com/{marker}/public/channel")).unwrap();
+            assert_eq!(strip_url_for_serialization(&url), url);
+        }
     }
 
     #[test]

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -4161,6 +4161,7 @@ dependencies = [
  "pep508_rs",
  "rattler_conda_types",
  "rattler_digest",
+ "rattler_redaction",
  "rattler_solve",
  "serde",
  "serde-untagged",


### PR DESCRIPTION
### Description

**Intentional behavior change:** normal `LockFile` serialization now rejects credential-bearing URLs and **all query strings**, including public and empty queries. URLs are rejected, not silently stripped or rewritten.

The policy applies to Serde serialization, `render_to_string()`, and `to_path()`. File output validates before opening the destination, so rejection cannot create or truncate it. Validated file output remains streamed without a second validation pass or a full output buffer.

Parsing remains permissive for inspecting and migrating legacy files. An explicit `allow_unsafe_urls()` serialization view provides the opt-out; it does not change the original lockfile, its clones, or subsequent exports, and no bypass flag is stored in the file. Existing Git fixtures with `?rev=...` URLs now assert default rejection and retain their lossless round-trip tests through this opt-out.

```rust
// Safe by default; no separate validation call is necessary.
let contents = lock.render_to_string()?;

// Deliberate opt-out for controlled legacy migration only:
let legacy = serde_yaml::to_string(&lock.allow_unsafe_urls())?;
```

The policy reuses `rattler_redaction::strip_url_for_serialization`, rejecting userinfo, Conda token prefixes, queries, and non-digest fragments. It covers:

- Environment channels, PyPI indexes and find-links URLs.
- Conda binary/source locations, channels, build sources and source mappings.
- PyPI package locations, preserved verbatim spellings, index URLs and direct URL requirements.
- All stored packages, including source build/host dependencies.

`validate_urls_for_export()` remains available for callers wanting a typed preflight error. `UrlExportError` identifies fields by numeric indices without retaining the URL or user-supplied names. Local paths and artifact digest fragments are accepted. This is not a general secret scanner for arbitrary metadata or unrecognized credential conventions.

Also recognizes percent-encoded Conda token markers in the shared redaction helpers and documents why stripping does not guarantee resource equivalence. Updates the Python bindings' Cargo.lock for the added `rattler_redaction` dependency.

Fixes #2764

### How Has This Been Tested?

- `pixi run cargo-fmt`
- `pixi run cargo-clippy` — full workspace, all targets, warnings denied.
- `pixi run -- cargo test -p rattler_lock -p rattler_redaction --locked` — 217 lock tests, 5 redaction tests, and 3 doctests passed.
- `pixi run -- env RUSTDOCFLAGS='-D warnings -Wunreachable-pub' cargo doc -p rattler_lock -p rattler_redaction --no-deps --all-features --locked`
- `cargo metadata --manifest-path py-rattler/Cargo.toml --locked --format-version 1`
- Targeted `typos` and `git diff --check` passed.

Regression tests cover default rejection through YAML/JSON/render/file APIs, public and empty queries, unchanged destinations on failure, zero output bytes on root serialization rejection, legacy parsing, explicit opt-out, URL-bearing fields, encoded tokens, credential-safe errors, local paths and digest fragments. Existing snapshot contents remain unchanged.

The optional whole-tree `dprint-check` reports existing whitespace in two files inside the initialized `rattler_libsolv_c/libsolv` submodule. Those files are untouched; none of this PR's changed files are handled by dprint.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.

Tools: OpenAI coding assistant via pi. The responsibility checkbox is left for the human contributor to confirm.

User prompts:
```plaintext
Can you open an issue in rattler if there is something missing?

You can check out rattler to e.g. `Programs/rattler` and create a PR from my fork if you want

I am not even sure if credentials shoiuld ever enter the lockfile - should we make it opt-out?

OK do it query strings should not relaly be in the url anyways
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
