### PR TITLE
ci: use ubuntu-slim for lightweight GitHub Actions jobs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,0 @@
-# `ubuntu-slim` is a GitHub-hosted runner label that actionlint 1.7.8 does not
-# know about yet. Listing it here keeps the runner-label rule from failing.
-# Remove this once actionlint ships the label in its built-in list.
-self-hosted-runner:
-  labels:
-    - ubuntu-slim

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# `ubuntu-slim` is a GitHub-hosted runner label that actionlint 1.7.8 does not
+# know about yet. Listing it here keeps the runner-label rule from failing.
+# Remove this once actionlint ships the label in its built-in list.
+self-hosted-runner:
+  labels:
+    - ubuntu-slim

--- a/.github/workflows/breaking-changes-comment.yml
+++ b/.github/workflows/breaking-changes-comment.yml
@@ -25,7 +25,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion != 'cancelled'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       actions: read
       pull-requests: write

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,7 +40,7 @@ jobs:
   # ── PR check: just build, don't deploy ──
   build-docs:
     if: github.repository == 'conda/rattler' && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -107,7 +107,7 @@ jobs:
       github.repository == 'conda/rattler' &&
       ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
        (github.event_name == 'workflow_dispatch' && github.event.inputs.tag == ''))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     concurrency:
@@ -139,7 +139,7 @@ jobs:
       github.repository == 'conda/rattler' &&
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.tag != ''
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     concurrency:

--- a/.github/workflows/enforce-sha.yml
+++ b/.github/workflows/enforce-sha.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   ensure-pinned-actions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   main:
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   validate-tag:
     name: Validate tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # If you don't set an input tag, it's a dry run (no uploads).
     if: ${{ inputs.tag }}
     steps:
@@ -97,7 +97,7 @@ jobs:
 
   upload-release:
     name: Upload to NPM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     environment: release
     if: ${{ inputs.tag }}
     needs:
@@ -121,7 +121,7 @@ jobs:
 
   tag-release:
     name: Tag release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: upload-release
     # If you don't set an input tag, it's a dry run (no uploads).
     if: ${{ inputs.tag }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -457,7 +457,7 @@ jobs:
 
   validate-tag:
     name: Validate tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # If you don't set an input tag, it's a dry run (no uploads).
     if: ${{ inputs.tag }}
     steps:
@@ -494,7 +494,7 @@ jobs:
 
   extract-changelog:
     name: Extract changelog
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ inputs.tag }}
     outputs:
       release_notes: ${{ steps.release_notes.outputs.release_notes }}
@@ -552,7 +552,7 @@ jobs:
 
   tag-release:
     name: Tag release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs:
       - upload-release
       - extract-changelog
@@ -577,7 +577,7 @@ jobs:
 
   deploy-release-docs:
     name: Deploy release docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: tag-release
     if: ${{ inputs.tag }}
     permissions:

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: >-
       github.event_name == 'pull_request_target' ||
       (github.event_name == 'issue_comment' &&

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   manage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: >-
       contains(github.event.comment.body, 'vouch') ||
         contains(github.event.comment.body, 'denounce')

--- a/pixi.lock
+++ b/pixi.lock
@@ -256,7 +256,7 @@ environments:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/actionlint-1.7.8-h965158b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/binutils-2.44-h4852527_5.conda
       - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.44-h9d8b0ac_5.conda
       - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.44-h4852527_5.conda
@@ -356,7 +356,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/vouch-1.4.2-h1760d83_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/vouch-lib-1.4.2-hc364b38_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/actionlint-1.7.8-h8080635_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
       - conda: https://prefix.dev/conda-forge/osx-64/c-ares-1.34.5-hf13058a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/c-compiler-1.11.0-h7a00415_0.conda
@@ -435,7 +435,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/vouch-1.4.2-h1760d83_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/vouch-lib-1.4.2-hc364b38_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/actionlint-1.7.8-h43f6c71_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/c-compiler-1.11.0-h61f9b84_0.conda
@@ -515,7 +515,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/actionlint-1.7.8-he477eed_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/actionlint-1.7.12-h11b0a5a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://prefix.dev/conda-forge/win-64/cargo-nextest-0.9.106-h18a1a76_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cmake-3.26.4-h1537add_0.conda
@@ -879,17 +879,18 @@ packages:
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- conda: https://prefix.dev/conda-forge/linux-64/actionlint-1.7.8-h965158b_0.conda
-  sha256: a7245cb879a5d2e3c3a76617b55aa1b740d1fd0c8e5d23469c2e6ec69c8c7c26
-  md5: 90f1e02ab112937f37a2322d6e6ebbd0
+- conda: https://prefix.dev/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+  sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+  md5: bab393750db08f50eebaf96f50d18734
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - __glibc >=2.17
+  - __glibc >=2.17,<3.0.a0
   license: MIT
   license_family: MIT
-  size: 1984203
-  timestamp: 1760199609591
+  run_exports: {}
+  size: 2131192
+  timestamp: 1774975766537
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.9.1-h0b8d109_6.conda
   sha256: e1b228d5e49a39ebf38e060545e571781b76201036f55fd14b4afa48f783dfd9
   md5: 4116c76889466aa66f195e450dce876f
@@ -3038,17 +3039,18 @@ packages:
   license: LicenseRef-Public-Domain
   size: 9555
   timestamp: 1733130678956
-- conda: https://prefix.dev/conda-forge/osx-64/actionlint-1.7.8-h8080635_0.conda
-  sha256: bb860c0c282fb6953d7e374d145d8cb1e4aaf81cc730ac8f26abcd343daae102
-  md5: 32aeac533e5bc51ea04fa87de864c021
+- conda: https://prefix.dev/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+  sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+  md5: 7a360d28a2a40006bc138f05b93188d1
   depends:
-  - __osx >=12.3
+  - __osx >=11.0
   constrains:
   - __osx >=10.12
   license: MIT
   license_family: MIT
-  size: 1942329
-  timestamp: 1760199648994
+  run_exports: {}
+  size: 2079880
+  timestamp: 1774975813961
 - conda: https://prefix.dev/conda-forge/osx-64/aws-c-auth-0.9.1-hcf31db4_6.conda
   sha256: 24e35edaeaee774ac1fb7dae25df7ec15fac5ccc79c6816d95948f557c08b914
   md5: 5e18481e742c35e85c93a87e5c48cb5c
@@ -4478,15 +4480,16 @@ packages:
   license_family: BSD
   size: 485754
   timestamp: 1742433356230
-- conda: https://prefix.dev/conda-forge/osx-arm64/actionlint-1.7.8-h43f6c71_0.conda
-  sha256: d225bef2c199d83c1e365f483715964372348f639259d7a1fb105da771c6cf81
-  md5: 659328c73b0d41b1dd4d064bc1188fd9
+- conda: https://prefix.dev/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+  sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+  md5: 87084addab359d538cbf8493726cf3f8
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 1752491
-  timestamp: 1760199640655
+  run_exports: {}
+  size: 1855795
+  timestamp: 1774975876774
 - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.9.1-h041523c_6.conda
   sha256: bd63de07b71e0a988f50baed52f936089b42b57b5996b6fcd5a24903a3afabac
   md5: 4e58e29f904d3d3ec7ca2f1facb2ca65
@@ -5975,20 +5978,18 @@ packages:
   license_family: BSD
   size: 49468
   timestamp: 1718213032772
-- conda: https://prefix.dev/conda-forge/win-64/actionlint-1.7.8-he477eed_0.conda
-  sha256: 76f90c393903f33564826bbd54055384747b0a6f38e0ff317ada4bbaec69ce0a
-  md5: 3abfff0c12bb43be26bed854d01226f8
+- conda: https://prefix.dev/conda-forge/win-64/actionlint-1.7.12-h11b0a5a_0.conda
+  sha256: c06ad63dd652546687ec28c131975c183a240cd7b281d14403ef3bb5c6858f76
+  md5: 78b9e566476a9df08fa5840ba9e2aeae
   depends:
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   license: MIT
   license_family: MIT
-  size: 2053082
-  timestamp: 1760199668776
+  run_exports: {}
+  size: 2152519
+  timestamp: 1774975834444
 - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.9.1-h29f1512_6.conda
   sha256: 7f25bbfe20e6ff76caaa02b5f5fdd3332adc87d4e3ca0187288328286d81d2a2
   md5: 17dae8400cc30f5f716cdebf1b7b0070

--- a/pixi.toml
+++ b/pixi.toml
@@ -63,7 +63,8 @@ ruff = ">=0.14.1,<0.15"
 typos = ">=1.23.1,<2"
 dprint = ">=0.50.0,<0.51"
 lefthook = ">=2.0.11,<3"
-actionlint = ">=1.7.7,<2"
+# 1.7.9 is the first release that knows the `ubuntu-slim` runner label.
+actionlint = ">=1.7.9,<2"
 zizmor = ">=1.29.0,<2"
 shellcheck = ">=0.10.0,<0.11"
 [feature.lint.target.unix.dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -63,7 +63,6 @@ ruff = ">=0.14.1,<0.15"
 typos = ">=1.23.1,<2"
 dprint = ">=0.50.0,<0.51"
 lefthook = ">=2.0.11,<3"
-# 1.7.9 is the first release that knows the `ubuntu-slim` runner label.
 actionlint = ">=1.7.9,<2"
 zizmor = ">=1.29.0,<2"
 shellcheck = ">=0.10.0,<0.11"


### PR DESCRIPTION
### Description

Moves the GitHub Actions jobs that don't compile anything onto the `ubuntu-slim` runner. This is **not** a blanket `ubuntu-latest` → `ubuntu-slim` swap — `ubuntu-slim` runs in a container rather than a VM, which buys a cheaper and faster start but costs 1 CPU / 5 GB RAM / 14 GB disk, caps a job at 15 minutes and forbids privileged operations (no Docker-in-Docker). Only jobs that comfortably fit inside that were moved.

**Moved to `ubuntu-slim` (15 jobs)** — each only shells out to git/gh, runs a JS/composite action, or builds the mkdocs site:

| Workflow | Jobs |
| --- | --- |
| `enforce-sha.yml` | `ensure-pinned-actions` |
| `lint-pr.yml` | `main` |
| `vouch-check-pr.yml` | `check` |
| `vouch-manage-by-issue.yml` | `manage` |
| `breaking-changes-comment.yml` | `comment-on-pr` |
| `docs.yaml` | `build-docs`, `py-rattler-docs-dev`, `py-rattler-docs-release` |
| `release-js.yml` | `validate-tag`, `upload-release`, `tag-release` |
| `release-python.yml` | `validate-tag`, `extract-changelog`, `tag-release`, `deploy-release-docs` |

**Deliberately left on `ubuntu-latest`:**

- Everything that compiles Rust: `rust-compile.yml`, `js-bindings`, `python-bindings`, `e2e-s3-tests`, `release-rust`, `breaking-changes` (cargo-semver-checks), `docs.yaml`'s `rust-docs`, `release-js`'s `build`, and all the maturin sdist/wheel jobs.
- `lint.yaml` — `pixi run lint` runs lefthook's `pre-push` hook, which is `cargo clippy`.
- `merge-gatekeeper` — a Docker action, and it polls for up to 45 minutes, well past the 15-minute cap.
- `release-python`'s `upload-release` — `pypa/gh-action-pypi-publish` generates and runs a Docker container action, which an unprivileged slim runner can't do.

**actionlint.** The pinned actionlint (1.7.8) didn't know the `ubuntu-slim` label and errors on unknown labels, which would have broken the `lint` job. actionlint learned the label in **1.7.9**, and conda-forge has shipped up to **1.7.12** since March — the lockfile was just stale. So this bumps the floor to `>=1.7.9` and updates the lock (`pixi update actionlint` touches nothing else) rather than carrying a workaround.

### How Has This Been Tested?

Runner labels can only be exercised by CI, so this PR's own run is the test. Proven green on `ubuntu-slim` here: **`ensure-pinned-actions`** and **`build-docs`**. Worth being explicit about what is *not* covered — `lint-pr.yml` and `vouch-check-pr.yml` trigger on `pull_request_target`, which runs the base branch's copy of the workflow, so `Validate PR title` and `check` ran from `main`'s `ubuntu-latest` here and only pick up the new label after merge. The release-workflow jobs are `workflow_dispatch`-only and stay unexercised until the next release.

Locally, `pixi run -e lint lint-fast` passes (zizmor, actionlint, typos, ruff, cargo-fmt, dprint). I also confirmed 1.7.12 is genuinely validating the label rather than ignoring it: it lists `ubuntu-slim` among its built-in labels, and still rejects a deliberately bogus one. That's a real advantage over the config-file approach, which would have told actionlint to stop checking that name at all — so a typo like `ubuntu-slmi` would have slipped through.

### On the actual speedup

Measured on this PR's run, `ubuntu-slim` is **slower to execute**, not faster — it has 1 CPU where `ubuntu-latest` has 4:

| Job | `ubuntu-latest` | `ubuntu-slim` |
| --- | --- | --- |
| `ensure-pinned-actions` | 8s | 9s |
| `build-docs` | 26s | 51s |

Queue times looked better on slim, but the pool was congested throughout and n=1 doesn't support attributing that to the runner. The case for this PR is **cost per minute**, not wall-clock: these are seconds of work that each occupied a 4-CPU VM. Nothing is near the 15-minute cap. If the extra ~25s on `build-docs` isn't worth it, that job alone is easy to revert.

### Checklist:

- [x] I have performed a self-review of my own code

---

Original prompt: "use ubuntu-slim in all places in github actions that make sense (i.e. everywhere where you dont do any rust compilations etc)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYSZg7wEyzx1SVoxqL5EBx