### PR TITLE
fix(index): stop advertising the legacy layout as "v0"

### DIFF
--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -950,8 +950,6 @@ async fn index_subdir_inner(
             repodata_revisions: repodata_revisions_for_packages(
                 &repodata_revisions,
                 &existing_repodata_revisions,
-                &packages,
-                &conda_packages,
                 &v3,
             ),
             channel_relations: channel_metadata.channel_relations,
@@ -1330,18 +1328,19 @@ impl RevisionStats {
 fn repodata_revisions_for_packages(
     configured: &[RepodataRevisionSelection],
     existing: &RepodataRevisions,
-    legacy_packages: &IndexMap<DistArchiveIdentifier, PackageRecord, ahash::RandomState>,
-    legacy_conda_packages: &IndexMap<DistArchiveIdentifier, PackageRecord, ahash::RandomState>,
     v3: &V3Packages,
 ) -> RepodataRevisions {
     // `BTreeMap` keeps the result ordered ascending regardless of input order.
     // Existing package statistics are deliberately discarded: generated
     // statistics always describe the typed records written below.
+    //
+    // The legacy layout is never advertised. CEP 48 requires every
+    // `info.repodata_revisions` key to be `vN` with `N` >= 3, so there is no
+    // revision to describe the `packages` and `packages.conda` maps, and an
+    // existing `v0` entry is dropped rather than carried forward.
     let mut revisions = existing
         .iter()
-        .filter(|(revision, _)| {
-            revision.uses_legacy_package_layout() || **revision == RepodataRevision::V3
-        })
+        .filter(|(revision, _)| **revision == RepodataRevision::V3)
         .map(|(revision, metadata)| {
             (
                 *revision,
@@ -1361,15 +1360,6 @@ fn repodata_revisions_for_packages(
     }
 
     let mut stats = BTreeMap::<RepodataRevision, RevisionStats>::new();
-    for record in legacy_packages
-        .values()
-        .chain(legacy_conda_packages.values())
-    {
-        stats
-            .entry(RepodataRevision::Legacy)
-            .or_default()
-            .add(record);
-    }
     for (_, record) in v3.records() {
         stats.entry(RepodataRevision::V3).or_default().add(record);
     }
@@ -2174,62 +2164,22 @@ mod tests {
     }
 
     #[test]
-    fn legacy_revision_metadata_includes_configured_message_and_package_stats() {
-        let mut legacy_packages = IndexMap::default();
-        let mut legacy_conda_packages = IndexMap::default();
-        let oldest: rattler_conda_types::utils::TimestampMs =
-            serde_json::from_str("1710000000000").unwrap();
-        let newest: rattler_conda_types::utils::TimestampMs =
-            serde_json::from_str("1720000000000").unwrap();
-
-        let mut tar_bz2_record = PackageRecord::new(
-            PackageName::new_unchecked("legacy-tar"),
-            Version::from_str("1.0").unwrap(),
-            "0".to_string(),
-        );
-        tar_bz2_record.timestamp = Some(oldest);
-        legacy_packages.insert(
-            DistArchiveIdentifier::try_from_filename("legacy-tar-1.0-0.tar.bz2").unwrap(),
-            tar_bz2_record,
-        );
-
-        let mut conda_record = PackageRecord::new(
-            PackageName::new_unchecked("legacy-conda"),
-            Version::from_str("1.0").unwrap(),
-            "0".to_string(),
-        );
-        conda_record.timestamp = Some(newest);
-        legacy_conda_packages.insert(
-            DistArchiveIdentifier::try_from_filename("legacy-conda-1.0-0.conda").unwrap(),
-            conda_record,
-        );
-
+    fn legacy_packages_are_not_advertised_as_a_revision() {
+        // CEP 48 has no revision key for the legacy package maps, so indexing a
+        // channel that only holds them must not write `info.repodata_revisions`,
+        // and an existing `v0` entry must not survive a re-index.
         let existing = RepodataRevisions::from([(
             RepodataRevision::Legacy,
             RepodataRevisionMetadata {
-                message: Some("stale message".to_string()),
+                message: Some("stale legacy message".to_string()),
                 n_packages: Some(99),
-                oldest: Some(newest),
-                newest: Some(newest),
+                ..RepodataRevisionMetadata::default()
             },
         )]);
-        let revisions = repodata_revisions_for_packages(
-            &[RepodataRevisionSelection {
-                revision: RepodataRevision::Legacy,
-                message: Some("legacy packages".to_string()),
-            }],
-            &existing,
-            &legacy_packages,
-            &legacy_conda_packages,
-            &V3Packages::default(),
-        );
 
-        assert_eq!(revisions.len(), 1);
-        let metadata = &revisions[&RepodataRevision::Legacy];
-        assert_eq!(metadata.message.as_deref(), Some("legacy packages"));
-        assert_eq!(metadata.n_packages, Some(2));
-        assert_eq!(metadata.oldest, Some(oldest));
-        assert_eq!(metadata.newest, Some(newest));
+        let revisions = repodata_revisions_for_packages(&[], &existing, &V3Packages::default());
+
+        assert!(revisions.is_empty());
     }
 
     #[test]
@@ -2319,10 +2269,7 @@ mod tests {
                 ..RepodataRevisionMetadata::default()
             },
         )]);
-        let empty = IndexMap::default();
-
-        let preserved =
-            repodata_revisions_for_packages(&[], &existing, &empty, &empty, &V3Packages::default());
+        let preserved = repodata_revisions_for_packages(&[], &existing, &V3Packages::default());
         assert_eq!(
             preserved[&RepodataRevision::V3].message.as_deref(),
             Some("existing message")
@@ -2335,8 +2282,6 @@ mod tests {
                 message: Some("caller message".to_string()),
             }],
             &existing,
-            &empty,
-            &empty,
             &V3Packages::default(),
         );
         assert_eq!(

--- a/crates/rattler_index/tests/integration/basic_indexing.rs
+++ b/crates/rattler_index/tests/integration/basic_indexing.rs
@@ -363,7 +363,7 @@ async fn test_normal_and_force_reindex_preserve_v3_extensions() {
 }
 
 #[tokio::test]
-async fn test_reindex_derives_authoritative_legacy_and_v3_stats_and_message_precedence() {
+async fn test_reindex_derives_authoritative_v3_stats_and_drops_legacy_revision() {
     let temp_dir = tempfile::tempdir().unwrap();
     let subdir_path = temp_dir.path().join("noarch");
     fs::create_dir(&subdir_path).unwrap();
@@ -461,13 +461,9 @@ async fn test_reindex_derives_authoritative_legacy_and_v3_stats_and_message_prec
     let repodata: Value = serde_json::from_reader(File::open(repodata_path).unwrap()).unwrap();
     assert_eq!(
         repodata["info"]["repodata_revisions"],
+        // The legacy layout is not advertised: CEP 48 keys start at `v3`, so the
+        // seeded `v0` entry is dropped rather than refreshed.
         serde_json::json!({
-            "v0": {
-                "message": "previous legacy message",
-                "n_packages": 1,
-                "oldest": 1710000000000i64,
-                "newest": 1710000000000i64
-            },
             "v3": {
                 "message": "configured v3 message",
                 "n_packages": 1,


### PR DESCRIPTION
### Description

CEP 48 requires every `info.repodata_revisions` key to be `vN` with `N` >= 3, so there is no revision that describes the legacy `packages` and `packages.conda` maps. #2669 started deriving statistics for `RepodataRevision::Legacy`, which made the indexer write a `"v0"` entry on every channel — including legacy-only channels that previously carried no `info.repodata_revisions` key at all.

Beyond being out of spec, emitting the key on channels that never had it breaks readers built against `rattler_conda_types` < 0.47.1, where the field was still a JSON array: they reject the whole `repodata.json`, and the shard index, with `invalid type: map, expected a sequence`. That is the failure reported in #2784, where @baszalmstra said:

> I think we should fix that. Lets not emit "v0" repodata_revisions.

Legacy statistics are no longer derived, and an existing `v0` entry is dropped rather than carried forward, so re-indexing repairs an affected channel.

This is the writer half of #2784 only. The reader-side leniency discussed there (tolerating an unrecognized shape, surfaced through the gateway warning path) is separate follow-up work.

One consequence worth flagging: a channel holding both legacy and `v3` records no longer publishes package counts or timestamps for the legacy half. That follows from the spec having no key for it, but #2669 added those statistics deliberately — happy to change course if the intent was to advertise them regardless.

### How Has This Been Tested?

- **End to end through the workflow that broke, with `rattler-build`.** I rebuilt `rattler-build` 0.75.0 against `rattler_index` from this branch and published the same recipe twice — once with the released 0.75.0, once with the patched build — then pointed a client pinned to `rattler_conda_types` 0.46.4 / `rattler_repodata_gateway` 0.29.2 at each channel over HTTP (a `file://` channel never fetches the shard index, so it would not exercise this):

  | | released 0.75.0 | 0.75.0 + this change |
  |---|---|---|
  | `repodata.json` `info` | `{"subdir": …, "repodata_revisions": {"v0": {"n_packages": 1, …}}}` | `{"subdir": …}` |
  | shard index `info` | same `v0` map embedded | no `repodata_revisions` |
  | pinned client | `failed to parse shard index from <url>: invalid type: map, expected a sequence` | `OK: 1 records across 2 subdirs` |

  Both subdirs (`noarch` and `linux-64`) publish, both packages stay resolvable by name, and package counts are unchanged. Note for anyone reproducing this: `[patch.crates-io]` is silently dropped as `patch.unused` here, because rattler crates pin each other exactly — registry `rattler_index` 0.31.3 requires `rattler_conda_types=0.52.0`. The `rattler*` workspace dependencies have to be repointed at local paths instead.

- Re-indexing repairs an already-affected channel: a fixture indexed by `rattler-index` 0.31.5, carrying `{"v0": {"n_packages": 1, …}}` in both `repodata.json` and `repodata_shards.msgpack.zst`, loses both copies of the key when re-indexed with this build, with package records untouched — and the same pinned client then loads it.

- `cargo test -p rattler_index` — 39 tests pass. `cargo clippy -p rattler_index --all-targets` and `cargo fmt --check` are clean.

- Replaced `legacy_revision_metadata_includes_configured_message_and_package_stats` with `legacy_packages_are_not_advertised_as_a_revision`, which asserts a seeded `v0` entry does not survive a re-index. The old test also configured `RepodataRevision::Legacy`, which `validate_configured_repodata_revisions` rejects outright.

- Renamed and re-asserted the integration test that expected `v0` in indexer output.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

