### PR TITLE
fix(rattler_conda_types): load prefix records in a deterministic order

### DIFF
--- a/crates/rattler_conda_types/src/prefix_data.rs
+++ b/crates/rattler_conda_types/src/prefix_data.rs
@@ -66,10 +66,16 @@ impl PrefixData {
             return Err(PrefixDataError(Arc::new(io_err)));
         };
 
-        for entry in fs::read_dir(meta_dir)? {
-            let entry = entry?;
-            let path = entry.path();
+        // The entries are sorted before they are inserted: records are keyed by
+        // package name, so if a prefix holds more than one record for the same
+        // name the last entry wins. Walking the directory in `fs::read_dir`
+        // order would make that choice depend on the filesystem.
+        let mut paths = fs::read_dir(meta_dir)?
+            .map(|entry| entry.map(|entry| entry.path()))
+            .collect::<Result<Vec<_>, _>>()?;
+        paths.sort_unstable();
 
+        for path in paths {
             if path.extension().and_then(|s| s.to_str()) != Some("json") {
                 continue;
             }
@@ -189,6 +195,34 @@ mod tests {
         assert!(
             prefix_data.get(&does_not_exist_name).is_none(),
             "Expected None because the package is not in the directory at all"
+        );
+    }
+
+    #[test]
+    fn test_prefix_data_picks_last_record_by_file_name() {
+        let dir = tempdir().unwrap();
+        let meta_dir = dir.path().join("conda-meta");
+        fs::create_dir_all(&meta_dir).unwrap();
+
+        // A prefix should never hold two records for the same package, but if it
+        // does the choice has to be the same everywhere instead of following the
+        // order the filesystem hands the entries out in.
+        fs::write(meta_dir.join("numpy-1.24.3-py311h_0.json"), "{}").unwrap();
+        fs::write(meta_dir.join("numpy-1.26.4-py311h_0.json"), "{}").unwrap();
+
+        let prefix_data = PrefixData::new(dir.path()).unwrap();
+        let numpy_name = PackageName::try_from("numpy").unwrap();
+
+        assert_eq!(prefix_data.records.len(), 1);
+        assert_eq!(
+            prefix_data
+                .records
+                .get(&numpy_name)
+                .unwrap()
+                .path
+                .file_name()
+                .unwrap(),
+            "numpy-1.26.4-py311h_0.json"
         );
     }
 }


### PR DESCRIPTION
### Description

`PrefixData::new` keys its records by package name, so when a `conda-meta`
directory holds more than one record for the same name, the last `fs::read_dir`
entry wins. Directory order is not specified, so *which* record wins depended on
the filesystem rather than on the prefix contents.

This surfaced in #2780: `test-data/conda-meta` carries two records each for
`libsqlite`, `tk` and `xz`, and the `rattler list --format urls` snapshot taken
there disagreed between macOS, Linux and Windows CI — every platform picked a
different one of each pair.

Sorting the entries before inserting them makes the winner the last one by file
name everywhere. Split out of #2780 so the fix lands as a non-breaking change to
this crate.

### How Has This Been Tested?

- New `test_prefix_data_picks_last_record_by_file_name` unit test: writes two
  records for the same package into a temp prefix and asserts the higher file
  name is the one kept.
- `cargo nextest run -p rattler_conda_types` — 427 tests pass.
- `cargo fmt` and `cargo clippy` clean.
- Verified the original symptom by hand: `rattler list -p test-data --format urls`
  now yields the same three lines regardless of platform.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 5)

```plaintext
ci is failing, can you look into whats going on?

the pr title is feat(rattler-bin)!: ...
but now it also touches rattler_conda_types. will release-plz think this is a
breaking change for rattler_conda_types as well?
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.