### PR TITLE
FreeBSD PPC patch

### DIFF
--- a/crates/rattler_conda_types/src/platform.rs
+++ b/crates/rattler_conda_types/src/platform.rs
@@ -35,6 +35,8 @@ pub enum Platform {
     FreeBsd32,
     FreeBsd64,
     FreeBsdArm64,
+    FreeBsdPpc64le,
+    FreeBsdPpc64,
 
     Osx64,
     OsxArm64,
@@ -189,7 +191,18 @@ impl Platform {
             #[cfg(target_arch = "aarch64")]
             return Platform::FreeBsdArm64;
 
-            #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+            #[cfg(all(target_arch = "powerpc64", target_endian = "little"))]
+            return Platform::FreeBsdPpc64le;
+
+            #[cfg(all(target_arch = "powerpc64", target_endian = "big"))]
+            return Platform::FreeBsdPpc64;
+
+            #[cfg(not(any(
+                target_arch = "x86",
+                target_arch = "x86_64",
+                target_arch = "aarch64",
+                target_arch = "powerpc64"
+            )))]
             compile_error!("unsupported freebsd architecture");
         }
         #[cfg(windows)]
@@ -323,6 +336,8 @@ impl Platform {
                     | Platform::FreeBsd32
                     | Platform::FreeBsd64
                     | Platform::FreeBsdArm64
+                    | Platform::FreeBsdPpc64le
+                    | Platform::FreeBsdPpc64
             )
     }
 
@@ -388,7 +403,11 @@ impl Platform {
             | Platform::LinuxS390X
             | Platform::LinuxRiscv32
             | Platform::LinuxRiscv64 => Some("linux"),
-            Platform::FreeBsd32 | Platform::FreeBsd64 | Platform::FreeBsdArm64 => Some("freebsd"),
+            Platform::FreeBsd32
+            | Platform::FreeBsd64
+            | Platform::FreeBsdArm64
+            | Platform::FreeBsdPpc64le
+            | Platform::FreeBsdPpc64 => Some("freebsd"),
             Platform::Osx64 | Platform::OsxArm64 => Some("osx"),
             Platform::IosArm64 => Some("ios"),
             Platform::IosSimulatorArm64 | Platform::IosSimulator64 => Some("iossimulator"),
@@ -443,6 +462,8 @@ impl FromStr for Platform {
             "freebsd-32" => Platform::FreeBsd32,
             "freebsd-64" => Platform::FreeBsd64,
             "freebsd-arm64" => Platform::FreeBsdArm64,
+            "freebsd-ppc64le" => Platform::FreeBsdPpc64le,
+            "freebsd-ppc64" => Platform::FreeBsdPpc64,
             "osx-64" => Platform::Osx64,
             "osx-arm64" => Platform::OsxArm64,
             "ios-arm64" => Platform::IosArm64,
@@ -487,6 +508,8 @@ impl From<Platform> for &'static str {
             Platform::FreeBsd32 => "freebsd-32",
             Platform::FreeBsd64 => "freebsd-64",
             Platform::FreeBsdArm64 => "freebsd-arm64",
+            Platform::FreeBsdPpc64le => "freebsd-ppc64le",
+            Platform::FreeBsdPpc64 => "freebsd-ppc64",
             Platform::Osx64 => "osx-64",
             Platform::OsxArm64 => "osx-arm64",
             Platform::IosArm64 => "ios-arm64",
@@ -519,8 +542,8 @@ impl Platform {
             Platform::LinuxArmV6l => Some(Arch::ArmV6l),
             Platform::LinuxArmV7l => Some(Arch::ArmV7l),
             Platform::LinuxLoongArch64 => Some(Arch::LoongArch64),
-            Platform::LinuxPpc64le => Some(Arch::Ppc64le),
-            Platform::LinuxPpc64 => Some(Arch::Ppc64),
+            Platform::LinuxPpc64le | Platform::FreeBsdPpc64le => Some(Arch::Ppc64le),
+            Platform::LinuxPpc64 | Platform::FreeBsdPpc64 => Some(Arch::Ppc64),
             Platform::LinuxPpc => Some(Arch::Ppc),
             Platform::LinuxS390X => Some(Arch::S390X),
             Platform::LinuxRiscv32 => Some(Arch::Riscv32),
@@ -704,6 +727,14 @@ mod tests {
             "freebsd-arm64".parse::<Platform>().unwrap(),
             Platform::FreeBsdArm64
         );
+        assert_eq!(
+            "freebsd-ppc64le".parse::<Platform>().unwrap(),
+            Platform::FreeBsdPpc64le
+        );
+        assert_eq!(
+            "freebsd-ppc64".parse::<Platform>().unwrap(),
+            Platform::FreeBsdPpc64
+        );
         assert_eq!("win-arm64".parse::<Platform>().unwrap(), Platform::WinArm64);
         assert_eq!(
             "emscripten-wasm32".parse::<Platform>().unwrap(),
@@ -824,6 +855,8 @@ mod tests {
         assert_eq!(Platform::FreeBsd32.arch(), Some(Arch::X86));
         assert_eq!(Platform::FreeBsd64.arch(), Some(Arch::X86_64));
         assert_eq!(Platform::FreeBsdArm64.arch(), Some(Arch::Arm64));
+        assert_eq!(Platform::FreeBsdPpc64le.arch(), Some(Arch::Ppc64le));
+        assert_eq!(Platform::FreeBsdPpc64.arch(), Some(Arch::Ppc64));
         assert_eq!(Platform::Osx64.arch(), Some(Arch::X86_64));
         assert_eq!(Platform::OsxArm64.arch(), Some(Arch::Arm64));
         assert_eq!(Platform::Win32.arch(), Some(Arch::X86));


### PR DESCRIPTION
### Description

This fixes PPC compatibility for FreeBSD.
This patch is from the FreeBSD port sysutils/mise.

### How Has This Been Tested?

mise builds on FreeBSD for all architectures including ppc*

### AI Disclosure
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
