### PR TITLE
ci: add zizmor to lefthook pre-commit and fix high-severity findings

### DIFF
--- a/.github/workflows/breaking-changes-comment.yml
+++ b/.github/workflows/breaking-changes-comment.yml
@@ -1,6 +1,8 @@
 name: Detect breaking changes - Comment
 
-on:
+# This workflow only reads the artifact of the trusted `Detect breaking changes`
+# run and posts a comment; it never checks out or executes PR code.
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: [Detect breaking changes]
     types: [completed]

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,6 +1,8 @@
 name: "Lint PR"
 
-on:
+# `pull_request_target` is needed to validate titles of PRs from forks. The
+# workflow never checks out or executes PR code.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -38,22 +38,27 @@ jobs:
           ref: main # We checkout the main branch to check for the commit
       - name: Check main branch
         if: ${{ inputs.sha }}
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
         run: |
           # Fetch the main branch since a shallow checkout is used by default
           git fetch origin main --unshallow
-          if ! git branch --contains ${{ inputs.sha }} | grep -E '(^|\s)main$'; then
+          if ! git branch --contains "$INPUT_SHA" | grep -E '(^|\s)main$'; then
             echo "The specified sha is not on the main branch" >&2
             exit 1
           fi
       - name: Check tag consistency
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          # Switch to the commit we want to release
-          git checkout ${{ inputs.sha }}
+          # Switch to the commit we want to release (stay on the current commit if no sha was given)
+          git checkout "${INPUT_SHA:-HEAD}"
           cd js-rattler
           version=$(npm pkg get version --workspaces=false | tr -d \")
-          if [ "${{ inputs.tag }}" != "${version}" ]; then
+          if [ "$INPUT_TAG" != "${version}" ]; then
             echo "The input tag does not match the version from package.js:" >&2
-            echo "${{ inputs.tag }}" >&2
+            echo "$INPUT_TAG" >&2
             echo "${version}" >&2
             exit 1
           else
@@ -128,10 +133,12 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
       - name: git tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           git config user.email "hi@prefix.dev"
           git config user.name "Prefix.dev Release CI"
-          git tag -m "js-rattler-v${{ inputs.tag }}" "js-rattler-v${{ inputs.tag }}"
+          git tag -m "js-rattler-v$INPUT_TAG" "js-rattler-v$INPUT_TAG"
           # If there is duplicate tag, this will fail. The publish to npm action will have been a noop (due to skip
           # existing), so we make a non-destructive exit here
           git push --tags

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -466,21 +466,26 @@ jobs:
           ref: main # We checkout the main branch to check for the commit
       - name: Check main branch
         if: ${{ inputs.sha }}
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
         run: |
           # Fetch the main branch since a shallow checkout is used by default
           git fetch origin main --unshallow
-          if ! git branch --contains ${{ inputs.sha }} | grep -E '(^|\s)main$'; then
+          if ! git branch --contains "$INPUT_SHA" | grep -E '(^|\s)main$'; then
             echo "The specified sha is not on the main branch" >&2
             exit 1
           fi
       - name: Check tag consistency
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          # Switch to the commit we want to release
-          git checkout ${{ inputs.sha }}
+          # Switch to the commit we want to release (stay on the current commit if no sha was given)
+          git checkout "${INPUT_SHA:-HEAD}"
           version=$(grep -m 1 "version = " py-rattler/Cargo.toml | sed -e 's/version = "\(.*\)"/\1/g')
-          if [ "${{ inputs.tag }}" != "${version}" ]; then
+          if [ "$INPUT_TAG" != "${version}" ]; then
             echo "The input tag does not match the version from Cargo.toml:" >&2
-            echo "${{ inputs.tag }}" >&2
+            echo "$INPUT_TAG" >&2
             echo "${version}" >&2
             exit 1
           else
@@ -561,11 +566,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_NOTES: ${{ needs.extract-changelog.outputs.release_notes }}
+          INPUT_TAG: ${{ inputs.tag }}
+          TARGET_SHA: ${{ inputs.sha || github.sha }}
         run: |
-          gh release create "py-rattler-v${{ inputs.tag }}" \
+          gh release create "py-rattler-v$INPUT_TAG" \
             --repo "${{ github.repository }}" \
-            --target "${{ inputs.sha || github.sha }}" \
-            --title "py-rattler v${{ inputs.tag }}" \
+            --target "$TARGET_SHA" \
+            --title "py-rattler v$INPUT_TAG" \
             --notes "$RELEASE_NOTES"
 
   deploy-release-docs:

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,6 +1,8 @@
 name: Check PR
 
-on:
+# `pull_request_target` is needed to label/close PRs from forks. The workflow
+# never checks out or executes PR code.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, reopened]
   issue_comment:

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -28,6 +28,8 @@ jobs:
           private-key: ${{ secrets.VOUCHED_APP_PRIVATE_KEY }}
           owner: prefix-dev
           repositories: vouched
+          # The token is only used to check out and push to the vouched repo
+          permission-contents: write
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -22,6 +22,10 @@ pre-commit:
   jobs:
     - name: actionlint
       run: pixi {run} actionlint
+    - name: zizmor
+      glob: "*.{yml,yaml}"
+      stage_fixed: true
+      run: pixi {run} zizmor
     - name: cargo-fmt
       glob: "*.rs"
       stage_fixed: true

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -25,7 +25,7 @@ pre-commit:
     - name: zizmor
       glob: "*.{yml,yaml}"
       stage_fixed: true
-      run: pixi {run} zizmor
+      run: pixi {run} zizmor-check
     - name: cargo-fmt
       glob: "*.rs"
       stage_fixed: true

--- a/pixi.lock
+++ b/pixi.lock
@@ -333,6 +333,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zizmor-1.29.0-hb17b654_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
@@ -422,6 +423,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/xz-5.8.1-h357f2ed_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/xz-gpl-tools-5.8.1-h357f2ed_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/xz-tools-5.8.1-hd471939_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/zizmor-1.29.0-h19f9e61_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h8210216_2.conda
       osx-arm64:
@@ -502,6 +504,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xz-tools-5.8.1-h39f12f2_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/zizmor-1.29.0-h6fdd925_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
       win-64:
@@ -547,6 +550,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_32.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_32.conda
+      - conda: https://prefix.dev/conda-forge/win-64/zizmor-1.29.0-h18a1a76_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
   minio:
     channels:
@@ -2504,6 +2508,19 @@ packages:
   license: 0BSD AND LGPL-2.1-or-later
   size: 96433
   timestamp: 1749230076687
+- conda: https://prefix.dev/conda-forge/linux-64/zizmor-1.29.0-hb17b654_0.conda
+  sha256: 9d5d169aa8351e36f21bbe2b9de6bbe14e5b23f1f2f3d414d22ba187bd6ba25b
+  md5: b4fc38113e926755295bff26ac065c50
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 7153107
+  timestamp: 1785627167864
 - conda: https://prefix.dev/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
   sha256: 245c9ee8d688e23661b95e3c6dd7272ca936fabc03d423cdb3cdee1bbcf9f2f2
   md5: c2a01a08fc991620a74b32420e97868a
@@ -4416,6 +4433,18 @@ packages:
   license: 0BSD AND LGPL-2.1-or-later
   size: 85777
   timestamp: 1749230191007
+- conda: https://prefix.dev/conda-forge/osx-64/zizmor-1.29.0-h19f9e61_0.conda
+  sha256: aaa72ec28c82b9de28ce924af99172e0b3d3bbf70b35dfcdc9d59ae5059275d2
+  md5: c7d23e15e37a0f9c43df9c5d312b36ab
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 7020863
+  timestamp: 1785627245169
 - conda: https://prefix.dev/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
   sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
   md5: c989e0295dcbdc08106fe5d9e935f0b9
@@ -5887,6 +5916,18 @@ packages:
   license: 0BSD AND LGPL-2.1-or-later
   size: 86425
   timestamp: 1749230316106
+- conda: https://prefix.dev/conda-forge/osx-arm64/zizmor-1.29.0-h6fdd925_0.conda
+  sha256: 5cec7f410a5f3b34a510f53d1369538e33cd4b2a74f95750c34f583fd7a155df
+  md5: 8550674440f90ae9a846d7abbd9f039f
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 6587395
+  timestamp: 1785627184309
 - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
   sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
   md5: e3170d898ca6cb48f1bb567afb92f775
@@ -6821,6 +6862,18 @@ packages:
     - ucrt >=10.0.20348.0
   size: 19606
   timestamp: 1767320221083
+- conda: https://prefix.dev/conda-forge/win-64/zizmor-1.29.0-h18a1a76_0.conda
+  sha256: 0ef5635612c25e1be879420c35fafe78370bd23fb6bcea984fa916b62aff0876
+  md5: 2983d1a01bf141341d0789c21b6a1df7
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 7380733
+  timestamp: 1785627207412
 - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
   sha256: bc64864377d809b904e877a98d0584f43836c9f2ef27d3d2a1421fa6eae7ca04
   md5: 21f56217d6125fb30c3c3f10c786d751

--- a/pixi.toml
+++ b/pixi.toml
@@ -64,12 +64,14 @@ typos = ">=1.23.1,<2"
 dprint = ">=0.50.0,<0.51"
 lefthook = ">=2.0.11,<3"
 actionlint = ">=1.7.7,<2"
+zizmor = ">=1.29.0,<2"
 shellcheck = ">=0.10.0,<0.11"
 [feature.lint.target.unix.dependencies]
 vouch = "*"
 
 [feature.lint.tasks]
 actionlint = { cmd = "actionlint", env = { SHELLCHECK_OPTS = "-e SC2086 -e SC2046 -e SC2028" } }
+zizmor = { cmd = "zizmor --no-progress --min-severity high --fix --offline .", description = "Audit GitHub Actions workflows with zizmor" }
 dprint-check = { cmd = "dprint check --log-level=silent", description = "Check formatting with dprint" }
 dprint-fmt = { cmd = "dprint fmt --incremental=false", description = "Format with dprint" }
 lefthook = { cmd = "lefthook", description = "Run lefthook" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -71,7 +71,7 @@ vouch = "*"
 
 [feature.lint.tasks]
 actionlint = { cmd = "actionlint", env = { SHELLCHECK_OPTS = "-e SC2086 -e SC2046 -e SC2028" } }
-zizmor = { cmd = "zizmor --no-progress --min-severity high --fix --offline .", description = "Audit GitHub Actions workflows with zizmor" }
+zizmor-check = { cmd = "zizmor --no-progress --min-severity high --fix --offline .", description = "Audit GitHub Actions workflows with zizmor" }
 dprint-check = { cmd = "dprint check --log-level=silent", description = "Check formatting with dprint" }
 dprint-fmt = { cmd = "dprint fmt --incremental=false", description = "Format with dprint" }
 lefthook = { cmd = "lefthook", description = "Run lefthook" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -71,7 +71,7 @@ vouch = "*"
 
 [feature.lint.tasks]
 actionlint = { cmd = "actionlint", env = { SHELLCHECK_OPTS = "-e SC2086 -e SC2046 -e SC2028" } }
-zizmor-check = { cmd = "zizmor --no-progress --min-severity high --fix --offline .", description = "Audit GitHub Actions workflows with zizmor" }
+zizmor-check = { cmd = "zizmor --no-progress --min-severity high --fix --offline .github", description = "Audit GitHub Actions workflows with zizmor" }
 dprint-check = { cmd = "dprint check --log-level=silent", description = "Check formatting with dprint" }
 dprint-fmt = { cmd = "dprint fmt --incremental=false", description = "Format with dprint" }
 lefthook = { cmd = "lefthook", description = "Run lefthook" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -71,7 +71,7 @@ vouch = "*"
 
 [feature.lint.tasks]
 actionlint = { cmd = "actionlint", env = { SHELLCHECK_OPTS = "-e SC2086 -e SC2046 -e SC2028" } }
-zizmor-check = { cmd = "zizmor --no-progress --min-severity high --fix --offline .github", description = "Audit GitHub Actions workflows with zizmor" }
+zizmor-check = { cmd = "zizmor --no-progress --min-severity high --fix --offline .", description = "Audit GitHub Actions workflows with zizmor" }
 dprint-check = { cmd = "dprint check --log-level=silent", description = "Check formatting with dprint" }
 dprint-fmt = { cmd = "dprint fmt --incremental=false", description = "Format with dprint" }
 lefthook = { cmd = "lefthook", description = "Run lefthook" }


### PR DESCRIPTION
Add zizmor (GitHub Actions security auditor) to the lint environment and
run it as a lefthook pre-commit job, mirroring the setup in
Quantco/copier-template-python-open-source. It runs with
`--min-severity high --offline --fix` over the whole repo, so it also
executes in CI via `pixi run lint`.

Fix the 17 high-severity findings the audit reported so the hook passes:

- template-injection: pass `inputs.sha` / `inputs.tag` through `env`
  instead of expanding them directly into `run:` scripts in the JS and
  Python release workflows.
- dangerous-triggers: annotate the `pull_request_target` /
  `workflow_run` workflows (PR title lint, vouch check, breaking-changes
  comment) with an ignore comment; none of them check out or run PR code.
- github-app: scope the vouched app token to `permission-contents: write`,
  which is all the checkout + push needs.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HvjZNPgh6rxdnMBtMFZdBM