### PR TITLE
feat(py-rattler): expose missing `IndexJson` fields (`noarch`, `extra_depends`, `flags`, `purls`, `python_site_packages_path`, `repodata_revision`)

### DIFF
--- a/py-rattler/rattler/package/index_json.py
+++ b/py-rattler/rattler/package/index_json.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import os
 import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from rattler.package.no_arch_type import NoArchLiteral, NoArchType
 from rattler.package.package_name import PackageName
@@ -232,6 +232,32 @@ class IndexJson:
         self._inner.set_depends(value)
 
     @property
+    def extra_depends(self) -> Dict[str, List[str]]:
+        """
+        Extra dependency groups that can be selected using `foobar[extras=["scientific"]]`.
+        The implementation is specified in this CEP: <https://github.com/conda/ceps/pull/111>
+
+        Examples
+        --------
+        ```python
+        >>> idx_json = IndexJson.from_path(
+        ...     "../test-data/conda-22.11.1-py38haa244fe_1-index.json"
+        ... )
+        >>> idx_json.extra_depends
+        {}
+        >>> idx_json.extra_depends = {"security": ["cryptography >=3.0"]}
+        >>> idx_json.extra_depends
+        {'security': ['cryptography >=3.0']}
+        >>>
+        ```
+        """
+        return self._inner.extra_depends
+
+    @extra_depends.setter
+    def extra_depends(self, value: Dict[str, List[str]]) -> None:
+        self._inner.extra_depends = value
+
+    @property
     def features(self) -> Optional[str]:
         """
         Features are a deprecated way to specify different feature sets for the conda solver. This is not
@@ -256,6 +282,34 @@ class IndexJson:
     @features.setter
     def features(self, value: Optional[str]) -> None:
         self._inner.set_features(value)
+
+    @property
+    def flags(self) -> List[str]:
+        """
+        Plain string flags used to select package variants.
+
+        Rattler preserves unrecognized flags so applications can round-trip
+        flags introduced by newer repodata revisions.
+
+        Examples
+        --------
+        ```python
+        >>> idx_json = IndexJson.from_path(
+        ...     "../test-data/conda-22.11.1-py38haa244fe_1-index.json"
+        ... )
+        >>> idx_json.flags
+        []
+        >>> idx_json.flags = ["optional", "future-flag"]
+        >>> idx_json.flags
+        ['optional', 'future-flag']
+        >>>
+        ```
+        """
+        return self._inner.flags
+
+    @flags.setter
+    def flags(self, value: List[str]) -> None:
+        self._inner.flags = value
 
     @property
     def license(self) -> Optional[str]:
@@ -388,6 +442,97 @@ class IndexJson:
     @platform.setter
     def platform(self, value: Optional[str]) -> None:
         self._inner.set_platform(value)
+
+    @property
+    def purls(self) -> Optional[List[str]]:
+        """
+        A list of Package URLs identifying this package.
+        See this CEP: <https://github.com/conda/ceps/pull/63>
+
+        Examples
+        --------
+        ```python
+        >>> idx_json = IndexJson.from_path(
+        ...     "../test-data/conda-22.11.1-py38haa244fe_1-index.json"
+        ... )
+        >>> idx_json.purls is None
+        True
+        >>> idx_json.purls = ["pkg:pypi/conda@22.11.1"]
+        >>> idx_json.purls
+        ['pkg:pypi/conda@22.11.1']
+        >>> idx_json.purls = None
+        >>> idx_json.purls is None
+        True
+        >>>
+        ```
+        """
+        return self._inner.purls
+
+    @purls.setter
+    def purls(self, value: Optional[List[str]]) -> None:
+        self._inner.purls = value
+
+    @property
+    def python_site_packages_path(self) -> Optional[str]:
+        """
+        Optionally a path within the environment of the site-packages directory. This field is only
+        present for python interpreter packages.
+        This field was introduced with <https://github.com/conda/ceps/blob/main/cep-17.md>.
+
+        Examples
+        --------
+        ```python
+        >>> idx_json = IndexJson.from_path(
+        ...     "../test-data/conda-22.11.1-py38haa244fe_1-index.json"
+        ... )
+        >>> idx_json.python_site_packages_path is None
+        True
+        >>> idx_json.python_site_packages_path = "lib/python3.11/site-packages"
+        >>> idx_json.python_site_packages_path
+        'lib/python3.11/site-packages'
+        >>>
+        ```
+        """
+        return self._inner.python_site_packages_path
+
+    @python_site_packages_path.setter
+    def python_site_packages_path(self, value: Optional[str]) -> None:
+        self._inner.python_site_packages_path = value
+
+    @property
+    def repodata_revision(self) -> Optional[str]:
+        """
+        The repodata revision required by this package, formatted as `vN` (e.g. `"v3"`).
+
+        Indexers use this field to decide whether the record can be written to the legacy
+        `packages` / `packages.conda` maps or must be written to a newer top-level `vN` map.
+        The setter accepts either a `vN` string or the integer revision number.
+
+        Examples
+        --------
+        ```python
+        >>> idx_json = IndexJson.from_path(
+        ...     "../test-data/conda-22.11.1-py38haa244fe_1-index.json"
+        ... )
+        >>> idx_json.repodata_revision is None
+        True
+        >>> idx_json.repodata_revision = "v3"
+        >>> idx_json.repodata_revision
+        'v3'
+        >>> idx_json.repodata_revision = 3
+        >>> idx_json.repodata_revision
+        'v3'
+        >>> idx_json.repodata_revision = None
+        >>> idx_json.repodata_revision is None
+        True
+        >>>
+        ```
+        """
+        return self._inner.repodata_revision
+
+    @repodata_revision.setter
+    def repodata_revision(self, value: Optional[Union[str, int]]) -> None:
+        self._inner.repodata_revision = None if value is None else str(value)
 
     @property
     def subdir(self) -> Optional[str]:

--- a/py-rattler/rattler/package/index_json.py
+++ b/py-rattler/rattler/package/index_json.py
@@ -444,35 +444,6 @@ class IndexJson:
         self._inner.set_platform(value)
 
     @property
-    def purls(self) -> Optional[List[str]]:
-        """
-        A list of Package URLs identifying this package.
-        See this CEP: <https://github.com/conda/ceps/pull/63>
-
-        Examples
-        --------
-        ```python
-        >>> idx_json = IndexJson.from_path(
-        ...     "../test-data/conda-22.11.1-py38haa244fe_1-index.json"
-        ... )
-        >>> idx_json.purls is None
-        True
-        >>> idx_json.purls = ["pkg:pypi/conda@22.11.1"]
-        >>> idx_json.purls
-        ['pkg:pypi/conda@22.11.1']
-        >>> idx_json.purls = None
-        >>> idx_json.purls is None
-        True
-        >>>
-        ```
-        """
-        return self._inner.purls
-
-    @purls.setter
-    def purls(self, value: Optional[List[str]]) -> None:
-        self._inner.purls = value
-
-    @property
     def python_site_packages_path(self) -> Optional[str]:
         """
         Optionally a path within the environment of the site-packages directory. This field is only

--- a/py-rattler/rattler/package/index_json.py
+++ b/py-rattler/rattler/package/index_json.py
@@ -444,6 +444,35 @@ class IndexJson:
         self._inner.set_platform(value)
 
     @property
+    def purls(self) -> Optional[List[str]]:
+        """
+        A list of Package URLs identifying this package.
+        See this CEP: <https://github.com/conda/ceps/pull/63>
+
+        Examples
+        --------
+        ```python
+        >>> idx_json = IndexJson.from_path(
+        ...     "../test-data/conda-22.11.1-py38haa244fe_1-index.json"
+        ... )
+        >>> idx_json.purls is None
+        True
+        >>> idx_json.purls = ["pkg:pypi/conda@22.11.1"]
+        >>> idx_json.purls
+        ['pkg:pypi/conda@22.11.1']
+        >>> idx_json.purls = None
+        >>> idx_json.purls is None
+        True
+        >>>
+        ```
+        """
+        return self._inner.purls
+
+    @purls.setter
+    def purls(self, value: Optional[List[str]]) -> None:
+        self._inner.purls = value
+
+    @property
     def python_site_packages_path(self) -> Optional[str]:
         """
         Optionally a path within the environment of the site-packages directory. This field is only

--- a/py-rattler/rattler/package/index_json.py
+++ b/py-rattler/rattler/package/index_json.py
@@ -4,6 +4,7 @@ import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
+from rattler.package.no_arch_type import NoArchLiteral, NoArchType
 from rattler.package.package_name import PackageName
 from rattler.rattler import PyIndexJson
 from rattler.version.version import Version
@@ -329,6 +330,39 @@ class IndexJson:
     @name.setter
     def name(self, value: PackageName) -> None:
         self._inner.name = value._name
+
+    @property
+    def noarch(self) -> NoArchType:
+        """
+        If this package is independent of architecture this field specifies in what way.
+
+        Examples
+        --------
+        ```python
+        >>> idx_json = IndexJson.from_path(
+        ...     "../test-data/conda-22.11.1-py38haa244fe_1-index.json"
+        ... )
+        >>> idx_json.noarch
+        NoArchType(None)
+        >>> idx_json.noarch = NoArchType("python")
+        >>> idx_json.noarch
+        NoArchType("python")
+        >>> idx_json.noarch = "generic"
+        >>> idx_json.noarch
+        NoArchType("generic")
+        >>> idx_json.noarch = None
+        >>> idx_json.noarch.none
+        True
+        >>>
+        ```
+        """
+        return NoArchType._from_py_no_arch_type(self._inner.noarch)
+
+    @noarch.setter
+    def noarch(self, value: NoArchType | NoArchLiteral) -> None:
+        if not isinstance(value, NoArchType):
+            value = NoArchType(value)
+        self._inner.noarch = value._noarch
 
     @property
     def platform(self) -> Optional[str]:

--- a/py-rattler/src/index_json.rs
+++ b/py-rattler/src/index_json.rs
@@ -1,11 +1,15 @@
-use std::path::PathBuf;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+    str::FromStr,
+};
 
 use pyo3::{
     Bound, Py, PyAny, PyErr, PyResult, Python, exceptions::PyValueError, pyclass, pymethods,
 };
 use pyo3_async_runtimes::tokio::future_into_py;
 use rattler_conda_types::{
-    Flag, VersionWithSource,
+    Flag, PackageUrl, RepodataRevision, VersionWithSource,
     package::{IndexJson, PackageFile},
     utils::TimestampMs,
 };
@@ -171,6 +175,18 @@ impl PyIndexJson {
         self.inner.depends = depends;
     }
 
+    /// Extra dependency groups that can be selected using `foobar[extras=["scientific"]]`.
+    /// The implementation is specified in this CEP: <https://github.com/conda/ceps/pull/111>
+    #[getter]
+    pub fn extra_depends(&self) -> BTreeMap<String, Vec<String>> {
+        self.inner.extra_depends.clone()
+    }
+
+    #[setter]
+    pub fn set_extra_depends(&mut self, extra_depends: BTreeMap<String, Vec<String>>) {
+        self.inner.extra_depends = extra_depends;
+    }
+
     /// Features are a deprecated way to specify different feature sets for the conda solver. This is not
     /// supported anymore and should not be used. Instead, `mutex` packages should be used to specify
     /// mutually exclusive features.
@@ -248,6 +264,66 @@ impl PyIndexJson {
     #[setter]
     pub fn set_platform(&mut self, platform: Option<String>) {
         self.inner.platform = platform;
+    }
+
+    /// A list of Package URLs identifying this package.
+    /// See this CEP: <https://github.com/conda/ceps/pull/63>
+    #[getter]
+    pub fn purls(&self) -> Option<Vec<String>> {
+        self.inner
+            .purls
+            .as_ref()
+            .map(|purls| purls.iter().map(ToString::to_string).collect())
+    }
+
+    #[setter]
+    pub fn set_purls(&mut self, purls: Option<Vec<String>>) -> PyResult<()> {
+        self.inner.purls = purls
+            .map(|purls| {
+                purls
+                    .iter()
+                    .map(|purl| {
+                        PackageUrl::from_str(purl).map_err(|err| {
+                            PyValueError::new_err(format!("Invalid package URL '{purl}': {err}"))
+                        })
+                    })
+                    .collect::<PyResult<BTreeSet<_>>>()
+            })
+            .transpose()?;
+        Ok(())
+    }
+
+    /// Optionally a path within the environment of the site-packages directory.
+    /// This field is only present for python interpreter packages.
+    /// This field was introduced with <https://github.com/conda/ceps/blob/main/cep-17.md>.
+    #[getter]
+    pub fn python_site_packages_path(&self) -> Option<String> {
+        self.inner.python_site_packages_path.clone()
+    }
+
+    #[setter]
+    pub fn set_python_site_packages_path(&mut self, python_site_packages_path: Option<String>) {
+        self.inner.python_site_packages_path = python_site_packages_path;
+    }
+
+    /// The repodata revision required by this package record, formatted as `vN`.
+    #[getter]
+    pub fn repodata_revision(&self) -> Option<String> {
+        self.inner
+            .repodata_revision
+            .map(|revision| revision.to_string())
+    }
+
+    #[setter]
+    pub fn set_repodata_revision(&mut self, repodata_revision: Option<String>) -> PyResult<()> {
+        self.inner.repodata_revision = repodata_revision
+            .map(|revision| {
+                RepodataRevision::from_str(&revision).map_err(|err| {
+                    PyValueError::new_err(format!("Invalid repodata revision '{revision}': {err}"))
+                })
+            })
+            .transpose()?;
+        Ok(())
     }
 
     /// The subdirectory that contains this package

--- a/py-rattler/src/index_json.rs
+++ b/py-rattler/src/index_json.rs
@@ -1,15 +1,11 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    path::PathBuf,
-    str::FromStr,
-};
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
 
 use pyo3::{
     Bound, Py, PyAny, PyErr, PyResult, Python, exceptions::PyValueError, pyclass, pymethods,
 };
 use pyo3_async_runtimes::tokio::future_into_py;
 use rattler_conda_types::{
-    Flag, PackageUrl, RepodataRevision, VersionWithSource,
+    Flag, RepodataRevision, VersionWithSource,
     package::{IndexJson, PackageFile},
     utils::TimestampMs,
 };
@@ -264,33 +260,6 @@ impl PyIndexJson {
     #[setter]
     pub fn set_platform(&mut self, platform: Option<String>) {
         self.inner.platform = platform;
-    }
-
-    /// A list of Package URLs identifying this package.
-    /// See this CEP: <https://github.com/conda/ceps/pull/63>
-    #[getter]
-    pub fn purls(&self) -> Option<Vec<String>> {
-        self.inner
-            .purls
-            .as_ref()
-            .map(|purls| purls.iter().map(ToString::to_string).collect())
-    }
-
-    #[setter]
-    pub fn set_purls(&mut self, purls: Option<Vec<String>>) -> PyResult<()> {
-        self.inner.purls = purls
-            .map(|purls| {
-                purls
-                    .iter()
-                    .map(|purl| {
-                        PackageUrl::from_str(purl).map_err(|err| {
-                            PyValueError::new_err(format!("Invalid package URL '{purl}': {err}"))
-                        })
-                    })
-                    .collect::<PyResult<BTreeSet<_>>>()
-            })
-            .transpose()?;
-        Ok(())
     }
 
     /// Optionally a path within the environment of the site-packages directory.

--- a/py-rattler/src/index_json.rs
+++ b/py-rattler/src/index_json.rs
@@ -1,11 +1,15 @@
-use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+    str::FromStr,
+};
 
 use pyo3::{
     Bound, Py, PyAny, PyErr, PyResult, Python, exceptions::PyValueError, pyclass, pymethods,
 };
 use pyo3_async_runtimes::tokio::future_into_py;
 use rattler_conda_types::{
-    Flag, RepodataRevision, VersionWithSource,
+    Flag, PackageUrl, RepodataRevision, VersionWithSource,
     package::{IndexJson, PackageFile},
     utils::TimestampMs,
 };
@@ -260,6 +264,33 @@ impl PyIndexJson {
     #[setter]
     pub fn set_platform(&mut self, platform: Option<String>) {
         self.inner.platform = platform;
+    }
+
+    /// A list of Package URLs identifying this package.
+    /// See this CEP: <https://github.com/conda/ceps/pull/63>
+    #[getter]
+    pub fn purls(&self) -> Option<Vec<String>> {
+        self.inner
+            .purls
+            .as_ref()
+            .map(|purls| purls.iter().map(ToString::to_string).collect())
+    }
+
+    #[setter]
+    pub fn set_purls(&mut self, purls: Option<Vec<String>>) -> PyResult<()> {
+        self.inner.purls = purls
+            .map(|purls| {
+                purls
+                    .iter()
+                    .map(|purl| {
+                        PackageUrl::from_str(purl).map_err(|err| {
+                            PyValueError::new_err(format!("Invalid package URL '{purl}': {err}"))
+                        })
+                    })
+                    .collect::<PyResult<BTreeSet<_>>>()
+            })
+            .transpose()?;
+        Ok(())
     }
 
     /// Optionally a path within the environment of the site-packages directory.

--- a/py-rattler/src/index_json.rs
+++ b/py-rattler/src/index_json.rs
@@ -13,8 +13,8 @@ use rattler_package_streaming::seek::read_package_file;
 use url::Url;
 
 use crate::{
-    error::PyRattlerError, networking::client::PyClientWithMiddleware, package_name::PyPackageName,
-    version::PyVersion,
+    error::PyRattlerError, networking::client::PyClientWithMiddleware, no_arch_type::PyNoArchType,
+    package_name::PyPackageName, version::PyVersion,
 };
 
 #[pyclass(from_py_object)]
@@ -226,6 +226,17 @@ impl PyIndexJson {
     #[setter]
     pub fn set_name(&mut self, name: PyPackageName) {
         self.inner.name = name.into();
+    }
+
+    /// If this package is independent of architecture this field specifies in what way.
+    #[getter]
+    pub fn noarch(&self) -> PyNoArchType {
+        self.inner.noarch.into()
+    }
+
+    #[setter]
+    pub fn set_noarch(&mut self, noarch: PyNoArchType) {
+        self.inner.noarch = noarch.into();
     }
 
     /// Optionally, the OS the package is build for.


### PR DESCRIPTION
### Description

The Rust `IndexJson` struct had several fields that were not reachable from the Python `IndexJson` class. This PR exposes all of them so every Rust field now has a Python getter and setter:

| Field | Python type | Notes |
|---|---|---|
| `noarch` | `NoArchType` | Setter also accepts a `NoArchLiteral` (`"python"`, `"generic"`, `True`, `None`), mirroring `PackageRecord`. |
| `extra_depends` | `Dict[str, List[str]]` | Same shape as `PackageRecord.extra_depends`. |
| `flags` | `List[str]` | Already existed on the pyo3 class; now exposed on the Python wrapper too. |
| `purls` | `Optional[List[str]]` | Package URL strings. Invalid purls raise `ValueError`. |
| `python_site_packages_path` | `Optional[str]` | CEP-17 field. |
| `repodata_revision` | `Optional[str]` | Formatted as `vN` (e.g. `"v3"`). Setter also accepts an `int`. Invalid values raise `ValueError`. |

```python
>>> idx = IndexJson.from_path("../test-data/conda-22.11.1-py38haa244fe_1-index.json")
>>> idx.noarch
NoArchType(None)
>>> idx.noarch = "python"
>>> idx.noarch
NoArchType("python")
>>> idx.extra_depends = {"security": ["cryptography >=3.0"]}
>>> idx.purls = ["pkg:pypi/conda@22.11.1"]
>>> idx.repodata_revision = 3
>>> idx.repodata_revision
'v3'
```

### How Has This Been Tested?

- Added doctests for each new property in `py-rattler/rattler/package/index_json.py` covering read, set, and clear. The full py-rattler doctest suite passes (`pixi run test` in `py-rattler`).
- Verified round-tripping by parsing an `index.json` string containing all the new fields, and verified that invalid `purls` and `repodata_revision` values raise `ValueError`.
- `cargo fmt`, `cargo clippy --all`, `ruff`, and `mypy` are clean.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

```plaintext
i think in py-rattler in IndexJson, the `noarch` field is not available in contrast to the rust part. Can you verify this and add it?
are there any other fields in there that are not exposed in python?
add them
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPo22a7JmWAvyriLtFcnZC